### PR TITLE
feat(ci): Run updates at PR level instead of after merge

### DIFF
--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -70,8 +70,7 @@ runs:
       id: check-changes
       shell: bash
       run: |
-        echo "Checking for staged changes in seed/${{ inputs.generator-name }}"
-        git --no-pager diff --staged --exit-code -- seed/${{ inputs.generator-name }}
+        git --no-pager diff --staged --quiet -- seed/${{ inputs.generator-name }}
         diff_code=$?
         echo "Git diff exit code: $diff_code"
 
@@ -94,7 +93,7 @@ runs:
             ;;
         esac
 
-        echo "Step completed successfully with exit code: $diff_code"
+        echo "Step completed successfully with exit code: ${{ diff_code }}"
 
     # Make patch file for seed changes
     - name: Make Patch for Seed Artifacts

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -60,16 +60,12 @@ runs:
         cache-disabled: ${{ inputs.cache-disabled }}
 
     # Add changes first to simplify git diff checks, no changes will NOT error here
-    - name: Stage Seed Changes
-      if: inputs.create-artifacts == 'true'
-      shell: bash
-      run: |
-        git add seed/${{ inputs.generator-name }}/*
-
     - name: Check for changes
+      if: inputs.create-artifacts == 'true'
       id: check-changes
       shell: bash
       run: |
+        git add seed/${{ inputs.generator-name }}/*
         if git --no-pager diff --staged --exit-code; then
           echo "No changes detected for seed."
           echo "seed-changes-generated=false" >> $GITHUB_OUTPUT

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -74,26 +74,35 @@ runs:
         diff_code=$?
         echo "Git diff exit code: $diff_code"
 
-        case $diff_code in
-          0)
-            echo "No changes detected in seed/${{ inputs.generator-name }}"
-            echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
-            ;;
-          1)
-            echo "Changes detected in seed/${{ inputs.generator-name }}"
-            echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
-            ;;
-          2)
-            echo "Error occurred while checking seed/${{ inputs.generator-name }}"
-            exit 1
-            ;;
-          *)
-            echo "Unexpected exit code: $diff_code"
-            exit 1
-            ;;
-        esac
+        if [ $diff_code -eq 0 ]; then
+          echo "No changes detected in seed/${{ inputs.generator-name }}"
+          echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
+        elif [ $diff_code -eq 1 ]; then
+          echo "Changes detected in seed/${{ inputs.generator-name }}"
+          echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
+        else
+          echo "Error occurred while checking seed/${{ inputs.generator-name }}"
+          exit 1
+        fi
 
-        echo "Step completed successfully with exit code: ${{ diff_code }}"
+        # case $diff_code in
+        #   0)
+        #     echo "No changes detected in seed/${{ inputs.generator-name }}"
+        #     echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
+        #     ;;
+        #   1)
+        #     echo "Changes detected in seed/${{ inputs.generator-name }}"
+        #     echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
+        #     ;;
+        #   2)
+        #     echo "Error occurred while checking seed/${{ inputs.generator-name }}"
+        #     exit 1
+        #     ;;
+        #   *)
+        #     echo "Unexpected exit code: $diff_code"
+        #     exit 1
+        #     ;;
+        # esac
 
     # Make patch file for seed changes
     - name: Make Patch for Seed Artifacts

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -60,15 +60,16 @@ runs:
         cache-disabled: ${{ inputs.cache-disabled }}
 
     # Upload artifacts to be applied and committed by caller when all of seed is up to date
+    # CHRISM - what if diff is empty? Work okay?
     - name: Make Patch for Seed Artifacts
-      if: steps.seed.outputs.seed-generated == 'true' && inputs.create-artifacts == 'true'
+      if: inputs.create-artifacts == 'true'
       shell: bash
       run: |
         git add seed/${{ inputs.generator-name }}/*
         git diff --staged > seed-${{ inputs.generator-name }}.patch
 
     - name: Upload Seed Artifacts
-      if: steps.seed.outputs.seed-generated == 'true' && inputs.create-artifacts == 'true'
+      if: inputs.create-artifacts == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: seed-${{ inputs.generator-name }}.patch
@@ -78,7 +79,7 @@ runs:
 
     # Create PR, approve and set to merge all at generator level
     - name: Create Pull Request
-      if: steps.seed.outputs.seed-generated == 'true' && inputs.create-pr == 'true'
+      if: inputs.create-pr == 'true'
       id: cpr
       uses: peter-evans/create-pull-request@v5
       with:

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -70,10 +70,12 @@ runs:
       id: check-changes
       shell: bash
       run: |
+        echo "Checking for staged changes in seed/${{ inputs.generator-name }}"
         git --no-pager diff --staged --exit-code -- seed/${{ inputs.generator-name }}
-        exit_code=$?
+        diff_code=$?
+        echo "Git diff exit code: $diff_code"
 
-        case $exit_code in
+        case $diff_code in
           0)
             echo "No changes detected in seed/${{ inputs.generator-name }}"
             echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
@@ -87,10 +89,12 @@ runs:
             exit 1
             ;;
           *)
-            echo "Unexpected exit code: $exit_code"
+            echo "Unexpected exit code: $diff_code"
             exit 1
             ;;
         esac
+
+        echo "Step completed successfully with exit code: $diff_code"
 
     # Make patch file for seed changes
     - name: Make Patch for Seed Artifacts

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -70,39 +70,12 @@ runs:
       id: check-changes
       shell: bash
       run: |
-        git --no-pager diff --staged --quiet -- seed/${{ inputs.generator-name }}
-        diff_code=$?
-        echo "Git diff exit code: $diff_code"
-
-        if [ $diff_code -eq 0 ]; then
-          echo "No changes detected in seed/${{ inputs.generator-name }}"
+        if git --no-pager diff --staged --exit-code; then
+          echo "No changes detected."
           echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
-        elif [ $diff_code -eq 1 ]; then
-          echo "Changes detected in seed/${{ inputs.generator-name }}"
-          echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
         else
-          echo "Error occurred while checking seed/${{ inputs.generator-name }}"
-          exit 1
+          echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
         fi
-
-        # case $diff_code in
-        #   0)
-        #     echo "No changes detected in seed/${{ inputs.generator-name }}"
-        #     echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
-        #     ;;
-        #   1)
-        #     echo "Changes detected in seed/${{ inputs.generator-name }}"
-        #     echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
-        #     ;;
-        #   2)
-        #     echo "Error occurred while checking seed/${{ inputs.generator-name }}"
-        #     exit 1
-        #     ;;
-        #   *)
-        #     echo "Unexpected exit code: $diff_code"
-        #     exit 1
-        #     ;;
-        # esac
 
     # Make patch file for seed changes
     - name: Make Patch for Seed Artifacts

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -59,17 +59,49 @@ runs:
         skip-scripts: ${{ inputs.skip-scripts }}
         cache-disabled: ${{ inputs.cache-disabled }}
 
-    # Upload artifacts to be applied and committed by caller when all of seed is up to date
-    # CHRISM - what if diff is empty? Work okay?
-    - name: Make Patch for Seed Artifacts
+    # Add changes first to simplify git diff checks, no changes will NOT error here
+    - name: Stage Seed Changes
       if: inputs.create-artifacts == 'true'
       shell: bash
       run: |
         git add seed/${{ inputs.generator-name }}/*
+
+    - name: Check for changes
+      id: check-changes
+      shell: bash
+      run: |
+        git --no-pager diff --staged --exit-code -- seed/${{ inputs.generator-name }}
+        exit_code=$?
+
+        case $exit_code in
+          0)
+            echo "No changes detected in seed/${{ inputs.generator-name }}"
+            echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
+            ;;
+          1)
+            echo "Changes detected in seed/${{ inputs.generator-name }}"
+            echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
+            ;;
+          2)
+            echo "Error occurred while checking seed/${{ inputs.generator-name }}"
+            exit 1
+            ;;
+          *)
+            echo "Unexpected exit code: $exit_code"
+            exit 1
+            ;;
+        esac
+
+    # Make patch file for seed changes
+    - name: Make Patch for Seed Artifacts
+      if: steps.check-changes.outputs.seed-changes-generated == 'true' && inputs.create-artifacts == 'true'
+      shell: bash
+      run: |
         git diff --staged > seed-${{ inputs.generator-name }}.patch
 
+    # Upload patch files as artifacts to be applied and committed by caller when all of seed is up to date
     - name: Upload Seed Artifacts
-      if: inputs.create-artifacts == 'true'
+      if: steps.check-changes.outputs.seed-changes-generated == 'true' && inputs.create-artifacts == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: seed-${{ inputs.generator-name }}.patch
@@ -79,7 +111,7 @@ runs:
 
     # Create PR, approve and set to merge all at generator level
     - name: Create Pull Request
-      if: inputs.create-pr == 'true'
+      if: steps.check-changes.outputs.seed-changes-generated == 'true' && inputs.create-pr == 'true'
       id: cpr
       uses: peter-evans/create-pull-request@v5
       with:

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -71,10 +71,11 @@ runs:
       shell: bash
       run: |
         if git --no-pager diff --staged --exit-code; then
-          echo "No changes detected."
+          echo "No changes detected for seed."
           echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
         else
-          echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
+          echo "Changes detected for seed."
+          echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
         fi
 
     # Make patch file for seed changes

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -25,6 +25,12 @@ inputs:
     description: "Whether to skip caching and always regenerate"
     required: false
     default: "true"
+  create-artifacts:
+    description: "Whether or not to create artifacts for the seed changes"
+    required: true
+  create-pr:
+    description: "Whether or not to create a PR with changes"
+    required: true
   secret-fern-github-pat:
     description: "GitHub Access Token for Fern"
     required: true
@@ -45,7 +51,26 @@ runs:
         skip-scripts: ${{ inputs.skip-scripts }}
         cache-disabled: ${{ inputs.cache-disabled }}
 
+    # Upload artifacts to be applied and committed by caller when all of seed is up to date
+    - name: Make Patch for Seed Artifacts
+      if: steps.seed.outputs.seed-generated == 'true' && inputs.create-artifacts == 'true'
+      shell: bash
+      run: |
+        git add seed/${{ inputs.generator-name }}/*
+        git diff --staged > seed-${{ inputs.generator-name }}.patch
+
+    - name: Upload Seed Artifacts
+      if: steps.seed.outputs.seed-generated == 'true' && inputs.create-artifacts == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: seed-${{ inputs.generator-name }}.patch
+        path: seed-${{ inputs.generator-name }}.patch
+        if-no-files-found: error
+        retention-days: 7
+
+    # Create PR, approve and set to merge all at generator level
     - name: Create Pull Request
+      if: steps.seed.outputs.seed-generated == 'true' && inputs.create-pr == 'true'
       id: cpr
       uses: peter-evans/create-pull-request@v5
       with:
@@ -60,19 +85,19 @@ runs:
           language/${{ inputs.language-name }}
 
     - name: Log PR Creation Failure
-      if: steps.cpr.outputs.pull-request-operation != 'created'
+      if: steps.cpr.outputs.pull-request-operation != 'created' && inputs.create-pr  == 'true'
       shell: bash
       run: |
         echo "PR was not created, likely due to no diff for the generated seed output"
 
     - name: Log PR Creation Details
-      if: steps.cpr.outputs.pull-request-operation == 'created'
+      if: steps.cpr.outputs.pull-request-operation == 'created' && inputs.create-pr  == 'true'
       shell: bash
       run: |
         echo "PR Created: ${{ steps.cpr.outputs.pull-request-url }}"
 
     - name: Enable Pull Request Automerge
-      if: steps.cpr.outputs.pull-request-operation == 'created'
+      if: steps.cpr.outputs.pull-request-operation == 'created' && inputs.create-pr  == 'true'
       uses: peter-evans/enable-pull-request-automerge@v3
       with:
         token: ${{ inputs.secret-fern-github-pat }}
@@ -80,7 +105,7 @@ runs:
         merge-method: squash
 
     - name: Approve PR
-      if: steps.cpr.outputs.pull-request-operation == 'created'
+      if: steps.cpr.outputs.pull-request-operation == 'created' && inputs.create-pr  == 'true'
       uses: ./.github/actions/auto-approve
       with:
         approver-gh-token: ${{ inputs.secret-pr-bot-gh-pat }}

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -41,6 +41,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate update options
+      shell: bash
+      run: |
+        if [[ "${{ inputs.create-artifacts }}" == "${{ inputs.create-pr }}" ]]; then
+          echo "Invalid seed update settings. One and only one update method must be enabled."
+          exit 1
+        fi
+
     - name: Run seed
       uses: ./.github/actions/cached-seed
       with:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1,26 +1,14 @@
 name: Seed Snapshot Tests
 
 on:
-  # Note: for push, run this when something merges to main and meets path filter criteria
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/update-seed.yml"
-      - "packages/seed/**"
-      - "packages/ir-sdk/fern/apis/**"
-      - "packages/cli/generation/ir-generator/**"
-      - "test-definitions/**"
-      - "test-definitions-openapi/**"
-      - "generators/**"
-      - "seed/**"
-  # Note: for workflow_run, run this when update-seed workflow completes unless the branch is main 
-  # (which will use the push trigger above)
-  workflow_run:
-    workflows: [update-seed,"Update Seed"]
-    types: [requested]
-    # branches-ignore:
-    #   - main
+  # Note: pull request trigger will be removed once repository_dispatch trigger is verified
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
   repository_dispatch:
     types: [seed-tests]
   workflow_call:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -21,6 +21,8 @@ on:
     types: [requested]
     # branches-ignore:
     #   - main
+  repository_dispatch:
+    types: [seed-tests]
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1,13 +1,14 @@
 name: Seed Snapshot Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
+  # Note: only want this to run when the Update Seed workflow runs so all
+  # settings to start are in that workflow (except the manual trigger which
+  # is also allowed here). This will kick off so long as the Update Seed workflow
+  # passes or is skipped, it will not run if the Update Seed workflow never starts.
+# CHRISM - note, have to make sure this runs after merge to PR branch
+  workflow_run:
+    workflows: [Update Seed]
+    types: [completed]
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1,14 +1,26 @@
 name: Seed Snapshot Tests
 
 on:
-  # Note: only want this to run when the Update Seed workflow runs so all
-  # settings to start are in that workflow (except the manual trigger which
-  # is also allowed here). This will kick off so long as the Update Seed workflow
-  # passes or is skipped, it will not run if the Update Seed workflow never starts.
-# CHRISM - note, have to make sure this runs after merge to PR branch
+  # Note: for push, run this when something merges to main and meets path filter criteria
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/update-seed.yml"
+      - "packages/seed/**"
+      - "packages/ir-sdk/fern/apis/**"
+      - "packages/cli/generation/ir-generator/**"
+      - "test-definitions/**"
+      - "test-definitions-openapi/**"
+      - "generators/**"
+      - "seed/**"
+  # Note: for workflow_run, run this when update-seed workflow completes unless the branch is main 
+  # (which will use the push trigger above)
   workflow_run:
-    workflows: [Update Seed]
+    workflows: ["Update Seed"]
     types: [completed]
+    branches-ignore:
+      - main
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -19,8 +19,8 @@ on:
   workflow_run:
     workflows: ["Update Seed"]
     types: [completed]
-    branches-ignore:
-      - main
+    # branches-ignore:
+    #   - main
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -17,8 +17,8 @@ on:
   # Note: for workflow_run, run this when update-seed workflow completes unless the branch is main 
   # (which will use the push trigger above)
   workflow_run:
-    workflows: [update-seed,UpdateSeed]
-    types: [in_progress]
+    workflows: [update-seed,"Update Seed"]
+    types: [requested]
     # branches-ignore:
     #   - main
   workflow_call:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -17,8 +17,8 @@ on:
   # Note: for workflow_run, run this when update-seed workflow completes unless the branch is main 
   # (which will use the push trigger above)
   workflow_run:
-    workflows: ["Update Seed"]
-    types: [completed]
+    workflows: [update-seed,UpdateSeed]
+    types: [in_progress]
     # branches-ignore:
     #   - main
   workflow_call:

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -19,6 +19,8 @@ on:
       - main
   workflow_dispatch:
 
+# CHRISM - look at concurrency setup and replicate here
+
 permissions:
   pull-requests: write
   contents: write
@@ -30,16 +32,10 @@ jobs:
   setup:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
-    # Note: Keep these in sync with env in .github/actions/auto-update-seed/action.yaml
-    env:
-      APPLY_BY_COMMIT_OPTION: 'Commit'
-      APPLY_BY_PR_OPTION: 'PR'
     outputs:
       skip-scripts: ${{ steps.set-update-options.outputs.skip-scripts }}
       create-artifacts: ${{ steps.set-update-options.outputs.create-artifacts }}
       create-pr: ${{ steps.set-update-options.outputs.create-pr }}
-      commit-option-name: ${{ env.APPLY_BY_COMMIT_OPTION }}
-      pr-option-name: ${{ env.APPLY_BY_PR_OPTION }}
     steps:
        # Apply by commit for PR to main, apply by PR for push to main or workflow_dispatch
       - name: Set update options
@@ -643,14 +639,28 @@ jobs:
         with:
           path: ./artifacts
 
+      - name: Get number of patches
+        shell: bash
+        id: get-number-of-patches
+        run: |
+          file_count=$(find ./artifacts -type f -name "*.patch" | wc -l)
+          echo "Number of patches downloaded: $file_count"
+          if [ "$INTEGER_VALUE" -gt 5 ]; then
+            echo "HAS_PATCHES=true" >> $GITHUB_OUTPUT
+          else
+            echo "HAS_PATCHES=false" >> $GITHUB_OUTPUT
+          fi
+
       #CHRISM - test on failure (no changes)
       - name: Apply patches
         shell: bash
+        if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
         run: |
           git apply artifacts/*.patch 
 
       - name: Add and Commit Changes
         uses: EndBug/add-and-commit@v9
+        if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
         with:
           add: "seed/*"
           push: true

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -44,20 +44,20 @@ jobs:
       create-artifacts: ${{ steps.set-update-options.outputs.create-artifacts }}
       create-pr: ${{ steps.set-update-options.outputs.create-pr }}
     steps:
-       # Apply by commit for PR to main, apply by PR for push to main or workflow_dispatch
+      # Apply by commit for PR to main, apply by PR for push to main or workflow_dispatch
       - name: Set update options
         id: set-update-options
         shell: bash
         run: |
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "skip-scripts=true" >> $GITHUB_OUTPUT
-              echo "create-artifacts=true" >> $GITHUB_OUTPUT
-              echo "create-pr=false" >> $GITHUB_OUTPUT
-            else
-              echo "skip-scripts=false" >> $GITHUB_OUTPUT
-              echo "create-artifacts=false" >> $GITHUB_OUTPUT
-              echo "create-pr=true" >> $GITHUB_OUTPUT
-            fi
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "skip-scripts=true" >> $GITHUB_OUTPUT
+            echo "create-artifacts=true" >> $GITHUB_OUTPUT
+            echo "create-pr=false" >> $GITHUB_OUTPUT
+          else
+            echo "skip-scripts=false" >> $GITHUB_OUTPUT
+            echo "create-artifacts=false" >> $GITHUB_OUTPUT
+            echo "create-pr=true" >> $GITHUB_OUTPUT
+          fi
   changes:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
@@ -617,7 +617,7 @@ jobs:
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
-  # Use always() to ensure this runs even if stages from needs are skipped. 
+  # Use always() to ensure this runs even if stages from needs are skipped.
   # Add check back to make sure it doesn't run for failures or cancellations.
   commit-seed-changes:
     outputs:
@@ -628,13 +628,32 @@ jobs:
         !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
       }}
     needs:
-      [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
-      pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 
-      postman-seed-update, java-sdk-seed-update, java-model-seed-update, java-spring-seed-update,
-      typescript-sdk-seed-update, typescript-express-seed-update, go-fiber-seed-update, 
-      go-model-seed-update, go-sdk-seed-update, csharp-model-seed-update, csharp-sdk-seed-update, 
-      php-model-seed-update, php-sdk-seed-update, swift-sdk-seed-update, rust-model-seed-update, 
-      rust-sdk-seed-update
+      [
+        changes,
+        setup,
+        ruby-model-seed-update,
+        ruby-sdk-seed-update,
+        ruby-sdk-v2-seed-update,
+        pydantic-model-seed-update,
+        python-sdk-seed-update,
+        fastapi-seed-update,
+        openapi-seed-update,
+        postman-seed-update,
+        java-sdk-seed-update,
+        java-model-seed-update,
+        java-spring-seed-update,
+        typescript-sdk-seed-update,
+        typescript-express-seed-update,
+        go-fiber-seed-update,
+        go-model-seed-update,
+        go-sdk-seed-update,
+        csharp-model-seed-update,
+        csharp-sdk-seed-update,
+        php-model-seed-update,
+        php-sdk-seed-update,
+        swift-sdk-seed-update,
+        rust-model-seed-update,
+        rust-sdk-seed-update
       ]
     runs-on: Seed
     steps:
@@ -662,9 +681,8 @@ jobs:
           else
             echo "WARNING: Directory '$DIRECTORY' already exists. Not an immediate error but could cause a problem downstream."
           fi
-          
 
-      # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise 
+      # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise
       # they are subfoldered into folders that match *.patch pattern and cause errors downstream
       - name: Download patches
         uses: actions/download-artifact@v5
@@ -693,7 +711,7 @@ jobs:
         shell: bash
         if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
         run: |
-          git apply artifacts/*.patch 
+          git apply artifacts/*.patch
 
       - name: Add and Commit Changes
         id: commit-changes
@@ -704,8 +722,8 @@ jobs:
           push: true
           fetch: false
           message: "Automated update of seed files"
-          
-  # Use always() to ensure this runs even if stages from needs are skipped. 
+
+  # Use always() to ensure this runs even if stages from needs are skipped.
   # Add check back to make sure it doesn't run for failures or cancellations.
   # Only trigger if there are no new patches (seed is up to date)
   trigger-seed-snapshot-tests:
@@ -717,11 +735,11 @@ jobs:
         !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
       }}
     runs-on: Seed
-    steps: 
-    # Note: this will trigger to the default branch of the repo, not the PR branch
-    - name: Trigger seed tests
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ secrets.FERN_GITHUB_PAT }}
-        event-type: seed-tests
-        client-payload: '{"ref": "${{ github.ref }}"}'
+    steps:
+      # Note: this will trigger to the default branch of the repo, not the PR branch
+      - name: Trigger seed tests
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+          event-type: seed-tests
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -19,7 +19,10 @@ on:
       - main
   workflow_dispatch:
 
-# CHRISM - look at concurrency setup and replicate here
+# Cancel previous workflows on previous push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -13,16 +13,20 @@ on:
       - "test-definitions-openapi/**"
       - "generators/**"
       - "seed/**"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
+  # TODO: Re-enable this trigger once repository_dispatch trigger is verified, then remove it from seed.yml
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
+  #   branches:
+  #     - main
   workflow_dispatch:
 
+# TODO: Re-enable this concurrency once repository_dispatch trigger is verified
+# Also need to verify that stopping this workflow won't miss the addition of new seed
+# changes, which likely means playing around with how changes works or the path filering
 # Cancel previous workflows on previous push
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+#   cancel-in-progress: true
 
 permissions:
   pull-requests: write
@@ -704,37 +708,17 @@ jobs:
   # Use always() to ensure this runs even if stages from needs are skipped. 
   # Add check back to make sure it doesn't run for failures or cancellations.
   # Only trigger if there are no new patches (seed is up to date)
-        # needs.commit-seed-changes.outputs.has-patches == 'false' && CHRISM ADD BACK
   trigger-seed-snapshot-tests:
     needs: [commit-seed-changes, changes, setup]
     if: >-
       ${{ 
         always() && needs.setup.outputs.create-artifacts == 'true' &&
+        needs.commit-seed-changes.outputs.has-patches == 'false' &&
         !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
       }}
     runs-on: Seed
     steps: 
-      - name: Manually call seed snapshot tests
-        uses: ./.github/workflows/seed.yml
-    # outputs:
-    # steps:
-    #   - name: Checkout repo
-    #     uses: actions/checkout@v4
-    #     with:
-    #       token: ${{ secrets.FERN_GITHUB_PAT }}
-
-    #   - name: Trigger seed snapshot tests
-    #     uses: fern-api/fern/.github/workflows/seed.yml@mallinson/example-PR-level-testing #CHRISM - change
-
-  trigger-seed-snapshot-tests2:
-    needs: [commit-seed-changes, changes, setup]
-    if: >-
-      ${{ 
-        always() && needs.setup.outputs.create-artifacts == 'true' &&
-        !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-      }}
-    runs-on: Seed
-    steps: 
+    # Note: this will trigger to the default branch of the repo, not the PR branch
     - name: Trigger seed tests
       uses: peter-evans/repository-dispatch@v2
       with:

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -645,7 +645,7 @@ jobs:
         run: |
           file_count=$(find ./artifacts -type f -name "*.patch" | wc -l)
           echo "Number of patches downloaded: $file_count"
-          if [ "$INTEGER_VALUE" -gt 5 ]; then
+          if [ "$file_count" -gt 0 ]; then
             echo "HAS_PATCHES=true" >> $GITHUB_OUTPUT
           else
             echo "HAS_PATCHES=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -616,6 +616,8 @@ jobs:
   # Use always() to ensure this runs even if stages from needs are skipped. 
   # Add check back to make sure it doesn't run for failures or cancellations.
   commit-seed-changes:
+    outputs:
+      has-patches: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES }}
     if: >-
       ${{ 
         always() && needs.setup.outputs.create-artifacts == 'true' &&
@@ -690,6 +692,7 @@ jobs:
           git apply artifacts/*.patch 
 
       - name: Add and Commit Changes
+        id: commit-changes
         uses: EndBug/add-and-commit@v9
         if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
         with:
@@ -698,19 +701,23 @@ jobs:
           fetch: false
           message: "Automated update of seed files"
           
-  # # Use always() to ensure this runs even if stages from needs are skipped. 
-  # # Add check back to make sure it doesn't run for failures or cancellations.
-  # start-seed-snapshot-tests:
-  #   needs: [commit-seed-changes, changes, setup]
-  #   if: >-
-  #     ${{ 
-  #       always() && needs.setup.outputs.create-artifacts == 'true' &&
-  #       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-  #     }}
-  #   runs-on: Seed
-  #   steps:
-  #     - name: Trigger seed snapshot tests
-  #       shell: bash
-  #       run: |
-  #         echo "Triggering seed snapshot tests"
-  #         echo "seed-snapshot-tests-triggered=true" >> $GITHUB_OUTPUT
+  # Use always() to ensure this runs even if stages from needs are skipped. 
+  # Add check back to make sure it doesn't run for failures or cancellations.
+  # Only trigger if there are no new patches (seed is up to date)
+  trigger-seed-snapshot-tests:
+    needs: [commit-seed-changes, changes, setup]
+    if: >-
+      ${{ 
+        always() && needs.setup.outputs.create-artifacts == 'true' &&
+        needs.commit-seed-changes.outputs.has-patches == 'false' &&
+        !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+      }}
+    runs-on: Seed
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+
+      - name: Trigger seed snapshot tests
+        uses: ./.github/workflows/seed.yml

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -704,20 +704,20 @@ jobs:
   # Use always() to ensure this runs even if stages from needs are skipped. 
   # Add check back to make sure it doesn't run for failures or cancellations.
   # Only trigger if there are no new patches (seed is up to date)
-  trigger-seed-snapshot-tests:
-    needs: [commit-seed-changes, changes, setup]
-    if: >-
-      ${{ 
-        always() && needs.setup.outputs.create-artifacts == 'true' &&
-        needs.commit-seed-changes.outputs.has-patches == 'false' &&
-        !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-      }}
-    runs-on: Seed
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.FERN_GITHUB_PAT }}
+  # trigger-seed-snapshot-tests:
+  #   needs: [commit-seed-changes, changes, setup]
+  #   if: >-
+  #     ${{ 
+  #       always() && needs.setup.outputs.create-artifacts == 'true' &&
+  #       needs.commit-seed-changes.outputs.has-patches == 'false' &&
+  #       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+  #     }}
+  #   runs-on: Seed
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Trigger seed snapshot tests
-        uses: fern-api/fern/.github/workflows/seed.yml@mallinson/example-PR-level-testing #CHRISM - change
+  #     - name: Trigger seed snapshot tests
+  #       uses: fern-api/fern/.github/workflows/seed.yml@mallinson/example-PR-level-testing #CHRISM - change

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -691,9 +691,9 @@ jobs:
         with:
           add: "seed/*"
           push: true
+          fetch: false
           message: "Automated update of seed files"
-          author_name: "Fern Support"
-
-
+          committer_name: "Fern Support"
+          committer_email: "26544928+fern-support@users.noreply.github.com"
 
   #CHRISM - kick off seed snapshot tests

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -617,9 +617,10 @@ jobs:
   # make sure it doesn't run for failures or cancellations
   # always() && ${{ needs.setup.outputs.create-artifacts == 'true' }} &&
       # !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    # CHRISM - need to fix the always later
   commit-seed-changes:
     if: | 
-      always() && ${{ needs.setup.outputs.create-artifacts == 'true' }}
+      always()
     needs:
       [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
       pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -653,10 +653,13 @@ jobs:
           mkdir artifacts
 
       #CHRISM - test on failure (no changes)
+      # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise 
+      # they are subfoldered into folders that match *.patch pattern and cause errors downstream
       - name: Download patches
         uses: actions/download-artifact@v5
         with:
           path: ./artifacts
+          merge-multiple: true
 
       - name: Get number of patches
         shell: bash
@@ -689,6 +692,8 @@ jobs:
           add: "seed/*"
           push: true
           message: "Automated update of seed files"
+          committer_name: "Fern Support"
+
 
 
   #CHRISM - kick off seed snapshot tests

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -621,7 +621,8 @@ jobs:
   commit-seed-changes:
     if: >-
       ${{ 
-        always() && needs.setup.outputs.create-artifacts == 'true' 
+        always() && needs.setup.outputs.create-artifacts == 'true' &&
+        !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
       }}
     needs:
       [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -28,16 +28,33 @@ env:
 
 jobs:
   setup:
+    if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
+    # Note: Keep these in sync with env in .github/actions/auto-update-seed/action.yaml
+    env:
+      APPLY_BY_COMMIT_OPTION: 'Commit'
+      APPLY_BY_PR_OPTION: 'PR'
     outputs:
-      application-method: ${{ inputs.application-method }}
+      skip-scripts: ${{ steps.set-update-options.outputs.skip-scripts }}
+      create-artifacts: ${{ steps.set-update-options.outputs.create-artifacts }}
+      create-pr: ${{ steps.set-update-options.outputs.create-pr }}
+      commit-option-name: ${{ env.APPLY_BY_COMMIT_OPTION }}
+      pr-option-name: ${{ env.APPLY_BY_PR_OPTION }}
     steps:
-      - name: Set application method
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "application-method=Commit" >> $GITHUB_OUTPUT
-      - name: Set application method
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "application-method=PR" >> $GITHUB_OUTPUT
+       # Apply by commit for PR to main, apply by PR for push to main or workflow_dispatch
+      - name: Set update options
+        id: set-update-options
+        shell: bash
+        run: |
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "skip-scripts=true" >> $GITHUB_OUTPUT
+              echo "create-artifacts=true" >> $GITHUB_OUTPUT
+              echo "create-pr=false" >> $GITHUB_OUTPUT
+            else
+              echo "skip-scripts=false" >> $GITHUB_OUTPUT
+              echo "create-artifacts=false" >> $GITHUB_OUTPUT
+              echo "create-pr=true" >> $GITHUB_OUTPUT
+            fi
   changes:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
@@ -55,8 +72,7 @@ jobs:
       php: ${{ steps.get-generator-changes.outputs.php }}
       swift: ${{ steps.get-generator-changes.outputs.swift }}
       rust: ${{ steps.get-generator-changes.outputs.rust }}
-      apply-changes-by-commit: ${{ steps.set-seed-application-method.outputs.apply-changes-by-commit }}
-      apply-changes-by-PR: ${{ steps.set-seed-application-method.outputs.apply-changes-by-PR }}
+
     steps:
       - if: github.event_name != 'workflow_dispatch'
         name: Checkout repo
@@ -69,20 +85,8 @@ jobs:
         id: get-generator-changes
         uses: ./.github/actions/get-generator-changes
 
-       # Apply by commit for PR to main, apply by PR for push to main or workflow_dispatch
-      - name: Set seed application method
-        id: set-seed-application-method
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "apply-changes-by-commit=true" >> $GITHUB_OUTPUT
-            echo "apply-changes-by-PR=false" >> $GITHUB_OUTPUT
-          else
-            echo "apply-changes-by-commit=false" >> $GITHUB_OUTPUT
-            echo "apply-changes-by-PR=true" >> $GITHUB_OUTPUT
-          fi
-
   ruby-model-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -98,13 +102,14 @@ jobs:
           generator-path: generators/ruby
           language-name: ruby
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   ruby-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -120,13 +125,14 @@ jobs:
           generator-path: generators/ruby
           language-name: ruby
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   ruby-sdk-v2-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.ruby-v2 == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -142,13 +148,14 @@ jobs:
           generator-path: generators/ruby-v2
           language-name: ruby
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   pydantic-model-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -164,13 +171,14 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   python-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -186,13 +194,14 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   fastapi-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -208,13 +217,14 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   openapi-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.openapi == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -230,13 +240,14 @@ jobs:
           generator-path: generators/openapi
           language-name: openapi
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   postman-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.postman == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -252,13 +263,14 @@ jobs:
           generator-path: generators/postman
           language-name: postman
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   java-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -274,13 +286,14 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   java-model-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -296,13 +309,14 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   java-spring-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -318,13 +332,14 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   typescript-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -340,13 +355,14 @@ jobs:
           generator-path: generators/typescript
           language-name: typescript
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   typescript-express-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -362,13 +378,14 @@ jobs:
           generator-path: generators/typescript
           language-name: typescript
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   go-fiber-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -384,13 +401,14 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   go-model-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -406,13 +424,14 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   go-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -428,13 +447,14 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   csharp-model-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -450,13 +470,14 @@ jobs:
           generator-path: generators/csharp
           language-name: csharp
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   csharp-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -472,13 +493,14 @@ jobs:
           generator-path: generators/csharp
           language-name: csharp
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   php-model-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -494,13 +516,14 @@ jobs:
           generator-path: generators/php
           language-name: php
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   php-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -516,13 +539,14 @@ jobs:
           generator-path: generators/php
           language-name: php
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   swift-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.swift == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -538,13 +562,14 @@ jobs:
           generator-path: generators/swift
           language-name: swift
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   rust-model-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -560,13 +585,14 @@ jobs:
           generator-path: generators/rust
           language-name: rust
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   rust-sdk-seed-update:
-    needs: changes
+    needs: [changes, setup]
     if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: Seed
     steps:
@@ -582,15 +608,16 @@ jobs:
           generator-path: generators/rust
           language-name: rust
           allow-unexpected-failures: true
-          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
-          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          create-artifacts: ${{ needs.setup.outputs.create-artifacts }}
+          create-pr: ${{ needs.setup.outputs.create-pr }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   commit-seed-changes:
-    if: ${{ needs.changes.outputs.apply-changes-by-commit == 'true' }}
+    if: ${{ needs.setup.outputs.create-artifacts == 'true' }}
     needs:
-      [changes, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
+      [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
       pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 
       postman-seed-update, java-sdk-seed-update, java-model-seed-update, java-spring-seed-update,
       typescript-sdk-seed-update, typescript-express-seed-update, go-fiber-seed-update, 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -615,9 +615,6 @@ jobs:
 
   # Use always() to ensure this runs even if stages are skipped. Add check back to
   # make sure it doesn't run for failures or cancellations
-  # always() && ${{ needs.setup.outputs.create-artifacts == 'true' }} &&
-      # !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-    # CHRISM - need to fix the always later
   commit-seed-changes:
     if: >-
       ${{ 
@@ -641,6 +638,8 @@ jobs:
         run: |
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
           echo $branch
+
+      # Checkout the branch directly to avoid detaching the head so we can commit back changes
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -652,7 +651,6 @@ jobs:
         run: |
           mkdir artifacts
 
-      #CHRISM - test on failure (no changes)
       # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise 
       # they are subfoldered into folders that match *.patch pattern and cause errors downstream
       - name: Download patches
@@ -693,7 +691,5 @@ jobs:
           push: true
           fetch: false
           message: "Automated update of seed files"
-          committer_name: "Fern Support"
-          committer_email: "26544928+fern-support@users.noreply.github.com"
-
+          
   #CHRISM - kick off seed snapshot tests

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -13,20 +13,16 @@ on:
       - "test-definitions-openapi/**"
       - "generators/**"
       - "seed/**"
-  # TODO: Re-enable this trigger once repository_dispatch trigger is verified, then remove it from seed.yml
-  # pull_request:
-  #   types: [opened, synchronize, reopened, ready_for_review]
-  #   branches:
-  #     - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
-# TODO: Re-enable this concurrency once repository_dispatch trigger is verified
-# Also need to verify that stopping this workflow won't miss the addition of new seed
-# changes, which likely means playing around with how changes works or the path filering
 # Cancel previous workflows on previous push
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -13,6 +13,10 @@ on:
       - "test-definitions-openapi/**"
       - "generators/**"
       - "seed/**"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -23,6 +27,17 @@ env:
   DOCKER_BUILDKIT: 1
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      application-method: ${{ inputs.application-method }}
+    steps:
+      - name: Set application method
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "application-method=Commit" >> $GITHUB_OUTPUT
+      - name: Set application method
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "application-method=PR" >> $GITHUB_OUTPUT
   changes:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
@@ -40,6 +55,8 @@ jobs:
       php: ${{ steps.get-generator-changes.outputs.php }}
       swift: ${{ steps.get-generator-changes.outputs.swift }}
       rust: ${{ steps.get-generator-changes.outputs.rust }}
+      apply-changes-by-commit: ${{ steps.set-seed-application-method.outputs.apply-changes-by-commit }}
+      apply-changes-by-PR: ${{ steps.set-seed-application-method.outputs.apply-changes-by-PR }}
     steps:
       - if: github.event_name != 'workflow_dispatch'
         name: Checkout repo
@@ -47,11 +64,22 @@ jobs:
         with:
           # Get sufficient history to check for changes
           fetch-depth: 200
-
       - if: github.event_name != 'workflow_dispatch'
         name: Get generator changes
         id: get-generator-changes
         uses: ./.github/actions/get-generator-changes
+
+       # Apply by commit for PR to main, apply by PR for push to main or workflow_dispatch
+      - name: Set seed application method
+        id: set-seed-application-method
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "apply-changes-by-commit=true" >> $GITHUB_OUTPUT
+            echo "apply-changes-by-PR=false" >> $GITHUB_OUTPUT
+          else
+            echo "apply-changes-by-commit=false" >> $GITHUB_OUTPUT
+            echo "apply-changes-by-PR=true" >> $GITHUB_OUTPUT
+          fi
 
   ruby-model-seed-update:
     needs: changes
@@ -70,6 +98,8 @@ jobs:
           generator-path: generators/ruby
           language-name: ruby
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -90,6 +120,8 @@ jobs:
           generator-path: generators/ruby
           language-name: ruby
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -110,6 +142,8 @@ jobs:
           generator-path: generators/ruby-v2
           language-name: ruby
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -130,6 +164,8 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -150,6 +186,8 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -170,6 +208,8 @@ jobs:
           generator-path: generators/python
           language-name: python
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -190,6 +230,8 @@ jobs:
           generator-path: generators/openapi
           language-name: openapi
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -210,6 +252,8 @@ jobs:
           generator-path: generators/postman
           language-name: postman
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -230,6 +274,8 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -250,6 +296,8 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -270,6 +318,8 @@ jobs:
           generator-path: generators/java
           language-name: java
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -290,6 +340,8 @@ jobs:
           generator-path: generators/typescript
           language-name: typescript
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -310,6 +362,8 @@ jobs:
           generator-path: generators/typescript
           language-name: typescript
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -330,6 +384,8 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -350,6 +406,8 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -370,6 +428,8 @@ jobs:
           generator-path: generators/go
           language-name: go
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -390,6 +450,8 @@ jobs:
           generator-path: generators/csharp
           language-name: csharp
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -410,6 +472,8 @@ jobs:
           generator-path: generators/csharp
           language-name: csharp
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -430,6 +494,8 @@ jobs:
           generator-path: generators/php
           language-name: php
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -450,6 +516,8 @@ jobs:
           generator-path: generators/php
           language-name: php
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -470,6 +538,8 @@ jobs:
           generator-path: generators/swift
           language-name: swift
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -490,6 +560,8 @@ jobs:
           generator-path: generators/rust
           language-name: rust
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
@@ -510,5 +582,52 @@ jobs:
           generator-path: generators/rust
           language-name: rust
           allow-unexpected-failures: true
+          apply-changes-by-commit: ${{ needs.changes.outputs.apply-changes-by-commit }}
+          apply-changes-by-PR: ${{ needs.changes.outputs.apply-changes-by-PR }}
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
+
+  commit-seed-changes:
+    if: ${{ needs.changes.outputs.apply-changes-by-commit == 'true' }}
+    needs:
+      [changes, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
+      pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 
+      postman-seed-update, java-sdk-seed-update, java-model-seed-update, java-spring-seed-update,
+      typescript-sdk-seed-update, typescript-express-seed-update, go-fiber-seed-update, 
+      go-model-seed-update, go-sdk-seed-update, csharp-model-seed-update, csharp-sdk-seed-update, 
+      php-model-seed-update, php-sdk-seed-update, swift-sdk-seed-update, rust-model-seed-update, 
+      rust-sdk-seed-update
+      ]
+    runs-on: Seed
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+
+      - name: Create artifacts downloads directory
+        shell: bash
+        run: |
+          mkdir artifacts
+
+      #CHRISM - test on failure (no changes)
+      - name: Download patches
+        uses: actions/download-artifact@v5
+        with:
+          path: ./artifacts
+
+      #CHRISM - test on failure (no changes)
+      - name: Apply patches
+        shell: bash
+        run: |
+          git apply artifacts/*.patch 
+
+      - name: Add and Commit Changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "seed/*"
+          push: true
+          message: "Automated update of seed files"
+
+
+  #CHRISM - kick off seed snapshot tests

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -619,8 +619,10 @@ jobs:
       # !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     # CHRISM - need to fix the always later
   commit-seed-changes:
-    if: | 
-      always()
+    if: >-
+      ${{ 
+        always() && needs.setup.outputs.create-artifacts == 'true' 
+      }}
     needs:
       [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
       pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -619,7 +619,7 @@ jobs:
       # !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
   commit-seed-changes:
     if: | 
-      always()
+      always() && ${{ needs.setup.outputs.create-artifacts == 'true' }}
     needs:
       [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
       pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 
@@ -634,11 +634,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref_name }}
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
       - name: Create artifacts downloads directory
         shell: bash
         run: |
+          echo "${{ github.ref_name }}"
           mkdir artifacts
 
       #CHRISM - test on failure (no changes)

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -614,11 +614,12 @@ jobs:
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
   # Use always() to ensure this runs even if stages are skipped. Add check back to
-  # make sure it doesn't 
+  # make sure it doesn't run for failures or cancellations
+  # always() && ${{ needs.setup.outputs.create-artifacts == 'true' }} &&
+      # !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
   commit-seed-changes:
     if: | 
-      always() && ${{ needs.setup.outputs.create-artifacts == 'true' }} &&
-      !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+      always()
     needs:
       [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
       pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -704,20 +704,40 @@ jobs:
   # Use always() to ensure this runs even if stages from needs are skipped. 
   # Add check back to make sure it doesn't run for failures or cancellations.
   # Only trigger if there are no new patches (seed is up to date)
-  # trigger-seed-snapshot-tests:
-  #   needs: [commit-seed-changes, changes, setup]
-  #   if: >-
-  #     ${{ 
-  #       always() && needs.setup.outputs.create-artifacts == 'true' &&
-  #       needs.commit-seed-changes.outputs.has-patches == 'false' &&
-  #       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
-  #     }}
-  #   runs-on: Seed
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-  #       with:
-  #         token: ${{ secrets.FERN_GITHUB_PAT }}
+        # needs.commit-seed-changes.outputs.has-patches == 'false' && CHRISM ADD BACK
+  trigger-seed-snapshot-tests:
+    needs: [commit-seed-changes, changes, setup]
+    if: >-
+      ${{ 
+        always() && needs.setup.outputs.create-artifacts == 'true' &&
+        !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+      }}
+    runs-on: Seed
+    steps: 
+      - name: Manually call seed snapshot tests
+        uses: ./.github/workflows/seed.yml
+    # outputs:
+    # steps:
+    #   - name: Checkout repo
+    #     uses: actions/checkout@v4
+    #     with:
+    #       token: ${{ secrets.FERN_GITHUB_PAT }}
 
-  #     - name: Trigger seed snapshot tests
-  #       uses: fern-api/fern/.github/workflows/seed.yml@mallinson/example-PR-level-testing #CHRISM - change
+    #   - name: Trigger seed snapshot tests
+    #     uses: fern-api/fern/.github/workflows/seed.yml@mallinson/example-PR-level-testing #CHRISM - change
+
+  trigger-seed-snapshot-tests2:
+    needs: [commit-seed-changes, changes, setup]
+    if: >-
+      ${{ 
+        always() && needs.setup.outputs.create-artifacts == 'true' &&
+        !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+      }}
+    runs-on: Seed
+    steps: 
+    - name: Trigger seed tests
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        event-type: seed-tests
+        client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -738,6 +738,6 @@ jobs:
     - name: Trigger seed tests
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.FERN_GITHUB_PAT }}
         event-type: seed-tests
         client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -613,8 +613,8 @@ jobs:
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
-  # Use always() to ensure this runs even if stages are skipped. Add check back to
-  # make sure it doesn't run for failures or cancellations
+  # Use always() to ensure this runs even if stages from needs are skipped. 
+  # Add check back to make sure it doesn't run for failures or cancellations.
   commit-seed-changes:
     if: >-
       ${{ 
@@ -649,7 +649,14 @@ jobs:
       - name: Create artifacts downloads directory
         shell: bash
         run: |
-          mkdir artifacts
+          DIRECTORY=artifacts
+          if [ ! -d "$DIRECTORY" ]; then
+            echo "'$DIRECTORY' does NOT exist, creating it now."
+            mkdir $DIRECTORY
+          else
+            echo "WARNING: Directory '$DIRECTORY' already exists. Not an immediate error but could cause a problem downstream."
+          fi
+          
 
       # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise 
       # they are subfoldered into folders that match *.patch pattern and cause errors downstream
@@ -676,7 +683,6 @@ jobs:
           echo "Content of 'artifacts' folder:"
           ls -R artifacts/
 
-      #CHRISM - test on failure (no changes)
       - name: Apply patches
         shell: bash
         if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
@@ -692,4 +698,19 @@ jobs:
           fetch: false
           message: "Automated update of seed files"
           
-  #CHRISM - kick off seed snapshot tests
+  # # Use always() to ensure this runs even if stages from needs are skipped. 
+  # # Add check back to make sure it doesn't run for failures or cancellations.
+  # start-seed-snapshot-tests:
+  #   needs: [commit-seed-changes, changes, setup]
+  #   if: >-
+  #     ${{ 
+  #       always() && needs.setup.outputs.create-artifacts == 'true' &&
+  #       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+  #     }}
+  #   runs-on: Seed
+  #   steps:
+  #     - name: Trigger seed snapshot tests
+  #       shell: bash
+  #       run: |
+  #         echo "Triggering seed snapshot tests"
+  #         echo "seed-snapshot-tests-triggered=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -692,7 +692,7 @@ jobs:
           add: "seed/*"
           push: true
           message: "Automated update of seed files"
-          committer_name: "Fern Support"
+          author_name: "Fern Support"
 
 
 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -670,6 +670,11 @@ jobs:
             echo "HAS_PATCHES=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Display content of a folder
+        run: |
+          echo "Content of 'artifacts' folder:"
+          ls -R artifacts/
+
       #CHRISM - test on failure (no changes)
       - name: Apply patches
         shell: bash

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -720,4 +720,4 @@ jobs:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
       - name: Trigger seed snapshot tests
-        uses: ./.github/workflows/seed.yml
+        uses: fern-api/fern/.github/workflows/seed.yml@mallinson/example-PR-level-testing #CHRISM - change

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -613,8 +613,12 @@ jobs:
           secret-fern-github-pat: ${{ secrets.FERN_GITHUB_PAT }}
           secret-pr-bot-gh-pat: ${{ secrets.PR_BOT_GH_PAT }}
 
+  # Use always() to ensure this runs even if stages are skipped. Add check back to
+  # make sure it doesn't 
   commit-seed-changes:
-    if: ${{ needs.setup.outputs.create-artifacts == 'true' }}
+    if: | 
+      always() && ${{ needs.setup.outputs.create-artifacts == 'true' }} &&
+      !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     needs:
       [changes, setup, ruby-model-seed-update, ruby-sdk-seed-update, ruby-sdk-v2-seed-update,
       pydantic-model-seed-update, python-sdk-seed-update, fastapi-seed-update, openapi-seed-update, 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -632,16 +632,21 @@ jobs:
       ]
     runs-on: Seed
     steps:
+      - name: Extract branch name
+        id: extract_branch
+        shell: bash
+        run: |
+          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+          echo $branch
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ steps.extract_branch.outputs.branch }}
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
       - name: Create artifacts downloads directory
         shell: bash
         run: |
-          echo "${{ github.ref_name }}"
           mkdir artifacts
 
       #CHRISM - test on failure (no changes)

--- a/seed/go-fiber/accept-header/internal/explicit_fields.go
+++ b/seed/go-fiber/accept-header/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/accept-header/internal/explicit_fields_test.go
+++ b/seed/go-fiber/accept-header/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/alias/internal/explicit_fields.go
+++ b/seed/go-fiber/alias/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/alias/internal/explicit_fields_test.go
+++ b/seed/go-fiber/alias/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/alias/types.go
+++ b/seed/go-fiber/alias/types.go
@@ -6,15 +6,24 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/alias/fern/internal"
+	big "math/big"
 )
 
 // Object is an alias for a type.
 type Object = *Type
 
 // A simple type with just a name.
+var (
+	typeFieldId   = big.NewInt(1 << 0)
+	typeFieldName = big.NewInt(1 << 1)
+)
+
 type Type struct {
 	Id   TypeId `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -37,6 +46,27 @@ func (t *Type) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Type) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetId(id TypeId) {
+	t.Id = id
+	t.require(typeFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetName(name string) {
+	t.Name = name
+	t.require(typeFieldName)
+}
+
 func (t *Type) UnmarshalJSON(data []byte) error {
 	type unmarshaler Type
 	var value unmarshaler
@@ -50,6 +80,17 @@ func (t *Type) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *Type) MarshalJSON() ([]byte, error) {
+	type embed Type
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Type) String() string {

--- a/seed/go-fiber/any-auth/auth.go
+++ b/seed/go-fiber/any-auth/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/any-auth/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -51,10 +52,19 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -84,6 +94,34 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -97,6 +135,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/any-auth/internal/explicit_fields.go
+++ b/seed/go-fiber/any-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/any-auth/internal/explicit_fields_test.go
+++ b/seed/go-fiber/any-auth/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/any-auth/user.go
+++ b/seed/go-fiber/any-auth/user.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/any-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
 )
 
 type User struct {
 	Id   string `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id string) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -46,6 +76,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/api-wide-base-path/internal/explicit_fields.go
+++ b/seed/go-fiber/api-wide-base-path/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/api-wide-base-path/internal/explicit_fields_test.go
+++ b/seed/go-fiber/api-wide-base-path/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/audiences/foldera/service.go
+++ b/seed/go-fiber/audiences/foldera/service.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderb "github.com/audiences/fern/folderb"
 	internal "github.com/audiences/fern/internal"
+	big "math/big"
+)
+
+var (
+	responseFieldFoo = big.NewInt(1 << 0)
 )
 
 type Response struct {
 	Foo *folderb.Foo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -26,6 +34,20 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetFoo(foo *folderb.Foo) {
+	r.Foo = foo
+	r.require(responseFieldFoo)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -39,6 +61,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	}
 	r.extraProperties = extraProperties
 	return nil
+}
+
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Response) String() string {

--- a/seed/go-fiber/audiences/folderb/common.go
+++ b/seed/go-fiber/audiences/folderb/common.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderc "github.com/audiences/fern/folderc"
 	internal "github.com/audiences/fern/internal"
+	big "math/big"
+)
+
+var (
+	fooFieldFoo = big.NewInt(1 << 0)
 )
 
 type Foo struct {
 	Foo *folderc.FolderCFoo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -26,6 +34,20 @@ func (f *Foo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Foo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *Foo) SetFoo(foo *folderc.FolderCFoo) {
+	f.Foo = foo
+	f.require(fooFieldFoo)
+}
+
 func (f *Foo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Foo
 	var value unmarshaler
@@ -39,6 +61,17 @@ func (f *Foo) UnmarshalJSON(data []byte) error {
 	}
 	f.extraProperties = extraProperties
 	return nil
+}
+
+func (f *Foo) MarshalJSON() ([]byte, error) {
+	type embed Foo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *Foo) String() string {

--- a/seed/go-fiber/audiences/internal/explicit_fields.go
+++ b/seed/go-fiber/audiences/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/audiences/internal/explicit_fields_test.go
+++ b/seed/go-fiber/audiences/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/auth-environment-variables/internal/explicit_fields.go
+++ b/seed/go-fiber/auth-environment-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/auth-environment-variables/internal/explicit_fields_test.go
+++ b/seed/go-fiber/auth-environment-variables/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/basic-auth-environment-variables/internal/explicit_fields.go
+++ b/seed/go-fiber/basic-auth-environment-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/basic-auth-environment-variables/internal/explicit_fields_test.go
+++ b/seed/go-fiber/basic-auth-environment-variables/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/basic-auth-environment-variables/types.go
+++ b/seed/go-fiber/basic-auth-environment-variables/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/basic-auth-environment-variables/fern/internal"
+	big "math/big"
+)
+
+var (
+	unauthorizedRequestErrorBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type UnauthorizedRequestErrorBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]interface
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
+	u.Message = message
+	u.require(unauthorizedRequestErrorBodyFieldMessage)
+}
+
 func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler UnauthorizedRequestErrorBody
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *UnauthorizedRequestErrorBody) MarshalJSON() ([]byte, error) {
+	type embed UnauthorizedRequestErrorBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UnauthorizedRequestErrorBody) String() string {

--- a/seed/go-fiber/basic-auth/internal/explicit_fields.go
+++ b/seed/go-fiber/basic-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/basic-auth/internal/explicit_fields_test.go
+++ b/seed/go-fiber/basic-auth/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/basic-auth/types.go
+++ b/seed/go-fiber/basic-auth/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/basic-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	unauthorizedRequestErrorBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type UnauthorizedRequestErrorBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]interface
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
+	u.Message = message
+	u.require(unauthorizedRequestErrorBodyFieldMessage)
+}
+
 func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler UnauthorizedRequestErrorBody
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *UnauthorizedRequestErrorBody) MarshalJSON() ([]byte, error) {
+	type embed UnauthorizedRequestErrorBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UnauthorizedRequestErrorBody) String() string {

--- a/seed/go-fiber/bearer-token-environment-variable/internal/explicit_fields.go
+++ b/seed/go-fiber/bearer-token-environment-variable/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/bearer-token-environment-variable/internal/explicit_fields_test.go
+++ b/seed/go-fiber/bearer-token-environment-variable/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/bytes-download/internal/explicit_fields.go
+++ b/seed/go-fiber/bytes-download/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/bytes-download/internal/explicit_fields_test.go
+++ b/seed/go-fiber/bytes-download/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/bytes-upload/internal/explicit_fields.go
+++ b/seed/go-fiber/bytes-upload/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/bytes-upload/internal/explicit_fields_test.go
+++ b/seed/go-fiber/bytes-upload/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/circular-references-advanced/a.go
+++ b/seed/go-fiber/circular-references-advanced/a.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references-advanced/fern/internal"
+	big "math/big"
+)
+
+var (
+	aFieldS = big.NewInt(1 << 0)
 )
 
 type A struct {
 	S string `json:"s" url:"s"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (a *A) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *A) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *A) SetS(s string) {
+	a.S = s
+	a.require(aFieldS)
+}
+
 func (a *A) UnmarshalJSON(data []byte) error {
 	type unmarshaler A
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (a *A) UnmarshalJSON(data []byte) error {
 	}
 	a.extraProperties = extraProperties
 	return nil
+}
+
+func (a *A) MarshalJSON() ([]byte, error) {
+	type embed A
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *A) String() string {

--- a/seed/go-fiber/circular-references-advanced/ast.go
+++ b/seed/go-fiber/circular-references-advanced/ast.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references-advanced/fern/internal"
+	big "math/big"
+)
+
+var (
+	acaiFieldAnimal = big.NewInt(1 << 0)
 )
 
 type Acai struct {
 	Animal *Animal `json:"animal" url:"animal"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (a *Acai) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Acai) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetAnimal sets the Animal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Acai) SetAnimal(animal *Animal) {
+	a.Animal = animal
+	a.require(acaiFieldAnimal)
+}
+
 func (a *Acai) UnmarshalJSON(data []byte) error {
 	type unmarshaler Acai
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (a *Acai) UnmarshalJSON(data []byte) error {
 	}
 	a.extraProperties = extraProperties
 	return nil
+}
+
+func (a *Acai) MarshalJSON() ([]byte, error) {
+	type embed Acai
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *Acai) String() string {
@@ -109,8 +142,15 @@ func (a *Animal) Accept(visitor AnimalVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", a)
 }
 
+var (
+	berryFieldAnimal = big.NewInt(1 << 0)
+)
+
 type Berry struct {
 	Animal *Animal `json:"animal" url:"animal"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -124,6 +164,20 @@ func (b *Berry) GetAnimal() *Animal {
 
 func (b *Berry) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
+}
+
+func (b *Berry) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+// SetAnimal sets the Animal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *Berry) SetAnimal(animal *Animal) {
+	b.Animal = animal
+	b.require(berryFieldAnimal)
 }
 
 func (b *Berry) UnmarshalJSON(data []byte) error {
@@ -141,6 +195,17 @@ func (b *Berry) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (b *Berry) MarshalJSON() ([]byte, error) {
+	type embed Berry
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (b *Berry) String() string {
 	if value, err := internal.StringifyJSON(b); err == nil {
 		return value
@@ -148,8 +213,15 @@ func (b *Berry) String() string {
 	return fmt.Sprintf("%#v", b)
 }
 
+var (
+	branchNodeFieldChildren = big.NewInt(1 << 0)
+)
+
 type BranchNode struct {
 	Children []*Node `json:"children" url:"children"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -163,6 +235,20 @@ func (b *BranchNode) GetChildren() []*Node {
 
 func (b *BranchNode) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
+}
+
+func (b *BranchNode) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+// SetChildren sets the Children field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BranchNode) SetChildren(children []*Node) {
+	b.Children = children
+	b.require(branchNodeFieldChildren)
 }
 
 func (b *BranchNode) UnmarshalJSON(data []byte) error {
@@ -180,6 +266,17 @@ func (b *BranchNode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (b *BranchNode) MarshalJSON() ([]byte, error) {
+	type embed BranchNode
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (b *BranchNode) String() string {
 	if value, err := internal.StringifyJSON(b); err == nil {
 		return value
@@ -187,8 +284,15 @@ func (b *BranchNode) String() string {
 	return fmt.Sprintf("%#v", b)
 }
 
+var (
+	catFieldFruit = big.NewInt(1 << 0)
+)
+
 type Cat struct {
 	Fruit *Fruit `json:"fruit" url:"fruit"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -204,6 +308,20 @@ func (c *Cat) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *Cat) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetFruit sets the Fruit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Cat) SetFruit(fruit *Fruit) {
+	c.Fruit = fruit
+	c.require(catFieldFruit)
+}
+
 func (c *Cat) UnmarshalJSON(data []byte) error {
 	type unmarshaler Cat
 	var value unmarshaler
@@ -217,6 +335,17 @@ func (c *Cat) UnmarshalJSON(data []byte) error {
 	}
 	c.extraProperties = extraProperties
 	return nil
+}
+
+func (c *Cat) MarshalJSON() ([]byte, error) {
+	type embed Cat
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (c *Cat) String() string {
@@ -361,8 +490,15 @@ func (c *ContainerValue) validate() error {
 	return nil
 }
 
+var (
+	dogFieldFruit = big.NewInt(1 << 0)
+)
+
 type Dog struct {
 	Fruit *Fruit `json:"fruit" url:"fruit"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -378,6 +514,20 @@ func (d *Dog) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Dog) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetFruit sets the Fruit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *Dog) SetFruit(fruit *Fruit) {
+	d.Fruit = fruit
+	d.require(dogFieldFruit)
+}
+
 func (d *Dog) UnmarshalJSON(data []byte) error {
 	type unmarshaler Dog
 	var value unmarshaler
@@ -391,6 +541,17 @@ func (d *Dog) UnmarshalJSON(data []byte) error {
 	}
 	d.extraProperties = extraProperties
 	return nil
+}
+
+func (d *Dog) MarshalJSON() ([]byte, error) {
+	type embed Dog
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (d *Dog) String() string {
@@ -561,8 +722,15 @@ func (f *FieldValue) validate() error {
 	return nil
 }
 
+var (
+	figFieldAnimal = big.NewInt(1 << 0)
+)
+
 type Fig struct {
 	Animal *Animal `json:"animal" url:"animal"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -578,6 +746,20 @@ func (f *Fig) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Fig) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetAnimal sets the Animal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *Fig) SetAnimal(animal *Animal) {
+	f.Animal = animal
+	f.require(figFieldAnimal)
+}
+
 func (f *Fig) UnmarshalJSON(data []byte) error {
 	type unmarshaler Fig
 	var value unmarshaler
@@ -591,6 +773,17 @@ func (f *Fig) UnmarshalJSON(data []byte) error {
 	}
 	f.extraProperties = extraProperties
 	return nil
+}
+
+func (f *Fig) MarshalJSON() ([]byte, error) {
+	type embed Fig
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *Fig) String() string {
@@ -663,11 +856,22 @@ func (f *Fruit) Accept(visitor FruitVisitor) error {
 }
 
 type LeafNode struct {
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+
 	extraProperties map[string]interface{}
 }
 
 func (l *LeafNode) GetExtraProperties() map[string]interface{} {
 	return l.extraProperties
+}
+
+func (l *LeafNode) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
 }
 
 func (l *LeafNode) UnmarshalJSON(data []byte) error {
@@ -683,6 +887,17 @@ func (l *LeafNode) UnmarshalJSON(data []byte) error {
 	}
 	l.extraProperties = extraProperties
 	return nil
+}
+
+func (l *LeafNode) MarshalJSON() ([]byte, error) {
+	type embed LeafNode
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (l *LeafNode) String() string {
@@ -754,8 +969,15 @@ func (n *Node) Accept(visitor NodeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
+var (
+	nodesWrapperFieldNodes = big.NewInt(1 << 0)
+)
+
 type NodesWrapper struct {
 	Nodes [][]*Node `json:"nodes" url:"nodes"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -769,6 +991,20 @@ func (n *NodesWrapper) GetNodes() [][]*Node {
 
 func (n *NodesWrapper) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
+}
+
+func (n *NodesWrapper) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NodesWrapper) SetNodes(nodes [][]*Node) {
+	n.Nodes = nodes
+	n.require(nodesWrapperFieldNodes)
 }
 
 func (n *NodesWrapper) UnmarshalJSON(data []byte) error {
@@ -786,6 +1022,17 @@ func (n *NodesWrapper) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NodesWrapper) MarshalJSON() ([]byte, error) {
+	type embed NodesWrapper
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NodesWrapper) String() string {
 	if value, err := internal.StringifyJSON(n); err == nil {
 		return value
@@ -794,9 +1041,17 @@ func (n *NodesWrapper) String() string {
 }
 
 // This type allows us to test a circular reference with a union type (see FieldValue).
+var (
+	objectFieldValueFieldName  = big.NewInt(1 << 0)
+	objectFieldValueFieldValue = big.NewInt(1 << 1)
+)
+
 type ObjectFieldValue struct {
 	Name  FieldName   `json:"name" url:"name"`
 	Value *FieldValue `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -819,6 +1074,27 @@ func (o *ObjectFieldValue) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *ObjectFieldValue) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectFieldValue) SetName(name FieldName) {
+	o.Name = name
+	o.require(objectFieldValueFieldName)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectFieldValue) SetValue(value *FieldValue) {
+	o.Value = value
+	o.require(objectFieldValueFieldValue)
+}
+
 func (o *ObjectFieldValue) UnmarshalJSON(data []byte) error {
 	type unmarshaler ObjectFieldValue
 	var value unmarshaler
@@ -834,6 +1110,17 @@ func (o *ObjectFieldValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (o *ObjectFieldValue) MarshalJSON() ([]byte, error) {
+	type embed ObjectFieldValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (o *ObjectFieldValue) String() string {
 	if value, err := internal.StringifyJSON(o); err == nil {
 		return value
@@ -842,11 +1129,22 @@ func (o *ObjectFieldValue) String() string {
 }
 
 type ObjectValue struct {
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+
 	extraProperties map[string]interface{}
 }
 
 func (o *ObjectValue) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
+}
+
+func (o *ObjectValue) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
 }
 
 func (o *ObjectValue) UnmarshalJSON(data []byte) error {
@@ -862,6 +1160,17 @@ func (o *ObjectValue) UnmarshalJSON(data []byte) error {
 	}
 	o.extraProperties = extraProperties
 	return nil
+}
+
+func (o *ObjectValue) MarshalJSON() ([]byte, error) {
+	type embed ObjectValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectValue) String() string {

--- a/seed/go-fiber/circular-references-advanced/internal/explicit_fields.go
+++ b/seed/go-fiber/circular-references-advanced/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/circular-references-advanced/internal/explicit_fields_test.go
+++ b/seed/go-fiber/circular-references-advanced/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/circular-references-advanced/types.go
+++ b/seed/go-fiber/circular-references-advanced/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references-advanced/fern/internal"
+	big "math/big"
+)
+
+var (
+	importingAFieldA = big.NewInt(1 << 0)
 )
 
 type ImportingA struct {
 	A *A `json:"a,omitempty" url:"a,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -23,6 +31,20 @@ func (i *ImportingA) GetA() *A {
 
 func (i *ImportingA) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
+}
+
+func (i *ImportingA) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+// SetA sets the A field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *ImportingA) SetA(a *A) {
+	i.A = a
+	i.require(importingAFieldA)
 }
 
 func (i *ImportingA) UnmarshalJSON(data []byte) error {
@@ -40,6 +62,17 @@ func (i *ImportingA) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (i *ImportingA) MarshalJSON() ([]byte, error) {
+	type embed ImportingA
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (i *ImportingA) String() string {
 	if value, err := internal.StringifyJSON(i); err == nil {
 		return value
@@ -47,8 +80,15 @@ func (i *ImportingA) String() string {
 	return fmt.Sprintf("%#v", i)
 }
 
+var (
+	rootTypeFieldS = big.NewInt(1 << 0)
+)
+
 type RootType struct {
 	S string `json:"s" url:"s"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -64,6 +104,20 @@ func (r *RootType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *RootType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *RootType) SetS(s string) {
+	r.S = s
+	r.require(rootTypeFieldS)
+}
+
 func (r *RootType) UnmarshalJSON(data []byte) error {
 	type unmarshaler RootType
 	var value unmarshaler
@@ -77,6 +131,17 @@ func (r *RootType) UnmarshalJSON(data []byte) error {
 	}
 	r.extraProperties = extraProperties
 	return nil
+}
+
+func (r *RootType) MarshalJSON() ([]byte, error) {
+	type embed RootType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *RootType) String() string {

--- a/seed/go-fiber/circular-references/a.go
+++ b/seed/go-fiber/circular-references/a.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references/fern/internal"
+	big "math/big"
+)
+
+var (
+	aFieldS = big.NewInt(1 << 0)
 )
 
 type A struct {
 	S string `json:"s" url:"s"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (a *A) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *A) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *A) SetS(s string) {
+	a.S = s
+	a.require(aFieldS)
+}
+
 func (a *A) UnmarshalJSON(data []byte) error {
 	type unmarshaler A
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (a *A) UnmarshalJSON(data []byte) error {
 	}
 	a.extraProperties = extraProperties
 	return nil
+}
+
+func (a *A) MarshalJSON() ([]byte, error) {
+	type embed A
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *A) String() string {

--- a/seed/go-fiber/circular-references/internal/explicit_fields.go
+++ b/seed/go-fiber/circular-references/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/circular-references/internal/explicit_fields_test.go
+++ b/seed/go-fiber/circular-references/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/circular-references/types.go
+++ b/seed/go-fiber/circular-references/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references/fern/internal"
+	big "math/big"
+)
+
+var (
+	importingAFieldA = big.NewInt(1 << 0)
 )
 
 type ImportingA struct {
 	A *A `json:"a,omitempty" url:"a,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -23,6 +31,20 @@ func (i *ImportingA) GetA() *A {
 
 func (i *ImportingA) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
+}
+
+func (i *ImportingA) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+// SetA sets the A field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *ImportingA) SetA(a *A) {
+	i.A = a
+	i.require(importingAFieldA)
 }
 
 func (i *ImportingA) UnmarshalJSON(data []byte) error {
@@ -40,6 +62,17 @@ func (i *ImportingA) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (i *ImportingA) MarshalJSON() ([]byte, error) {
+	type embed ImportingA
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (i *ImportingA) String() string {
 	if value, err := internal.StringifyJSON(i); err == nil {
 		return value
@@ -47,8 +80,15 @@ func (i *ImportingA) String() string {
 	return fmt.Sprintf("%#v", i)
 }
 
+var (
+	rootTypeFieldS = big.NewInt(1 << 0)
+)
+
 type RootType struct {
 	S string `json:"s" url:"s"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -64,6 +104,20 @@ func (r *RootType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *RootType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *RootType) SetS(s string) {
+	r.S = s
+	r.require(rootTypeFieldS)
+}
+
 func (r *RootType) UnmarshalJSON(data []byte) error {
 	type unmarshaler RootType
 	var value unmarshaler
@@ -77,6 +131,17 @@ func (r *RootType) UnmarshalJSON(data []byte) error {
 	}
 	r.extraProperties = extraProperties
 	return nil
+}
+
+func (r *RootType) MarshalJSON() ([]byte, error) {
+	type embed RootType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *RootType) String() string {

--- a/seed/go-fiber/client-side-params/internal/explicit_fields.go
+++ b/seed/go-fiber/client-side-params/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/client-side-params/internal/explicit_fields_test.go
+++ b/seed/go-fiber/client-side-params/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/client-side-params/types.go
+++ b/seed/go-fiber/client-side-params/types.go
@@ -6,10 +6,44 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/client-side-params/fern/internal"
+	big "math/big"
 	time "time"
 )
 
 // Represents a client application
+var (
+	clientFieldClientId                = big.NewInt(1 << 0)
+	clientFieldTenant                  = big.NewInt(1 << 1)
+	clientFieldName                    = big.NewInt(1 << 2)
+	clientFieldDescription             = big.NewInt(1 << 3)
+	clientFieldGlobal                  = big.NewInt(1 << 4)
+	clientFieldClientSecret            = big.NewInt(1 << 5)
+	clientFieldAppType                 = big.NewInt(1 << 6)
+	clientFieldLogoUri                 = big.NewInt(1 << 7)
+	clientFieldIsFirstParty            = big.NewInt(1 << 8)
+	clientFieldOidcConformant          = big.NewInt(1 << 9)
+	clientFieldCallbacks               = big.NewInt(1 << 10)
+	clientFieldAllowedOrigins          = big.NewInt(1 << 11)
+	clientFieldWebOrigins              = big.NewInt(1 << 12)
+	clientFieldGrantTypes              = big.NewInt(1 << 13)
+	clientFieldJwtConfiguration        = big.NewInt(1 << 14)
+	clientFieldSigningKeys             = big.NewInt(1 << 15)
+	clientFieldEncryptionKey           = big.NewInt(1 << 16)
+	clientFieldSso                     = big.NewInt(1 << 17)
+	clientFieldSsoDisabled             = big.NewInt(1 << 18)
+	clientFieldCrossOriginAuth         = big.NewInt(1 << 19)
+	clientFieldCrossOriginLoc          = big.NewInt(1 << 20)
+	clientFieldCustomLoginPageOn       = big.NewInt(1 << 21)
+	clientFieldCustomLoginPage         = big.NewInt(1 << 22)
+	clientFieldCustomLoginPagePreview  = big.NewInt(1 << 23)
+	clientFieldFormTemplate            = big.NewInt(1 << 24)
+	clientFieldIsHerokuApp             = big.NewInt(1 << 25)
+	clientFieldAddons                  = big.NewInt(1 << 26)
+	clientFieldTokenEndpointAuthMethod = big.NewInt(1 << 27)
+	clientFieldClientMetadata          = big.NewInt(1 << 28)
+	clientFieldMobile                  = big.NewInt(1 << 29)
+)
+
 type Client struct {
 	// The unique client identifier
 	ClientId string `json:"client_id" url:"client_id"`
@@ -71,6 +105,9 @@ type Client struct {
 	ClientMetadata map[string]interface{} `json:"client_metadata,omitempty" url:"client_metadata,omitempty"`
 	// Mobile app settings
 	Mobile map[string]interface{} `json:"mobile,omitempty" url:"mobile,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -289,6 +326,223 @@ func (c *Client) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *Client) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetClientId(clientId string) {
+	c.ClientId = clientId
+	c.require(clientFieldClientId)
+}
+
+// SetTenant sets the Tenant field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetTenant(tenant *string) {
+	c.Tenant = tenant
+	c.require(clientFieldTenant)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetName(name string) {
+	c.Name = name
+	c.require(clientFieldName)
+}
+
+// SetDescription sets the Description field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetDescription(description *string) {
+	c.Description = description
+	c.require(clientFieldDescription)
+}
+
+// SetGlobal sets the Global field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetGlobal(global *bool) {
+	c.Global = global
+	c.require(clientFieldGlobal)
+}
+
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetClientSecret(clientSecret *string) {
+	c.ClientSecret = clientSecret
+	c.require(clientFieldClientSecret)
+}
+
+// SetAppType sets the AppType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetAppType(appType *string) {
+	c.AppType = appType
+	c.require(clientFieldAppType)
+}
+
+// SetLogoUri sets the LogoUri field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetLogoUri(logoUri *string) {
+	c.LogoUri = logoUri
+	c.require(clientFieldLogoUri)
+}
+
+// SetIsFirstParty sets the IsFirstParty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetIsFirstParty(isFirstParty *bool) {
+	c.IsFirstParty = isFirstParty
+	c.require(clientFieldIsFirstParty)
+}
+
+// SetOidcConformant sets the OidcConformant field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetOidcConformant(oidcConformant *bool) {
+	c.OidcConformant = oidcConformant
+	c.require(clientFieldOidcConformant)
+}
+
+// SetCallbacks sets the Callbacks field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetCallbacks(callbacks []string) {
+	c.Callbacks = callbacks
+	c.require(clientFieldCallbacks)
+}
+
+// SetAllowedOrigins sets the AllowedOrigins field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetAllowedOrigins(allowedOrigins []string) {
+	c.AllowedOrigins = allowedOrigins
+	c.require(clientFieldAllowedOrigins)
+}
+
+// SetWebOrigins sets the WebOrigins field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetWebOrigins(webOrigins []string) {
+	c.WebOrigins = webOrigins
+	c.require(clientFieldWebOrigins)
+}
+
+// SetGrantTypes sets the GrantTypes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetGrantTypes(grantTypes []string) {
+	c.GrantTypes = grantTypes
+	c.require(clientFieldGrantTypes)
+}
+
+// SetJwtConfiguration sets the JwtConfiguration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetJwtConfiguration(jwtConfiguration map[string]interface{}) {
+	c.JwtConfiguration = jwtConfiguration
+	c.require(clientFieldJwtConfiguration)
+}
+
+// SetSigningKeys sets the SigningKeys field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetSigningKeys(signingKeys []map[string]interface{}) {
+	c.SigningKeys = signingKeys
+	c.require(clientFieldSigningKeys)
+}
+
+// SetEncryptionKey sets the EncryptionKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetEncryptionKey(encryptionKey map[string]interface{}) {
+	c.EncryptionKey = encryptionKey
+	c.require(clientFieldEncryptionKey)
+}
+
+// SetSso sets the Sso field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetSso(sso *bool) {
+	c.Sso = sso
+	c.require(clientFieldSso)
+}
+
+// SetSsoDisabled sets the SsoDisabled field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetSsoDisabled(ssoDisabled *bool) {
+	c.SsoDisabled = ssoDisabled
+	c.require(clientFieldSsoDisabled)
+}
+
+// SetCrossOriginAuth sets the CrossOriginAuth field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetCrossOriginAuth(crossOriginAuth *bool) {
+	c.CrossOriginAuth = crossOriginAuth
+	c.require(clientFieldCrossOriginAuth)
+}
+
+// SetCrossOriginLoc sets the CrossOriginLoc field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetCrossOriginLoc(crossOriginLoc *string) {
+	c.CrossOriginLoc = crossOriginLoc
+	c.require(clientFieldCrossOriginLoc)
+}
+
+// SetCustomLoginPageOn sets the CustomLoginPageOn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetCustomLoginPageOn(customLoginPageOn *bool) {
+	c.CustomLoginPageOn = customLoginPageOn
+	c.require(clientFieldCustomLoginPageOn)
+}
+
+// SetCustomLoginPage sets the CustomLoginPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetCustomLoginPage(customLoginPage *string) {
+	c.CustomLoginPage = customLoginPage
+	c.require(clientFieldCustomLoginPage)
+}
+
+// SetCustomLoginPagePreview sets the CustomLoginPagePreview field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetCustomLoginPagePreview(customLoginPagePreview *string) {
+	c.CustomLoginPagePreview = customLoginPagePreview
+	c.require(clientFieldCustomLoginPagePreview)
+}
+
+// SetFormTemplate sets the FormTemplate field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetFormTemplate(formTemplate *string) {
+	c.FormTemplate = formTemplate
+	c.require(clientFieldFormTemplate)
+}
+
+// SetIsHerokuApp sets the IsHerokuApp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetIsHerokuApp(isHerokuApp *bool) {
+	c.IsHerokuApp = isHerokuApp
+	c.require(clientFieldIsHerokuApp)
+}
+
+// SetAddons sets the Addons field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetAddons(addons map[string]interface{}) {
+	c.Addons = addons
+	c.require(clientFieldAddons)
+}
+
+// SetTokenEndpointAuthMethod sets the TokenEndpointAuthMethod field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetTokenEndpointAuthMethod(tokenEndpointAuthMethod *string) {
+	c.TokenEndpointAuthMethod = tokenEndpointAuthMethod
+	c.require(clientFieldTokenEndpointAuthMethod)
+}
+
+// SetClientMetadata sets the ClientMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetClientMetadata(clientMetadata map[string]interface{}) {
+	c.ClientMetadata = clientMetadata
+	c.require(clientFieldClientMetadata)
+}
+
+// SetMobile sets the Mobile field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Client) SetMobile(mobile map[string]interface{}) {
+	c.Mobile = mobile
+	c.require(clientFieldMobile)
+}
+
 func (c *Client) UnmarshalJSON(data []byte) error {
 	type unmarshaler Client
 	var value unmarshaler
@@ -304,6 +558,17 @@ func (c *Client) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Client) MarshalJSON() ([]byte, error) {
+	type embed Client
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Client) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -312,6 +577,18 @@ func (c *Client) String() string {
 }
 
 // Represents an identity provider connection
+var (
+	connectionFieldId                 = big.NewInt(1 << 0)
+	connectionFieldName               = big.NewInt(1 << 1)
+	connectionFieldDisplayName        = big.NewInt(1 << 2)
+	connectionFieldStrategy           = big.NewInt(1 << 3)
+	connectionFieldOptions            = big.NewInt(1 << 4)
+	connectionFieldEnabledClients     = big.NewInt(1 << 5)
+	connectionFieldRealms             = big.NewInt(1 << 6)
+	connectionFieldIsDomainConnection = big.NewInt(1 << 7)
+	connectionFieldMetadata           = big.NewInt(1 << 8)
+)
+
 type Connection struct {
 	// Connection identifier
 	Id string `json:"id" url:"id"`
@@ -331,6 +608,9 @@ type Connection struct {
 	IsDomainConnection *bool `json:"is_domain_connection,omitempty" url:"is_domain_connection,omitempty"`
 	// Additional metadata
 	Metadata map[string]interface{} `json:"metadata,omitempty" url:"metadata,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -402,6 +682,76 @@ func (c *Connection) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *Connection) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetId(id string) {
+	c.Id = id
+	c.require(connectionFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetName(name string) {
+	c.Name = name
+	c.require(connectionFieldName)
+}
+
+// SetDisplayName sets the DisplayName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetDisplayName(displayName *string) {
+	c.DisplayName = displayName
+	c.require(connectionFieldDisplayName)
+}
+
+// SetStrategy sets the Strategy field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetStrategy(strategy string) {
+	c.Strategy = strategy
+	c.require(connectionFieldStrategy)
+}
+
+// SetOptions sets the Options field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetOptions(options map[string]interface{}) {
+	c.Options = options
+	c.require(connectionFieldOptions)
+}
+
+// SetEnabledClients sets the EnabledClients field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetEnabledClients(enabledClients []string) {
+	c.EnabledClients = enabledClients
+	c.require(connectionFieldEnabledClients)
+}
+
+// SetRealms sets the Realms field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetRealms(realms []string) {
+	c.Realms = realms
+	c.require(connectionFieldRealms)
+}
+
+// SetIsDomainConnection sets the IsDomainConnection field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetIsDomainConnection(isDomainConnection *bool) {
+	c.IsDomainConnection = isDomainConnection
+	c.require(connectionFieldIsDomainConnection)
+}
+
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Connection) SetMetadata(metadata map[string]interface{}) {
+	c.Metadata = metadata
+	c.require(connectionFieldMetadata)
+}
+
 func (c *Connection) UnmarshalJSON(data []byte) error {
 	type unmarshaler Connection
 	var value unmarshaler
@@ -417,12 +767,35 @@ func (c *Connection) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Connection) MarshalJSON() ([]byte, error) {
+	type embed Connection
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Connection) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
 	}
 	return fmt.Sprintf("%#v", c)
 }
+
+var (
+	createUserRequestFieldEmail         = big.NewInt(1 << 0)
+	createUserRequestFieldEmailVerified = big.NewInt(1 << 1)
+	createUserRequestFieldUsername      = big.NewInt(1 << 2)
+	createUserRequestFieldPassword      = big.NewInt(1 << 3)
+	createUserRequestFieldPhoneNumber   = big.NewInt(1 << 4)
+	createUserRequestFieldPhoneVerified = big.NewInt(1 << 5)
+	createUserRequestFieldUserMetadata  = big.NewInt(1 << 6)
+	createUserRequestFieldAppMetadata   = big.NewInt(1 << 7)
+	createUserRequestFieldConnection    = big.NewInt(1 << 8)
+)
 
 type CreateUserRequest struct {
 	Email         string                 `json:"email" url:"email"`
@@ -434,6 +807,9 @@ type CreateUserRequest struct {
 	UserMetadata  map[string]interface{} `json:"user_metadata,omitempty" url:"user_metadata,omitempty"`
 	AppMetadata   map[string]interface{} `json:"app_metadata,omitempty" url:"app_metadata,omitempty"`
 	Connection    string                 `json:"connection" url:"connection"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -505,6 +881,76 @@ func (c *CreateUserRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateUserRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetEmail(email string) {
+	c.Email = email
+	c.require(createUserRequestFieldEmail)
+}
+
+// SetEmailVerified sets the EmailVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetEmailVerified(emailVerified *bool) {
+	c.EmailVerified = emailVerified
+	c.require(createUserRequestFieldEmailVerified)
+}
+
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetUsername(username *string) {
+	c.Username = username
+	c.require(createUserRequestFieldUsername)
+}
+
+// SetPassword sets the Password field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetPassword(password *string) {
+	c.Password = password
+	c.require(createUserRequestFieldPassword)
+}
+
+// SetPhoneNumber sets the PhoneNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetPhoneNumber(phoneNumber *string) {
+	c.PhoneNumber = phoneNumber
+	c.require(createUserRequestFieldPhoneNumber)
+}
+
+// SetPhoneVerified sets the PhoneVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetPhoneVerified(phoneVerified *bool) {
+	c.PhoneVerified = phoneVerified
+	c.require(createUserRequestFieldPhoneVerified)
+}
+
+// SetUserMetadata sets the UserMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetUserMetadata(userMetadata map[string]interface{}) {
+	c.UserMetadata = userMetadata
+	c.require(createUserRequestFieldUserMetadata)
+}
+
+// SetAppMetadata sets the AppMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetAppMetadata(appMetadata map[string]interface{}) {
+	c.AppMetadata = appMetadata
+	c.require(createUserRequestFieldAppMetadata)
+}
+
+// SetConnection sets the Connection field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateUserRequest) SetConnection(connection string) {
+	c.Connection = connection
+	c.require(createUserRequestFieldConnection)
+}
+
 func (c *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateUserRequest
 	var value unmarshaler
@@ -520,12 +966,32 @@ func (c *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateUserRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateUserRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateUserRequest) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
 	}
 	return fmt.Sprintf("%#v", c)
 }
+
+var (
+	identityFieldConnection  = big.NewInt(1 << 0)
+	identityFieldUserId      = big.NewInt(1 << 1)
+	identityFieldProvider    = big.NewInt(1 << 2)
+	identityFieldIsSocial    = big.NewInt(1 << 3)
+	identityFieldAccessToken = big.NewInt(1 << 4)
+	identityFieldExpiresIn   = big.NewInt(1 << 5)
+)
 
 type Identity struct {
 	Connection  string  `json:"connection" url:"connection"`
@@ -534,6 +1000,9 @@ type Identity struct {
 	IsSocial    bool    `json:"is_social" url:"is_social"`
 	AccessToken *string `json:"access_token,omitempty" url:"access_token,omitempty"`
 	ExpiresIn   *int    `json:"expires_in,omitempty" url:"expires_in,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -584,6 +1053,55 @@ func (i *Identity) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identity) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+// SetConnection sets the Connection field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identity) SetConnection(connection string) {
+	i.Connection = connection
+	i.require(identityFieldConnection)
+}
+
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identity) SetUserId(userId string) {
+	i.UserId = userId
+	i.require(identityFieldUserId)
+}
+
+// SetProvider sets the Provider field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identity) SetProvider(provider string) {
+	i.Provider = provider
+	i.require(identityFieldProvider)
+}
+
+// SetIsSocial sets the IsSocial field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identity) SetIsSocial(isSocial bool) {
+	i.IsSocial = isSocial
+	i.require(identityFieldIsSocial)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identity) SetAccessToken(accessToken *string) {
+	i.AccessToken = accessToken
+	i.require(identityFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identity) SetExpiresIn(expiresIn *int) {
+	i.ExpiresIn = expiresIn
+	i.require(identityFieldExpiresIn)
+}
+
 func (i *Identity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identity
 	var value unmarshaler
@@ -599,6 +1117,17 @@ func (i *Identity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (i *Identity) MarshalJSON() ([]byte, error) {
+	type embed Identity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (i *Identity) String() string {
 	if value, err := internal.StringifyJSON(i); err == nil {
 		return value
@@ -607,6 +1136,14 @@ func (i *Identity) String() string {
 }
 
 // Paginated response for clients listing
+var (
+	paginatedClientResponseFieldStart   = big.NewInt(1 << 0)
+	paginatedClientResponseFieldLimit   = big.NewInt(1 << 1)
+	paginatedClientResponseFieldLength  = big.NewInt(1 << 2)
+	paginatedClientResponseFieldTotal   = big.NewInt(1 << 3)
+	paginatedClientResponseFieldClients = big.NewInt(1 << 4)
+)
+
 type PaginatedClientResponse struct {
 	// Starting index (zero-based)
 	Start int `json:"start" url:"start"`
@@ -618,6 +1155,9 @@ type PaginatedClientResponse struct {
 	Total *int `json:"total,omitempty" url:"total,omitempty"`
 	// List of clients
 	Clients []*Client `json:"clients" url:"clients"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -661,6 +1201,48 @@ func (p *PaginatedClientResponse) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *PaginatedClientResponse) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetStart sets the Start field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedClientResponse) SetStart(start int) {
+	p.Start = start
+	p.require(paginatedClientResponseFieldStart)
+}
+
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedClientResponse) SetLimit(limit int) {
+	p.Limit = limit
+	p.require(paginatedClientResponseFieldLimit)
+}
+
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedClientResponse) SetLength(length int) {
+	p.Length = length
+	p.require(paginatedClientResponseFieldLength)
+}
+
+// SetTotal sets the Total field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedClientResponse) SetTotal(total *int) {
+	p.Total = total
+	p.require(paginatedClientResponseFieldTotal)
+}
+
+// SetClients sets the Clients field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedClientResponse) SetClients(clients []*Client) {
+	p.Clients = clients
+	p.require(paginatedClientResponseFieldClients)
+}
+
 func (p *PaginatedClientResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler PaginatedClientResponse
 	var value unmarshaler
@@ -676,6 +1258,17 @@ func (p *PaginatedClientResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PaginatedClientResponse) MarshalJSON() ([]byte, error) {
+	type embed PaginatedClientResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PaginatedClientResponse) String() string {
 	if value, err := internal.StringifyJSON(p); err == nil {
 		return value
@@ -684,12 +1277,23 @@ func (p *PaginatedClientResponse) String() string {
 }
 
 // Response with pagination info like Auth0
+var (
+	paginatedUserResponseFieldUsers  = big.NewInt(1 << 0)
+	paginatedUserResponseFieldStart  = big.NewInt(1 << 1)
+	paginatedUserResponseFieldLimit  = big.NewInt(1 << 2)
+	paginatedUserResponseFieldLength = big.NewInt(1 << 3)
+	paginatedUserResponseFieldTotal  = big.NewInt(1 << 4)
+)
+
 type PaginatedUserResponse struct {
 	Users  []*User `json:"users" url:"users"`
 	Start  int     `json:"start" url:"start"`
 	Limit  int     `json:"limit" url:"limit"`
 	Length int     `json:"length" url:"length"`
 	Total  *int    `json:"total,omitempty" url:"total,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -733,6 +1337,48 @@ func (p *PaginatedUserResponse) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *PaginatedUserResponse) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedUserResponse) SetUsers(users []*User) {
+	p.Users = users
+	p.require(paginatedUserResponseFieldUsers)
+}
+
+// SetStart sets the Start field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedUserResponse) SetStart(start int) {
+	p.Start = start
+	p.require(paginatedUserResponseFieldStart)
+}
+
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedUserResponse) SetLimit(limit int) {
+	p.Limit = limit
+	p.require(paginatedUserResponseFieldLimit)
+}
+
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedUserResponse) SetLength(length int) {
+	p.Length = length
+	p.require(paginatedUserResponseFieldLength)
+}
+
+// SetTotal sets the Total field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedUserResponse) SetTotal(total *int) {
+	p.Total = total
+	p.require(paginatedUserResponseFieldTotal)
+}
+
 func (p *PaginatedUserResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler PaginatedUserResponse
 	var value unmarshaler
@@ -748,12 +1394,32 @@ func (p *PaginatedUserResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PaginatedUserResponse) MarshalJSON() ([]byte, error) {
+	type embed PaginatedUserResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PaginatedUserResponse) String() string {
 	if value, err := internal.StringifyJSON(p); err == nil {
 		return value
 	}
 	return fmt.Sprintf("%#v", p)
 }
+
+var (
+	resourceFieldId          = big.NewInt(1 << 0)
+	resourceFieldName        = big.NewInt(1 << 1)
+	resourceFieldDescription = big.NewInt(1 << 2)
+	resourceFieldCreatedAt   = big.NewInt(1 << 3)
+	resourceFieldUpdatedAt   = big.NewInt(1 << 4)
+	resourceFieldMetadata    = big.NewInt(1 << 5)
+)
 
 type Resource struct {
 	Id          string                 `json:"id" url:"id"`
@@ -762,6 +1428,9 @@ type Resource struct {
 	CreatedAt   time.Time              `json:"created_at" url:"created_at"`
 	UpdatedAt   time.Time              `json:"updated_at" url:"updated_at"`
 	Metadata    map[string]interface{} `json:"metadata,omitempty" url:"metadata,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -812,6 +1481,55 @@ func (r *Resource) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Resource) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Resource) SetId(id string) {
+	r.Id = id
+	r.require(resourceFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Resource) SetName(name string) {
+	r.Name = name
+	r.require(resourceFieldName)
+}
+
+// SetDescription sets the Description field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Resource) SetDescription(description *string) {
+	r.Description = description
+	r.require(resourceFieldDescription)
+}
+
+// SetCreatedAt sets the CreatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Resource) SetCreatedAt(createdAt time.Time) {
+	r.CreatedAt = createdAt
+	r.require(resourceFieldCreatedAt)
+}
+
+// SetUpdatedAt sets the UpdatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Resource) SetUpdatedAt(updatedAt time.Time) {
+	r.UpdatedAt = updatedAt
+	r.require(resourceFieldUpdatedAt)
+}
+
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Resource) SetMetadata(metadata map[string]interface{}) {
+	r.Metadata = metadata
+	r.require(resourceFieldMetadata)
+}
+
 func (r *Resource) UnmarshalJSON(data []byte) error {
 	type embed Resource
 	var unmarshaler = struct {
@@ -846,7 +1564,8 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 		CreatedAt: internal.NewDateTime(r.CreatedAt),
 		UpdatedAt: internal.NewDateTime(r.UpdatedAt),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Resource) String() string {
@@ -856,10 +1575,19 @@ func (r *Resource) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	searchResponseFieldResults    = big.NewInt(1 << 0)
+	searchResponseFieldTotal      = big.NewInt(1 << 1)
+	searchResponseFieldNextOffset = big.NewInt(1 << 2)
+)
+
 type SearchResponse struct {
 	Results    []*Resource `json:"results" url:"results"`
 	Total      *int        `json:"total,omitempty" url:"total,omitempty"`
 	NextOffset *int        `json:"next_offset,omitempty" url:"next_offset,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -889,6 +1617,34 @@ func (s *SearchResponse) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SearchResponse) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SearchResponse) SetResults(results []*Resource) {
+	s.Results = results
+	s.require(searchResponseFieldResults)
+}
+
+// SetTotal sets the Total field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SearchResponse) SetTotal(total *int) {
+	s.Total = total
+	s.require(searchResponseFieldTotal)
+}
+
+// SetNextOffset sets the NextOffset field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SearchResponse) SetNextOffset(nextOffset *int) {
+	s.NextOffset = nextOffset
+	s.require(searchResponseFieldNextOffset)
+}
+
 func (s *SearchResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler SearchResponse
 	var value unmarshaler
@@ -904,12 +1660,35 @@ func (s *SearchResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SearchResponse) MarshalJSON() ([]byte, error) {
+	type embed SearchResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SearchResponse) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
 	}
 	return fmt.Sprintf("%#v", s)
 }
+
+var (
+	updateUserRequestFieldEmail         = big.NewInt(1 << 0)
+	updateUserRequestFieldEmailVerified = big.NewInt(1 << 1)
+	updateUserRequestFieldUsername      = big.NewInt(1 << 2)
+	updateUserRequestFieldPhoneNumber   = big.NewInt(1 << 3)
+	updateUserRequestFieldPhoneVerified = big.NewInt(1 << 4)
+	updateUserRequestFieldUserMetadata  = big.NewInt(1 << 5)
+	updateUserRequestFieldAppMetadata   = big.NewInt(1 << 6)
+	updateUserRequestFieldPassword      = big.NewInt(1 << 7)
+	updateUserRequestFieldBlocked       = big.NewInt(1 << 8)
+)
 
 type UpdateUserRequest struct {
 	Email         *string                `json:"email,omitempty" url:"email,omitempty"`
@@ -921,6 +1700,9 @@ type UpdateUserRequest struct {
 	AppMetadata   map[string]interface{} `json:"app_metadata,omitempty" url:"app_metadata,omitempty"`
 	Password      *string                `json:"password,omitempty" url:"password,omitempty"`
 	Blocked       *bool                  `json:"blocked,omitempty" url:"blocked,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -992,6 +1774,76 @@ func (u *UpdateUserRequest) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UpdateUserRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetEmail(email *string) {
+	u.Email = email
+	u.require(updateUserRequestFieldEmail)
+}
+
+// SetEmailVerified sets the EmailVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetEmailVerified(emailVerified *bool) {
+	u.EmailVerified = emailVerified
+	u.require(updateUserRequestFieldEmailVerified)
+}
+
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetUsername(username *string) {
+	u.Username = username
+	u.require(updateUserRequestFieldUsername)
+}
+
+// SetPhoneNumber sets the PhoneNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetPhoneNumber(phoneNumber *string) {
+	u.PhoneNumber = phoneNumber
+	u.require(updateUserRequestFieldPhoneNumber)
+}
+
+// SetPhoneVerified sets the PhoneVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetPhoneVerified(phoneVerified *bool) {
+	u.PhoneVerified = phoneVerified
+	u.require(updateUserRequestFieldPhoneVerified)
+}
+
+// SetUserMetadata sets the UserMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetUserMetadata(userMetadata map[string]interface{}) {
+	u.UserMetadata = userMetadata
+	u.require(updateUserRequestFieldUserMetadata)
+}
+
+// SetAppMetadata sets the AppMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetAppMetadata(appMetadata map[string]interface{}) {
+	u.AppMetadata = appMetadata
+	u.require(updateUserRequestFieldAppMetadata)
+}
+
+// SetPassword sets the Password field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetPassword(password *string) {
+	u.Password = password
+	u.require(updateUserRequestFieldPassword)
+}
+
+// SetBlocked sets the Blocked field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UpdateUserRequest) SetBlocked(blocked *bool) {
+	u.Blocked = blocked
+	u.require(updateUserRequestFieldBlocked)
+}
+
 func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler UpdateUserRequest
 	var value unmarshaler
@@ -1007,6 +1859,17 @@ func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UpdateUserRequest) MarshalJSON() ([]byte, error) {
+	type embed UpdateUserRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UpdateUserRequest) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -1015,6 +1878,30 @@ func (u *UpdateUserRequest) String() string {
 }
 
 // User object similar to Auth0 users
+var (
+	userFieldUserId        = big.NewInt(1 << 0)
+	userFieldEmail         = big.NewInt(1 << 1)
+	userFieldEmailVerified = big.NewInt(1 << 2)
+	userFieldUsername      = big.NewInt(1 << 3)
+	userFieldPhoneNumber   = big.NewInt(1 << 4)
+	userFieldPhoneVerified = big.NewInt(1 << 5)
+	userFieldCreatedAt     = big.NewInt(1 << 6)
+	userFieldUpdatedAt     = big.NewInt(1 << 7)
+	userFieldIdentities    = big.NewInt(1 << 8)
+	userFieldAppMetadata   = big.NewInt(1 << 9)
+	userFieldUserMetadata  = big.NewInt(1 << 10)
+	userFieldPicture       = big.NewInt(1 << 11)
+	userFieldName          = big.NewInt(1 << 12)
+	userFieldNickname      = big.NewInt(1 << 13)
+	userFieldMultifactor   = big.NewInt(1 << 14)
+	userFieldLastIp        = big.NewInt(1 << 15)
+	userFieldLastLogin     = big.NewInt(1 << 16)
+	userFieldLoginsCount   = big.NewInt(1 << 17)
+	userFieldBlocked       = big.NewInt(1 << 18)
+	userFieldGivenName     = big.NewInt(1 << 19)
+	userFieldFamilyName    = big.NewInt(1 << 20)
+)
+
 type User struct {
 	UserId        string                 `json:"user_id" url:"user_id"`
 	Email         string                 `json:"email" url:"email"`
@@ -1037,6 +1924,9 @@ type User struct {
 	Blocked       *bool                  `json:"blocked,omitempty" url:"blocked,omitempty"`
 	GivenName     *string                `json:"given_name,omitempty" url:"given_name,omitempty"`
 	FamilyName    *string                `json:"family_name,omitempty" url:"family_name,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1192,6 +2082,160 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetUserId(userId string) {
+	u.UserId = userId
+	u.require(userFieldUserId)
+}
+
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetEmail(email string) {
+	u.Email = email
+	u.require(userFieldEmail)
+}
+
+// SetEmailVerified sets the EmailVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetEmailVerified(emailVerified bool) {
+	u.EmailVerified = emailVerified
+	u.require(userFieldEmailVerified)
+}
+
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetUsername(username *string) {
+	u.Username = username
+	u.require(userFieldUsername)
+}
+
+// SetPhoneNumber sets the PhoneNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetPhoneNumber(phoneNumber *string) {
+	u.PhoneNumber = phoneNumber
+	u.require(userFieldPhoneNumber)
+}
+
+// SetPhoneVerified sets the PhoneVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetPhoneVerified(phoneVerified *bool) {
+	u.PhoneVerified = phoneVerified
+	u.require(userFieldPhoneVerified)
+}
+
+// SetCreatedAt sets the CreatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetCreatedAt(createdAt time.Time) {
+	u.CreatedAt = createdAt
+	u.require(userFieldCreatedAt)
+}
+
+// SetUpdatedAt sets the UpdatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetUpdatedAt(updatedAt time.Time) {
+	u.UpdatedAt = updatedAt
+	u.require(userFieldUpdatedAt)
+}
+
+// SetIdentities sets the Identities field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetIdentities(identities []*Identity) {
+	u.Identities = identities
+	u.require(userFieldIdentities)
+}
+
+// SetAppMetadata sets the AppMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetAppMetadata(appMetadata map[string]interface{}) {
+	u.AppMetadata = appMetadata
+	u.require(userFieldAppMetadata)
+}
+
+// SetUserMetadata sets the UserMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetUserMetadata(userMetadata map[string]interface{}) {
+	u.UserMetadata = userMetadata
+	u.require(userFieldUserMetadata)
+}
+
+// SetPicture sets the Picture field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetPicture(picture *string) {
+	u.Picture = picture
+	u.require(userFieldPicture)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name *string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetNickname sets the Nickname field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetNickname(nickname *string) {
+	u.Nickname = nickname
+	u.require(userFieldNickname)
+}
+
+// SetMultifactor sets the Multifactor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetMultifactor(multifactor []string) {
+	u.Multifactor = multifactor
+	u.require(userFieldMultifactor)
+}
+
+// SetLastIp sets the LastIp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetLastIp(lastIp *string) {
+	u.LastIp = lastIp
+	u.require(userFieldLastIp)
+}
+
+// SetLastLogin sets the LastLogin field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetLastLogin(lastLogin *time.Time) {
+	u.LastLogin = lastLogin
+	u.require(userFieldLastLogin)
+}
+
+// SetLoginsCount sets the LoginsCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetLoginsCount(loginsCount *int) {
+	u.LoginsCount = loginsCount
+	u.require(userFieldLoginsCount)
+}
+
+// SetBlocked sets the Blocked field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetBlocked(blocked *bool) {
+	u.Blocked = blocked
+	u.require(userFieldBlocked)
+}
+
+// SetGivenName sets the GivenName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetGivenName(givenName *string) {
+	u.GivenName = givenName
+	u.require(userFieldGivenName)
+}
+
+// SetFamilyName sets the FamilyName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetFamilyName(familyName *string) {
+	u.FamilyName = familyName
+	u.require(userFieldFamilyName)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type embed User
 	var unmarshaler = struct {
@@ -1230,7 +2274,8 @@ func (u *User) MarshalJSON() ([]byte, error) {
 		UpdatedAt: internal.NewDateTime(u.UpdatedAt),
 		LastLogin: internal.NewOptionalDateTime(u.LastLogin),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/content-type/internal/explicit_fields.go
+++ b/seed/go-fiber/content-type/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/content-type/internal/explicit_fields_test.go
+++ b/seed/go-fiber/content-type/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/cross-package-type-names/foldera/service.go
+++ b/seed/go-fiber/cross-package-type-names/foldera/service.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderb "github.com/cross-package-type-names/fern/folderb"
 	internal "github.com/cross-package-type-names/fern/internal"
+	big "math/big"
+)
+
+var (
+	responseFieldFoo = big.NewInt(1 << 0)
 )
 
 type Response struct {
 	Foo *folderb.Foo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -26,6 +34,20 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetFoo(foo *folderb.Foo) {
+	r.Foo = foo
+	r.require(responseFieldFoo)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -39,6 +61,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	}
 	r.extraProperties = extraProperties
 	return nil
+}
+
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Response) String() string {

--- a/seed/go-fiber/cross-package-type-names/folderb/common.go
+++ b/seed/go-fiber/cross-package-type-names/folderb/common.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderc "github.com/cross-package-type-names/fern/folderc"
 	internal "github.com/cross-package-type-names/fern/internal"
+	big "math/big"
+)
+
+var (
+	fooFieldFoo = big.NewInt(1 << 0)
 )
 
 type Foo struct {
 	Foo *folderc.Foo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -26,6 +34,20 @@ func (f *Foo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Foo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *Foo) SetFoo(foo *folderc.Foo) {
+	f.Foo = foo
+	f.require(fooFieldFoo)
+}
+
 func (f *Foo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Foo
 	var value unmarshaler
@@ -39,6 +61,17 @@ func (f *Foo) UnmarshalJSON(data []byte) error {
 	}
 	f.extraProperties = extraProperties
 	return nil
+}
+
+func (f *Foo) MarshalJSON() ([]byte, error) {
+	type embed Foo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *Foo) String() string {

--- a/seed/go-fiber/cross-package-type-names/folderc/common.go
+++ b/seed/go-fiber/cross-package-type-names/folderc/common.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	internal "github.com/cross-package-type-names/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
+)
+
+var (
+	fooFieldBarProperty = big.NewInt(1 << 0)
 )
 
 type Foo struct {
 	BarProperty uuid.UUID `json:"bar_property" url:"bar_property"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -26,6 +34,20 @@ func (f *Foo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Foo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetBarProperty sets the BarProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *Foo) SetBarProperty(barProperty uuid.UUID) {
+	f.BarProperty = barProperty
+	f.require(fooFieldBarProperty)
+}
+
 func (f *Foo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Foo
 	var value unmarshaler
@@ -39,6 +61,17 @@ func (f *Foo) UnmarshalJSON(data []byte) error {
 	}
 	f.extraProperties = extraProperties
 	return nil
+}
+
+func (f *Foo) MarshalJSON() ([]byte, error) {
+	type embed Foo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *Foo) String() string {

--- a/seed/go-fiber/cross-package-type-names/folderd/service.go
+++ b/seed/go-fiber/cross-package-type-names/folderd/service.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderb "github.com/cross-package-type-names/fern/folderb"
 	internal "github.com/cross-package-type-names/fern/internal"
+	big "math/big"
+)
+
+var (
+	responseFieldFoo = big.NewInt(1 << 0)
 )
 
 type Response struct {
 	Foo *folderb.Foo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -26,6 +34,20 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetFoo(foo *folderb.Foo) {
+	r.Foo = foo
+	r.require(responseFieldFoo)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -39,6 +61,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	}
 	r.extraProperties = extraProperties
 	return nil
+}
+
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Response) String() string {

--- a/seed/go-fiber/cross-package-type-names/internal/explicit_fields.go
+++ b/seed/go-fiber/cross-package-type-names/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/cross-package-type-names/internal/explicit_fields_test.go
+++ b/seed/go-fiber/cross-package-type-names/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/custom-auth/internal/explicit_fields.go
+++ b/seed/go-fiber/custom-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/custom-auth/internal/explicit_fields_test.go
+++ b/seed/go-fiber/custom-auth/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/custom-auth/types.go
+++ b/seed/go-fiber/custom-auth/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/custom-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	unauthorizedRequestErrorBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type UnauthorizedRequestErrorBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]interface
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
+	u.Message = message
+	u.require(unauthorizedRequestErrorBodyFieldMessage)
+}
+
 func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler UnauthorizedRequestErrorBody
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *UnauthorizedRequestErrorBody) MarshalJSON() ([]byte, error) {
+	type embed UnauthorizedRequestErrorBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UnauthorizedRequestErrorBody) String() string {

--- a/seed/go-fiber/empty-clients/internal/explicit_fields.go
+++ b/seed/go-fiber/empty-clients/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/empty-clients/internal/explicit_fields_test.go
+++ b/seed/go-fiber/empty-clients/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/enum/internal/explicit_fields.go
+++ b/seed/go-fiber/enum/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/enum/internal/explicit_fields_test.go
+++ b/seed/go-fiber/enum/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/error-property/internal/explicit_fields.go
+++ b/seed/go-fiber/error-property/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/error-property/internal/explicit_fields_test.go
+++ b/seed/go-fiber/error-property/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/error-property/types.go
+++ b/seed/go-fiber/error-property/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/error-property/fern/internal"
+	big "math/big"
+)
+
+var (
+	propertyBasedErrorTestBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type PropertyBasedErrorTestBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (p *PropertyBasedErrorTestBody) GetExtraProperties() map[string]interface{}
 	return p.extraProperties
 }
 
+func (p *PropertyBasedErrorTestBody) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PropertyBasedErrorTestBody) SetMessage(message string) {
+	p.Message = message
+	p.require(propertyBasedErrorTestBodyFieldMessage)
+}
+
 func (p *PropertyBasedErrorTestBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler PropertyBasedErrorTestBody
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (p *PropertyBasedErrorTestBody) UnmarshalJSON(data []byte) error {
 	}
 	p.extraProperties = extraProperties
 	return nil
+}
+
+func (p *PropertyBasedErrorTestBody) MarshalJSON() ([]byte, error) {
+	type embed PropertyBasedErrorTestBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *PropertyBasedErrorTestBody) String() string {

--- a/seed/go-fiber/errors/commons.go
+++ b/seed/go-fiber/errors/commons.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/errors/fern/internal"
+	big "math/big"
+)
+
+var (
+	errorBodyFieldMessage = big.NewInt(1 << 0)
+	errorBodyFieldCode    = big.NewInt(1 << 1)
 )
 
 type ErrorBody struct {
 	Message string `json:"message" url:"message"`
 	Code    int    `json:"code" url:"code"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (e *ErrorBody) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ErrorBody) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ErrorBody) SetMessage(message string) {
+	e.Message = message
+	e.require(errorBodyFieldMessage)
+}
+
+// SetCode sets the Code field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ErrorBody) SetCode(code int) {
+	e.Code = code
+	e.require(errorBodyFieldCode)
+}
+
 func (e *ErrorBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler ErrorBody
 	var value unmarshaler
@@ -46,6 +76,17 @@ func (e *ErrorBody) UnmarshalJSON(data []byte) error {
 	}
 	e.extraProperties = extraProperties
 	return nil
+}
+
+func (e *ErrorBody) MarshalJSON() ([]byte, error) {
+	type embed ErrorBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ErrorBody) String() string {

--- a/seed/go-fiber/errors/internal/explicit_fields.go
+++ b/seed/go-fiber/errors/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/errors/internal/explicit_fields_test.go
+++ b/seed/go-fiber/errors/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/errors/simple.go
+++ b/seed/go-fiber/errors/simple.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/errors/fern/internal"
+	big "math/big"
+)
+
+var (
+	fooRequestFieldBar = big.NewInt(1 << 0)
 )
 
 type FooRequest struct {
 	Bar string `json:"bar" url:"bar"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -23,6 +31,20 @@ func (f *FooRequest) GetBar() string {
 
 func (f *FooRequest) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FooRequest) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetBar sets the Bar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *FooRequest) SetBar(bar string) {
+	f.Bar = bar
+	f.require(fooRequestFieldBar)
 }
 
 func (f *FooRequest) UnmarshalJSON(data []byte) error {
@@ -40,6 +62,17 @@ func (f *FooRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FooRequest) MarshalJSON() ([]byte, error) {
+	type embed FooRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FooRequest) String() string {
 	if value, err := internal.StringifyJSON(f); err == nil {
 		return value
@@ -47,8 +80,15 @@ func (f *FooRequest) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	fooResponseFieldBar = big.NewInt(1 << 0)
+)
+
 type FooResponse struct {
 	Bar string `json:"bar" url:"bar"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -64,6 +104,20 @@ func (f *FooResponse) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *FooResponse) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetBar sets the Bar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *FooResponse) SetBar(bar string) {
+	f.Bar = bar
+	f.require(fooResponseFieldBar)
+}
+
 func (f *FooResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler FooResponse
 	var value unmarshaler
@@ -77,6 +131,17 @@ func (f *FooResponse) UnmarshalJSON(data []byte) error {
 	}
 	f.extraProperties = extraProperties
 	return nil
+}
+
+func (f *FooResponse) MarshalJSON() ([]byte, error) {
+	type embed FooResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *FooResponse) String() string {

--- a/seed/go-fiber/examples/commons/types.go
+++ b/seed/go-fiber/examples/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -302,6 +312,34 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -315,6 +353,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	}
 	m.extraProperties = extraProperties
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-fiber/examples/internal/explicit_fields.go
+++ b/seed/go-fiber/examples/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/examples/internal/explicit_fields_test.go
+++ b/seed/go-fiber/examples/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/examples/types.go
+++ b/seed/go-fiber/examples/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -91,6 +101,34 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -104,6 +142,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	}
 	i.extraProperties = extraProperties
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -175,9 +224,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -200,6 +257,27 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -215,6 +293,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if value, err := internal.StringifyJSON(a); err == nil {
 		return value
@@ -222,9 +311,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -247,6 +344,27 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -262,12 +380,39 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if value, err := internal.StringifyJSON(a); err == nil {
 		return value
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -283,6 +428,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -382,6 +530,104 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -395,6 +641,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	}
 	b.extraProperties = extraProperties
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -487,8 +744,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -502,6 +766,20 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -519,6 +797,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -526,10 +815,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -559,6 +857,34 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -574,6 +900,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if value, err := internal.StringifyJSON(d); err == nil {
 		return value
@@ -581,9 +918,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -606,6 +951,27 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -619,6 +985,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	}
 	e.extraProperties = extraProperties
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -752,10 +1129,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -785,6 +1171,34 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -800,12 +1214,36 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if value, err := internal.StringifyJSON(e); err == nil {
 		return value
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -819,7 +1257,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 }
@@ -902,6 +1343,83 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -935,7 +1453,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -945,9 +1464,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -970,6 +1497,27 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -983,6 +1531,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	}
 	f.extraProperties = extraProperties
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1155,9 +1714,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1180,6 +1747,27 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1193,6 +1781,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	}
 	m.extraProperties = extraProperties
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1229,10 +1828,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1260,6 +1868,34 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1296,7 +1932,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1305,6 +1942,18 @@ func (m *Moment) String() string {
 	}
 	return fmt.Sprintf("%#v", m)
 }
+
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
 
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -1317,7 +1966,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 }
@@ -1393,6 +2045,76 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1426,7 +2148,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1438,10 +2161,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1471,6 +2203,34 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1486,6 +2246,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if value, err := internal.StringifyJSON(n); err == nil {
 		return value
@@ -1493,8 +2264,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1508,6 +2286,20 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1525,6 +2317,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -1532,8 +2335,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1547,6 +2357,20 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1564,6 +2388,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -1571,9 +2406,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1596,6 +2439,27 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1611,6 +2475,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -1618,8 +2493,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1633,6 +2515,20 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1650,6 +2546,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -1657,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1682,6 +2597,27 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1695,6 +2631,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1839,8 +2786,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1856,6 +2810,20 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -1869,6 +2837,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-fiber/exhaustive/general_errors.go
+++ b/seed/go-fiber/exhaustive/general_errors.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
+	big "math/big"
+)
+
+var (
+	badObjectRequestInfoFieldMessage = big.NewInt(1 << 0)
 )
 
 type BadObjectRequestInfo struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (b *BadObjectRequestInfo) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BadObjectRequestInfo) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BadObjectRequestInfo) SetMessage(message string) {
+	b.Message = message
+	b.require(badObjectRequestInfoFieldMessage)
+}
+
 func (b *BadObjectRequestInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler BadObjectRequestInfo
 	var value unmarshaler
@@ -38,6 +60,17 @@ func (b *BadObjectRequestInfo) UnmarshalJSON(data []byte) error {
 	}
 	b.extraProperties = extraProperties
 	return nil
+}
+
+func (b *BadObjectRequestInfo) MarshalJSON() ([]byte, error) {
+	type embed BadObjectRequestInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BadObjectRequestInfo) String() string {

--- a/seed/go-fiber/exhaustive/internal/explicit_fields.go
+++ b/seed/go-fiber/exhaustive/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/exhaustive/internal/explicit_fields_test.go
+++ b/seed/go-fiber/exhaustive/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/exhaustive/types/docs.go
+++ b/seed/go-fiber/exhaustive/types/docs.go
@@ -6,6 +6,11 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
+	big "math/big"
+)
+
+var (
+	objectWithDocsFieldString = big.NewInt(1 << 0)
 )
 
 type ObjectWithDocs struct {
@@ -66,6 +71,9 @@ type ObjectWithDocs struct {
 	// - &: HTML entities
 	String string `json:"string" url:"string"`
 
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+
 	extraProperties map[string]interface{}
 }
 
@@ -78,6 +86,20 @@ func (o *ObjectWithDocs) GetString() string {
 
 func (o *ObjectWithDocs) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
+}
+
+func (o *ObjectWithDocs) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithDocs) SetString(string_ string) {
+	o.String = string_
+	o.require(objectWithDocsFieldString)
 }
 
 func (o *ObjectWithDocs) UnmarshalJSON(data []byte) error {
@@ -93,6 +115,17 @@ func (o *ObjectWithDocs) UnmarshalJSON(data []byte) error {
 	}
 	o.extraProperties = extraProperties
 	return nil
+}
+
+func (o *ObjectWithDocs) MarshalJSON() ([]byte, error) {
+	type embed ObjectWithDocs
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectWithDocs) String() string {

--- a/seed/go-fiber/exhaustive/types/object.go
+++ b/seed/go-fiber/exhaustive/types/object.go
@@ -7,11 +7,19 @@ import (
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
+)
+
+var (
+	doubleOptionalFieldOptionalAlias = big.NewInt(1 << 0)
 )
 
 type DoubleOptional struct {
 	OptionalAlias *OptionalAlias `json:"optionalAlias,omitempty" url:"optionalAlias,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (d *DoubleOptional) GetOptionalAlias() *OptionalAlias {
 
 func (d *DoubleOptional) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DoubleOptional) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetOptionalAlias sets the OptionalAlias field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DoubleOptional) SetOptionalAlias(optionalAlias *OptionalAlias) {
+	d.OptionalAlias = optionalAlias
+	d.require(doubleOptionalFieldOptionalAlias)
 }
 
 func (d *DoubleOptional) UnmarshalJSON(data []byte) error {
@@ -42,6 +64,17 @@ func (d *DoubleOptional) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DoubleOptional) MarshalJSON() ([]byte, error) {
+	type embed DoubleOptional
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DoubleOptional) String() string {
 	if value, err := internal.StringifyJSON(d); err == nil {
 		return value
@@ -49,9 +82,17 @@ func (d *DoubleOptional) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	nestedObjectWithOptionalFieldFieldString       = big.NewInt(1 << 0)
+	nestedObjectWithOptionalFieldFieldNestedObject = big.NewInt(1 << 1)
+)
+
 type NestedObjectWithOptionalField struct {
 	String       *string                  `json:"string,omitempty" url:"string,omitempty"`
 	NestedObject *ObjectWithOptionalField `json:"NestedObject,omitempty" url:"NestedObject,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -74,6 +115,27 @@ func (n *NestedObjectWithOptionalField) GetExtraProperties() map[string]interfac
 	return n.extraProperties
 }
 
+func (n *NestedObjectWithOptionalField) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedObjectWithOptionalField) SetString(string_ *string) {
+	n.String = string_
+	n.require(nestedObjectWithOptionalFieldFieldString)
+}
+
+// SetNestedObject sets the NestedObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedObjectWithOptionalField) SetNestedObject(nestedObject *ObjectWithOptionalField) {
+	n.NestedObject = nestedObject
+	n.require(nestedObjectWithOptionalFieldFieldNestedObject)
+}
+
 func (n *NestedObjectWithOptionalField) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedObjectWithOptionalField
 	var value unmarshaler
@@ -89,6 +151,17 @@ func (n *NestedObjectWithOptionalField) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedObjectWithOptionalField) MarshalJSON() ([]byte, error) {
+	type embed NestedObjectWithOptionalField
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedObjectWithOptionalField) String() string {
 	if value, err := internal.StringifyJSON(n); err == nil {
 		return value
@@ -96,9 +169,17 @@ func (n *NestedObjectWithOptionalField) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	nestedObjectWithRequiredFieldFieldString       = big.NewInt(1 << 0)
+	nestedObjectWithRequiredFieldFieldNestedObject = big.NewInt(1 << 1)
+)
+
 type NestedObjectWithRequiredField struct {
 	String       string                   `json:"string" url:"string"`
 	NestedObject *ObjectWithOptionalField `json:"NestedObject" url:"NestedObject"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -121,6 +202,27 @@ func (n *NestedObjectWithRequiredField) GetExtraProperties() map[string]interfac
 	return n.extraProperties
 }
 
+func (n *NestedObjectWithRequiredField) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedObjectWithRequiredField) SetString(string_ string) {
+	n.String = string_
+	n.require(nestedObjectWithRequiredFieldFieldString)
+}
+
+// SetNestedObject sets the NestedObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedObjectWithRequiredField) SetNestedObject(nestedObject *ObjectWithOptionalField) {
+	n.NestedObject = nestedObject
+	n.require(nestedObjectWithRequiredFieldFieldNestedObject)
+}
+
 func (n *NestedObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedObjectWithRequiredField
 	var value unmarshaler
@@ -136,6 +238,17 @@ func (n *NestedObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedObjectWithRequiredField) MarshalJSON() ([]byte, error) {
+	type embed NestedObjectWithRequiredField
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedObjectWithRequiredField) String() string {
 	if value, err := internal.StringifyJSON(n); err == nil {
 		return value
@@ -143,8 +256,15 @@ func (n *NestedObjectWithRequiredField) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	objectWithMapOfMapFieldMap = big.NewInt(1 << 0)
+)
+
 type ObjectWithMapOfMap struct {
 	Map map[string]map[string]string `json:"map" url:"map"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -158,6 +278,20 @@ func (o *ObjectWithMapOfMap) GetMap() map[string]map[string]string {
 
 func (o *ObjectWithMapOfMap) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
+}
+
+func (o *ObjectWithMapOfMap) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+// SetMap sets the Map field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithMapOfMap) SetMap(map_ map[string]map[string]string) {
+	o.Map = map_
+	o.require(objectWithMapOfMapFieldMap)
 }
 
 func (o *ObjectWithMapOfMap) UnmarshalJSON(data []byte) error {
@@ -175,12 +309,39 @@ func (o *ObjectWithMapOfMap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (o *ObjectWithMapOfMap) MarshalJSON() ([]byte, error) {
+	type embed ObjectWithMapOfMap
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (o *ObjectWithMapOfMap) String() string {
 	if value, err := internal.StringifyJSON(o); err == nil {
 		return value
 	}
 	return fmt.Sprintf("%#v", o)
 }
+
+var (
+	objectWithOptionalFieldFieldString   = big.NewInt(1 << 0)
+	objectWithOptionalFieldFieldInteger  = big.NewInt(1 << 1)
+	objectWithOptionalFieldFieldLong     = big.NewInt(1 << 2)
+	objectWithOptionalFieldFieldDouble   = big.NewInt(1 << 3)
+	objectWithOptionalFieldFieldBool     = big.NewInt(1 << 4)
+	objectWithOptionalFieldFieldDatetime = big.NewInt(1 << 5)
+	objectWithOptionalFieldFieldDate     = big.NewInt(1 << 6)
+	objectWithOptionalFieldFieldUuid     = big.NewInt(1 << 7)
+	objectWithOptionalFieldFieldBase64   = big.NewInt(1 << 8)
+	objectWithOptionalFieldFieldList     = big.NewInt(1 << 9)
+	objectWithOptionalFieldFieldSet      = big.NewInt(1 << 10)
+	objectWithOptionalFieldFieldMap      = big.NewInt(1 << 11)
+	objectWithOptionalFieldFieldBigint   = big.NewInt(1 << 12)
+)
 
 type ObjectWithOptionalField struct {
 	// This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered.
@@ -197,6 +358,9 @@ type ObjectWithOptionalField struct {
 	Set      []string       `json:"set,omitempty" url:"set,omitempty"`
 	Map      map[int]string `json:"map,omitempty" url:"map,omitempty"`
 	Bigint   *string        `json:"bigint,omitempty" url:"bigint,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -296,6 +460,104 @@ func (o *ObjectWithOptionalField) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *ObjectWithOptionalField) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetString(string_ *string) {
+	o.String = string_
+	o.require(objectWithOptionalFieldFieldString)
+}
+
+// SetInteger sets the Integer field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetInteger(integer *int) {
+	o.Integer = integer
+	o.require(objectWithOptionalFieldFieldInteger)
+}
+
+// SetLong sets the Long field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetLong(long *int64) {
+	o.Long = long
+	o.require(objectWithOptionalFieldFieldLong)
+}
+
+// SetDouble sets the Double field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetDouble(double *float64) {
+	o.Double = double
+	o.require(objectWithOptionalFieldFieldDouble)
+}
+
+// SetBool sets the Bool field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetBool(bool_ *bool) {
+	o.Bool = bool_
+	o.require(objectWithOptionalFieldFieldBool)
+}
+
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetDatetime(datetime *time.Time) {
+	o.Datetime = datetime
+	o.require(objectWithOptionalFieldFieldDatetime)
+}
+
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetDate(date *time.Time) {
+	o.Date = date
+	o.require(objectWithOptionalFieldFieldDate)
+}
+
+// SetUuid sets the Uuid field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetUuid(uuid *uuid.UUID) {
+	o.Uuid = uuid
+	o.require(objectWithOptionalFieldFieldUuid)
+}
+
+// SetBase64 sets the Base64 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetBase64(base64 *[]byte) {
+	o.Base64 = base64
+	o.require(objectWithOptionalFieldFieldBase64)
+}
+
+// SetList sets the List field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetList(list []string) {
+	o.List = list
+	o.require(objectWithOptionalFieldFieldList)
+}
+
+// SetSet sets the Set field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetSet(set []string) {
+	o.Set = set
+	o.require(objectWithOptionalFieldFieldSet)
+}
+
+// SetMap sets the Map field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetMap(map_ map[int]string) {
+	o.Map = map_
+	o.require(objectWithOptionalFieldFieldMap)
+}
+
+// SetBigint sets the Bigint field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithOptionalField) SetBigint(bigint *string) {
+	o.Bigint = bigint
+	o.require(objectWithOptionalFieldFieldBigint)
+}
+
 func (o *ObjectWithOptionalField) UnmarshalJSON(data []byte) error {
 	type embed ObjectWithOptionalField
 	var unmarshaler = struct {
@@ -330,7 +592,8 @@ func (o *ObjectWithOptionalField) MarshalJSON() ([]byte, error) {
 		Datetime: internal.NewOptionalDateTime(o.Datetime),
 		Date:     internal.NewOptionalDate(o.Date),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectWithOptionalField) String() string {
@@ -340,8 +603,15 @@ func (o *ObjectWithOptionalField) String() string {
 	return fmt.Sprintf("%#v", o)
 }
 
+var (
+	objectWithRequiredFieldFieldString = big.NewInt(1 << 0)
+)
+
 type ObjectWithRequiredField struct {
 	String string `json:"string" url:"string"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -357,6 +627,20 @@ func (o *ObjectWithRequiredField) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *ObjectWithRequiredField) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *ObjectWithRequiredField) SetString(string_ string) {
+	o.String = string_
+	o.require(objectWithRequiredFieldFieldString)
+}
+
 func (o *ObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	type unmarshaler ObjectWithRequiredField
 	var value unmarshaler
@@ -370,6 +654,17 @@ func (o *ObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	}
 	o.extraProperties = extraProperties
 	return nil
+}
+
+func (o *ObjectWithRequiredField) MarshalJSON() ([]byte, error) {
+	type embed ObjectWithRequiredField
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectWithRequiredField) String() string {

--- a/seed/go-fiber/extends/internal/explicit_fields.go
+++ b/seed/go-fiber/extends/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/extends/internal/explicit_fields_test.go
+++ b/seed/go-fiber/extends/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/extends/types.go
+++ b/seed/go-fiber/extends/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/extends/fern/internal"
+	big "math/big"
 )
 
 type Inlined struct {
@@ -14,8 +15,15 @@ type Inlined struct {
 	Unique string `json:"unique" url:"-"`
 }
 
+var (
+	docsFieldDocs = big.NewInt(1 << 0)
+)
+
 type Docs struct {
 	Docs string `json:"docs" url:"docs"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -29,6 +37,20 @@ func (d *Docs) GetDocs() string {
 
 func (d *Docs) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *Docs) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *Docs) SetDocs(docs string) {
+	d.Docs = docs
+	d.require(docsFieldDocs)
 }
 
 func (d *Docs) UnmarshalJSON(data []byte) error {
@@ -46,6 +68,17 @@ func (d *Docs) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Docs) MarshalJSON() ([]byte, error) {
+	type embed Docs
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Docs) String() string {
 	if value, err := internal.StringifyJSON(d); err == nil {
 		return value
@@ -53,9 +86,17 @@ func (d *Docs) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	exampleTypeFieldDocs = big.NewInt(1 << 0)
+	exampleTypeFieldName = big.NewInt(1 << 1)
+)
+
 type ExampleType struct {
 	Docs string `json:"docs" url:"docs"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -78,6 +119,27 @@ func (e *ExampleType) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExampleType) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExampleType) SetDocs(docs string) {
+	e.Docs = docs
+	e.require(exampleTypeFieldDocs)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *ExampleType) SetName(name string) {
+	e.Name = name
+	e.require(exampleTypeFieldName)
+}
+
 func (e *ExampleType) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExampleType
 	var value unmarshaler
@@ -93,6 +155,17 @@ func (e *ExampleType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExampleType) MarshalJSON() ([]byte, error) {
+	type embed ExampleType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExampleType) String() string {
 	if value, err := internal.StringifyJSON(e); err == nil {
 		return value
@@ -100,9 +173,17 @@ func (e *ExampleType) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	jsonFieldDocs = big.NewInt(1 << 0)
+	jsonFieldRaw  = big.NewInt(1 << 1)
+)
+
 type Json struct {
 	Docs string `json:"docs" url:"docs"`
 	Raw  string `json:"raw" url:"raw"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -125,6 +206,27 @@ func (j *Json) GetExtraProperties() map[string]interface{} {
 	return j.extraProperties
 }
 
+func (j *Json) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (j *Json) SetDocs(docs string) {
+	j.Docs = docs
+	j.require(jsonFieldDocs)
+}
+
+// SetRaw sets the Raw field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (j *Json) SetRaw(raw string) {
+	j.Raw = raw
+	j.require(jsonFieldRaw)
+}
+
 func (j *Json) UnmarshalJSON(data []byte) error {
 	type unmarshaler Json
 	var value unmarshaler
@@ -140,6 +242,17 @@ func (j *Json) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (j *Json) MarshalJSON() ([]byte, error) {
+	type embed Json
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*j),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, j.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (j *Json) String() string {
 	if value, err := internal.StringifyJSON(j); err == nil {
 		return value
@@ -147,10 +260,19 @@ func (j *Json) String() string {
 	return fmt.Sprintf("%#v", j)
 }
 
+var (
+	nestedTypeFieldDocs = big.NewInt(1 << 0)
+	nestedTypeFieldRaw  = big.NewInt(1 << 1)
+	nestedTypeFieldName = big.NewInt(1 << 2)
+)
+
 type NestedType struct {
 	Docs string `json:"docs" url:"docs"`
 	Raw  string `json:"raw" url:"raw"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -180,6 +302,34 @@ func (n *NestedType) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedType) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedType) SetDocs(docs string) {
+	n.Docs = docs
+	n.require(nestedTypeFieldDocs)
+}
+
+// SetRaw sets the Raw field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedType) SetRaw(raw string) {
+	n.Raw = raw
+	n.require(nestedTypeFieldRaw)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedType) SetName(name string) {
+	n.Name = name
+	n.require(nestedTypeFieldName)
+}
+
 func (n *NestedType) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedType
 	var value unmarshaler
@@ -193,6 +343,17 @@ func (n *NestedType) UnmarshalJSON(data []byte) error {
 	}
 	n.extraProperties = extraProperties
 	return nil
+}
+
+func (n *NestedType) MarshalJSON() ([]byte, error) {
+	type embed NestedType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (n *NestedType) String() string {

--- a/seed/go-fiber/extra-properties/internal/explicit_fields.go
+++ b/seed/go-fiber/extra-properties/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/extra-properties/internal/explicit_fields_test.go
+++ b/seed/go-fiber/extra-properties/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/file-download/internal/explicit_fields.go
+++ b/seed/go-fiber/file-download/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/file-download/internal/explicit_fields_test.go
+++ b/seed/go-fiber/file-download/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/file-upload/internal/explicit_fields.go
+++ b/seed/go-fiber/file-upload/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/file-upload/internal/explicit_fields_test.go
+++ b/seed/go-fiber/file-upload/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/folders/internal/explicit_fields.go
+++ b/seed/go-fiber/folders/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/folders/internal/explicit_fields_test.go
+++ b/seed/go-fiber/folders/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/go-bytes-request/internal/explicit_fields.go
+++ b/seed/go-fiber/go-bytes-request/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/go-bytes-request/internal/explicit_fields_test.go
+++ b/seed/go-fiber/go-bytes-request/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/go-content-type/imdb.go
+++ b/seed/go-fiber/go-content-type/imdb.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/go-content-type/fern/internal"
+	big "math/big"
+)
+
+var (
+	createMovieRequestFieldTitle  = big.NewInt(1 << 0)
+	createMovieRequestFieldRating = big.NewInt(1 << 1)
 )
 
 type CreateMovieRequest struct {
 	Title  string  `json:"title" url:"title"`
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateMovieRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateMovieRequest) SetTitle(title string) {
+	c.Title = title
+	c.require(createMovieRequestFieldTitle)
+}
+
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateMovieRequest) SetRating(rating float64) {
+	c.Rating = rating
+	c.require(createMovieRequestFieldRating)
+}
+
 func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateMovieRequest
 	var value unmarshaler
@@ -46,6 +76,17 @@ func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	}
 	c.extraProperties = extraProperties
 	return nil
+}
+
+func (c *CreateMovieRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateMovieRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (c *CreateMovieRequest) String() string {

--- a/seed/go-fiber/go-content-type/internal/explicit_fields.go
+++ b/seed/go-fiber/go-content-type/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/go-content-type/internal/explicit_fields_test.go
+++ b/seed/go-fiber/go-content-type/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/http-head/internal/explicit_fields.go
+++ b/seed/go-fiber/http-head/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/http-head/internal/explicit_fields_test.go
+++ b/seed/go-fiber/http-head/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/http-head/user.go
+++ b/seed/go-fiber/http-head/user.go
@@ -6,15 +6,24 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/http-head/fern/internal"
+	big "math/big"
 )
 
 type ListUsersRequest struct {
 	Limit int `query:"limit"`
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags" url:"tags"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -37,6 +46,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -50,6 +80,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/idempotency-headers/internal/explicit_fields.go
+++ b/seed/go-fiber/idempotency-headers/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/idempotency-headers/internal/explicit_fields_test.go
+++ b/seed/go-fiber/idempotency-headers/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/imdb/imdb.go
+++ b/seed/go-fiber/imdb/imdb.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/imdb/fern/internal"
+	big "math/big"
+)
+
+var (
+	createMovieRequestFieldTitle  = big.NewInt(1 << 0)
+	createMovieRequestFieldRating = big.NewInt(1 << 1)
 )
 
 type CreateMovieRequest struct {
 	Title  string  `json:"title" url:"title"`
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateMovieRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateMovieRequest) SetTitle(title string) {
+	c.Title = title
+	c.require(createMovieRequestFieldTitle)
+}
+
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateMovieRequest) SetRating(rating float64) {
+	c.Rating = rating
+	c.require(createMovieRequestFieldRating)
+}
+
 func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateMovieRequest
 	var value unmarshaler
@@ -48,6 +78,17 @@ func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateMovieRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateMovieRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateMovieRequest) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -55,11 +96,20 @@ func (c *CreateMovieRequest) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	movieFieldId     = big.NewInt(1 << 0)
+	movieFieldTitle  = big.NewInt(1 << 1)
+	movieFieldRating = big.NewInt(1 << 2)
+)
+
 type Movie struct {
 	Id    MovieId `json:"id" url:"id"`
 	Title string  `json:"title" url:"title"`
 	// The rating scale is one to five stars
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -89,6 +139,34 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type unmarshaler Movie
 	var value unmarshaler
@@ -102,6 +180,17 @@ func (m *Movie) UnmarshalJSON(data []byte) error {
 	}
 	m.extraProperties = extraProperties
 	return nil
+}
+
+func (m *Movie) MarshalJSON() ([]byte, error) {
+	type embed Movie
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {

--- a/seed/go-fiber/imdb/internal/explicit_fields.go
+++ b/seed/go-fiber/imdb/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/imdb/internal/explicit_fields_test.go
+++ b/seed/go-fiber/imdb/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/inferred-auth-explicit/auth.go
+++ b/seed/go-fiber/inferred-auth-explicit/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/inferred-auth-explicit/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -96,10 +97,19 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -129,6 +139,34 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -142,6 +180,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/inferred-auth-explicit/internal/explicit_fields.go
+++ b/seed/go-fiber/inferred-auth-explicit/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/inferred-auth-explicit/internal/explicit_fields_test.go
+++ b/seed/go-fiber/inferred-auth-explicit/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/inferred-auth-implicit-no-expiry/auth.go
+++ b/seed/go-fiber/inferred-auth-implicit-no-expiry/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/inferred-auth-implicit-no-expiry/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -96,9 +97,17 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 1)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -121,6 +130,27 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -134,6 +164,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/inferred-auth-implicit-no-expiry/internal/explicit_fields.go
+++ b/seed/go-fiber/inferred-auth-implicit-no-expiry/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/inferred-auth-implicit-no-expiry/internal/explicit_fields_test.go
+++ b/seed/go-fiber/inferred-auth-implicit-no-expiry/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/inferred-auth-implicit/internal/explicit_fields.go
+++ b/seed/go-fiber/inferred-auth-implicit/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/inferred-auth-implicit/internal/explicit_fields_test.go
+++ b/seed/go-fiber/inferred-auth-implicit/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/license/internal/explicit_fields.go
+++ b/seed/go-fiber/license/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/license/internal/explicit_fields_test.go
+++ b/seed/go-fiber/license/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/license/types.go
+++ b/seed/go-fiber/license/types.go
@@ -6,11 +6,19 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/license/fern/internal"
+	big "math/big"
 )
 
 // A simple type with just a name.
+var (
+	typeFieldName = big.NewInt(1 << 0)
+)
+
 type Type struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -26,6 +34,20 @@ func (t *Type) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Type) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetName(name string) {
+	t.Name = name
+	t.require(typeFieldName)
+}
+
 func (t *Type) UnmarshalJSON(data []byte) error {
 	type unmarshaler Type
 	var value unmarshaler
@@ -39,6 +61,17 @@ func (t *Type) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *Type) MarshalJSON() ([]byte, error) {
+	type embed Type
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Type) String() string {

--- a/seed/go-fiber/literals-unions/internal/explicit_fields.go
+++ b/seed/go-fiber/literals-unions/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/literals-unions/internal/explicit_fields_test.go
+++ b/seed/go-fiber/literals-unions/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/mixed-case/internal/explicit_fields.go
+++ b/seed/go-fiber/mixed-case/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/mixed-case/internal/explicit_fields_test.go
+++ b/seed/go-fiber/mixed-case/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/mixed-case/service.go
+++ b/seed/go-fiber/mixed-case/service.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/mixed-case/fern/internal"
+	big "math/big"
 	time "time"
 )
 
@@ -14,9 +15,17 @@ type ListResourcesRequest struct {
 	BeforeDate time.Time `query:"beforeDate"`
 }
 
+var (
+	nestedUserFieldName       = big.NewInt(1 << 0)
+	nestedUserFieldNestedUser = big.NewInt(1 << 1)
+)
+
 type NestedUser struct {
 	Name       string `json:"Name" url:"Name"`
 	NestedUser *User  `json:"NestedUser" url:"NestedUser"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -39,6 +48,27 @@ func (n *NestedUser) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedUser) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedUser) SetName(name string) {
+	n.Name = name
+	n.require(nestedUserFieldName)
+}
+
+// SetNestedUser sets the NestedUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedUser) SetNestedUser(nestedUser *User) {
+	n.NestedUser = nestedUser
+	n.require(nestedUserFieldNestedUser)
+}
+
 func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedUser
 	var value unmarshaler
@@ -54,6 +84,17 @@ func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedUser) MarshalJSON() ([]byte, error) {
+	type embed NestedUser
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedUser) String() string {
 	if value, err := internal.StringifyJSON(n); err == nil {
 		return value
@@ -61,8 +102,15 @@ func (n *NestedUser) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	organizationFieldName = big.NewInt(1 << 0)
+)
+
 type Organization struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -78,6 +126,20 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -91,6 +153,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	}
 	o.extraProperties = extraProperties
 	return nil
+}
+
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *Organization) String() string {
@@ -249,10 +322,19 @@ func (r ResourceStatus) Ptr() *ResourceStatus {
 	return &r
 }
 
+var (
+	userFieldUserName        = big.NewInt(1 << 0)
+	userFieldMetadataTags    = big.NewInt(1 << 1)
+	userFieldExtraProperties = big.NewInt(1 << 2)
+)
+
 type User struct {
 	UserName        string            `json:"userName" url:"userName"`
 	MetadataTags    []string          `json:"metadata_tags" url:"metadata_tags"`
 	ExtraProperties map[string]string `json:"EXTRA_PROPERTIES" url:"EXTRA_PROPERTIES"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -282,6 +364,34 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetUserName sets the UserName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetUserName(userName string) {
+	u.UserName = userName
+	u.require(userFieldUserName)
+}
+
+// SetMetadataTags sets the MetadataTags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetMetadataTags(metadataTags []string) {
+	u.MetadataTags = metadataTags
+	u.require(userFieldMetadataTags)
+}
+
+// SetExtraProperties sets the ExtraProperties field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetExtraProperties(extraProperties map[string]string) {
+	u.ExtraProperties = extraProperties
+	u.require(userFieldExtraProperties)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -295,6 +405,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/mixed-file-directory/internal/explicit_fields.go
+++ b/seed/go-fiber/mixed-file-directory/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/mixed-file-directory/internal/explicit_fields_test.go
+++ b/seed/go-fiber/mixed-file-directory/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/mixed-file-directory/organization.go
+++ b/seed/go-fiber/mixed-file-directory/organization.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/mixed-file-directory/fern/internal"
+	big "math/big"
+)
+
+var (
+	createOrganizationRequestFieldName = big.NewInt(1 << 0)
 )
 
 type CreateOrganizationRequest struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -23,6 +31,20 @@ func (c *CreateOrganizationRequest) GetName() string {
 
 func (c *CreateOrganizationRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CreateOrganizationRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CreateOrganizationRequest) SetName(name string) {
+	c.Name = name
+	c.require(createOrganizationRequestFieldName)
 }
 
 func (c *CreateOrganizationRequest) UnmarshalJSON(data []byte) error {
@@ -40,6 +62,17 @@ func (c *CreateOrganizationRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateOrganizationRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateOrganizationRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateOrganizationRequest) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -47,10 +80,19 @@ func (c *CreateOrganizationRequest) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	organizationFieldId    = big.NewInt(1 << 0)
+	organizationFieldName  = big.NewInt(1 << 1)
+	organizationFieldUsers = big.NewInt(1 << 2)
+)
+
 type Organization struct {
 	Id    Id      `json:"id" url:"id"`
 	Name  string  `json:"name" url:"name"`
 	Users []*User `json:"users" url:"users"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -80,6 +122,34 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *Organization) SetId(id Id) {
+	o.Id = id
+	o.require(organizationFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (o *Organization) SetUsers(users []*User) {
+	o.Users = users
+	o.require(organizationFieldUsers)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -93,6 +163,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	}
 	o.extraProperties = extraProperties
 	return nil
+}
+
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *Organization) String() string {

--- a/seed/go-fiber/mixed-file-directory/user.go
+++ b/seed/go-fiber/mixed-file-directory/user.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/mixed-file-directory/fern/internal"
+	big "math/big"
 )
 
 type ListUsersRequest struct {
@@ -13,10 +14,19 @@ type ListUsersRequest struct {
 	Limit *int `query:"limit"`
 }
 
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
+	userFieldAge  = big.NewInt(1 << 2)
+)
+
 type User struct {
 	Id   Id     `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
 	Age  int    `json:"age" url:"age"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -46,6 +56,34 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id Id) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetAge(age int) {
+	u.Age = age
+	u.require(userFieldAge)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -59,6 +97,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/multi-line-docs/internal/explicit_fields.go
+++ b/seed/go-fiber/multi-line-docs/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/multi-line-docs/internal/explicit_fields_test.go
+++ b/seed/go-fiber/multi-line-docs/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/multi-line-docs/user.go
+++ b/seed/go-fiber/multi-line-docs/user.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/multi-line-docs/fern/internal"
+	big "math/big"
 )
 
 type CreateUserRequest struct {
@@ -20,6 +21,12 @@ type CreateUserRequest struct {
 // A user object. This type is used throughout the following APIs:
 //   - createUser
 //   - getUser
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
+	userFieldAge  = big.NewInt(1 << 2)
+)
+
 type User struct {
 	Id string `json:"id" url:"id"`
 	// The user's name. This name is unique to each user. A few examples are included below:
@@ -29,6 +36,9 @@ type User struct {
 	Name string `json:"name" url:"name"`
 	// The user's age.
 	Age *int `json:"age,omitempty" url:"age,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -58,6 +68,34 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id string) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetAge(age *int) {
+	u.Age = age
+	u.require(userFieldAge)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -71,6 +109,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/multi-url-environment-no-default/internal/explicit_fields.go
+++ b/seed/go-fiber/multi-url-environment-no-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/multi-url-environment-no-default/internal/explicit_fields_test.go
+++ b/seed/go-fiber/multi-url-environment-no-default/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/multi-url-environment/internal/explicit_fields.go
+++ b/seed/go-fiber/multi-url-environment/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/multi-url-environment/internal/explicit_fields_test.go
+++ b/seed/go-fiber/multi-url-environment/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/multiple-request-bodies/internal/explicit_fields.go
+++ b/seed/go-fiber/multiple-request-bodies/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/multiple-request-bodies/internal/explicit_fields_test.go
+++ b/seed/go-fiber/multiple-request-bodies/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/multiple-request-bodies/types.go
+++ b/seed/go-fiber/multiple-request-bodies/types.go
@@ -6,6 +6,14 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/multiple-request-bodies/fern/internal"
+	big "math/big"
+)
+
+var (
+	documentMetadataFieldAuthor = big.NewInt(1 << 0)
+	documentMetadataFieldId     = big.NewInt(1 << 1)
+	documentMetadataFieldTags   = big.NewInt(1 << 2)
+	documentMetadataFieldTitle  = big.NewInt(1 << 3)
 )
 
 type DocumentMetadata struct {
@@ -13,6 +21,9 @@ type DocumentMetadata struct {
 	Id     *int          `json:"id,omitempty" url:"id,omitempty"`
 	Tags   []interface{} `json:"tags,omitempty" url:"tags,omitempty"`
 	Title  *string       `json:"title,omitempty" url:"title,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -49,6 +60,41 @@ func (d *DocumentMetadata) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *DocumentMetadata) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetAuthor sets the Author field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DocumentMetadata) SetAuthor(author *string) {
+	d.Author = author
+	d.require(documentMetadataFieldAuthor)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DocumentMetadata) SetId(id *int) {
+	d.Id = id
+	d.require(documentMetadataFieldId)
+}
+
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DocumentMetadata) SetTags(tags []interface{}) {
+	d.Tags = tags
+	d.require(documentMetadataFieldTags)
+}
+
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DocumentMetadata) SetTitle(title *string) {
+	d.Title = title
+	d.require(documentMetadataFieldTitle)
+}
+
 func (d *DocumentMetadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler DocumentMetadata
 	var value unmarshaler
@@ -64,6 +110,17 @@ func (d *DocumentMetadata) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DocumentMetadata) MarshalJSON() ([]byte, error) {
+	type embed DocumentMetadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DocumentMetadata) String() string {
 	if value, err := internal.StringifyJSON(d); err == nil {
 		return value
@@ -71,9 +128,17 @@ func (d *DocumentMetadata) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	documentUploadResultFieldFileId = big.NewInt(1 << 0)
+	documentUploadResultFieldStatus = big.NewInt(1 << 1)
+)
+
 type DocumentUploadResult struct {
 	FileId *string `json:"fileId,omitempty" url:"fileId,omitempty"`
 	Status *string `json:"status,omitempty" url:"status,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -96,6 +161,27 @@ func (d *DocumentUploadResult) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *DocumentUploadResult) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetFileId sets the FileId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DocumentUploadResult) SetFileId(fileId *string) {
+	d.FileId = fileId
+	d.require(documentUploadResultFieldFileId)
+}
+
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DocumentUploadResult) SetStatus(status *string) {
+	d.Status = status
+	d.require(documentUploadResultFieldStatus)
+}
+
 func (d *DocumentUploadResult) UnmarshalJSON(data []byte) error {
 	type unmarshaler DocumentUploadResult
 	var value unmarshaler
@@ -109,6 +195,17 @@ func (d *DocumentUploadResult) UnmarshalJSON(data []byte) error {
 	}
 	d.extraProperties = extraProperties
 	return nil
+}
+
+func (d *DocumentUploadResult) MarshalJSON() ([]byte, error) {
+	type embed DocumentUploadResult
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (d *DocumentUploadResult) String() string {

--- a/seed/go-fiber/no-environment/internal/explicit_fields.go
+++ b/seed/go-fiber/no-environment/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/no-environment/internal/explicit_fields_test.go
+++ b/seed/go-fiber/no-environment/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/nullable-optional/internal/explicit_fields.go
+++ b/seed/go-fiber/nullable-optional/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/nullable-optional/internal/explicit_fields_test.go
+++ b/seed/go-fiber/nullable-optional/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/nullable/internal/explicit_fields.go
+++ b/seed/go-fiber/nullable/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/nullable/internal/explicit_fields_test.go
+++ b/seed/go-fiber/nullable/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/oauth-client-credentials-custom/auth.go
+++ b/seed/go-fiber/oauth-client-credentials-custom/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-custom/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -96,10 +97,19 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -129,6 +139,34 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -142,6 +180,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/oauth-client-credentials-custom/internal/explicit_fields.go
+++ b/seed/go-fiber/oauth-client-credentials-custom/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/oauth-client-credentials-custom/internal/explicit_fields_test.go
+++ b/seed/go-fiber/oauth-client-credentials-custom/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/oauth-client-credentials-default/internal/explicit_fields.go
+++ b/seed/go-fiber/oauth-client-credentials-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/oauth-client-credentials-default/internal/explicit_fields_test.go
+++ b/seed/go-fiber/oauth-client-credentials-default/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/oauth-client-credentials-environment-variables/auth.go
+++ b/seed/go-fiber/oauth-client-credentials-environment-variables/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-environment-variables/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -94,10 +95,19 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -127,6 +137,34 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -140,6 +178,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/oauth-client-credentials-environment-variables/internal/explicit_fields.go
+++ b/seed/go-fiber/oauth-client-credentials-environment-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/oauth-client-credentials-environment-variables/internal/explicit_fields_test.go
+++ b/seed/go-fiber/oauth-client-credentials-environment-variables/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/oauth-client-credentials-nested-root/auth/types.go
+++ b/seed/go-fiber/oauth-client-credentials-nested-root/auth/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-nested-root/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -51,10 +52,19 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -84,6 +94,34 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -97,6 +135,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/oauth-client-credentials-nested-root/internal/explicit_fields.go
+++ b/seed/go-fiber/oauth-client-credentials-nested-root/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/oauth-client-credentials-nested-root/internal/explicit_fields_test.go
+++ b/seed/go-fiber/oauth-client-credentials-nested-root/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/oauth-client-credentials-with-variables/auth.go
+++ b/seed/go-fiber/oauth-client-credentials-with-variables/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-with-variables/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -94,10 +95,19 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -127,6 +137,34 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -140,6 +178,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/oauth-client-credentials-with-variables/internal/explicit_fields.go
+++ b/seed/go-fiber/oauth-client-credentials-with-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/oauth-client-credentials-with-variables/internal/explicit_fields_test.go
+++ b/seed/go-fiber/oauth-client-credentials-with-variables/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/oauth-client-credentials/auth.go
+++ b/seed/go-fiber/oauth-client-credentials/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -94,10 +95,19 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -127,6 +137,34 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -140,6 +178,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/oauth-client-credentials/internal/explicit_fields.go
+++ b/seed/go-fiber/oauth-client-credentials/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/oauth-client-credentials/internal/explicit_fields_test.go
+++ b/seed/go-fiber/oauth-client-credentials/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/object/internal/explicit_fields.go
+++ b/seed/go-fiber/object/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/object/internal/explicit_fields_test.go
+++ b/seed/go-fiber/object/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/object/types.go
+++ b/seed/go-fiber/object/types.go
@@ -7,12 +7,21 @@ import (
 	fmt "fmt"
 	uuid "github.com/google/uuid"
 	internal "github.com/object/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	nameFieldId    = big.NewInt(1 << 0)
+	nameFieldValue = big.NewInt(1 << 1)
 )
 
 type Name struct {
 	Id    string `json:"id" url:"id"`
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -35,6 +44,27 @@ func (n *Name) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Name) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *Name) SetId(id string) {
+	n.Id = id
+	n.require(nameFieldId)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *Name) SetValue(value string) {
+	n.Value = value
+	n.require(nameFieldValue)
+}
+
 func (n *Name) UnmarshalJSON(data []byte) error {
 	type unmarshaler Name
 	var value unmarshaler
@@ -50,6 +80,17 @@ func (n *Name) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Name) MarshalJSON() ([]byte, error) {
+	type embed Name
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Name) String() string {
 	if value, err := internal.StringifyJSON(n); err == nil {
 		return value
@@ -58,6 +99,33 @@ func (n *Name) String() string {
 }
 
 // Exercises all of the built-in types.
+var (
+	typeFieldOne         = big.NewInt(1 << 0)
+	typeFieldTwo         = big.NewInt(1 << 1)
+	typeFieldThree       = big.NewInt(1 << 2)
+	typeFieldFour        = big.NewInt(1 << 3)
+	typeFieldFive        = big.NewInt(1 << 4)
+	typeFieldSix         = big.NewInt(1 << 5)
+	typeFieldSeven       = big.NewInt(1 << 6)
+	typeFieldEight       = big.NewInt(1 << 7)
+	typeFieldNine        = big.NewInt(1 << 8)
+	typeFieldTen         = big.NewInt(1 << 9)
+	typeFieldEleven      = big.NewInt(1 << 10)
+	typeFieldTwelve      = big.NewInt(1 << 11)
+	typeFieldThirteen    = big.NewInt(1 << 12)
+	typeFieldFourteen    = big.NewInt(1 << 13)
+	typeFieldFifteen     = big.NewInt(1 << 14)
+	typeFieldSixteen     = big.NewInt(1 << 15)
+	typeFieldSeventeen   = big.NewInt(1 << 16)
+	typeFieldNineteen    = big.NewInt(1 << 17)
+	typeFieldTwenty      = big.NewInt(1 << 18)
+	typeFieldTwentyone   = big.NewInt(1 << 19)
+	typeFieldTwentytwo   = big.NewInt(1 << 20)
+	typeFieldTwentythree = big.NewInt(1 << 21)
+	typeFieldTwentyfour  = big.NewInt(1 << 22)
+	typeFieldTwentyfive  = big.NewInt(1 << 23)
+)
+
 type Type struct {
 	One         int              `json:"one" url:"one"`
 	Two         float64          `json:"two" url:"two"`
@@ -83,7 +151,10 @@ type Type struct {
 	Twentythree string           `json:"twentythree" url:"twentythree"`
 	Twentyfour  *time.Time       `json:"twentyfour,omitempty" url:"twentyfour,omitempty"`
 	Twentyfive  *time.Time       `json:"twentyfive,omitempty" url:"twentyfive,omitempty" format:"date"`
-	eighteen    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	eighteen       string
 
 	extraProperties map[string]interface{}
 }
@@ -264,6 +335,181 @@ func (t *Type) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Type) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetOne sets the One field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetOne(one int) {
+	t.One = one
+	t.require(typeFieldOne)
+}
+
+// SetTwo sets the Two field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwo(two float64) {
+	t.Two = two
+	t.require(typeFieldTwo)
+}
+
+// SetThree sets the Three field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetThree(three string) {
+	t.Three = three
+	t.require(typeFieldThree)
+}
+
+// SetFour sets the Four field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetFour(four bool) {
+	t.Four = four
+	t.require(typeFieldFour)
+}
+
+// SetFive sets the Five field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetFive(five int64) {
+	t.Five = five
+	t.require(typeFieldFive)
+}
+
+// SetSix sets the Six field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetSix(six time.Time) {
+	t.Six = six
+	t.require(typeFieldSix)
+}
+
+// SetSeven sets the Seven field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetSeven(seven time.Time) {
+	t.Seven = seven
+	t.require(typeFieldSeven)
+}
+
+// SetEight sets the Eight field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetEight(eight uuid.UUID) {
+	t.Eight = eight
+	t.require(typeFieldEight)
+}
+
+// SetNine sets the Nine field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetNine(nine []byte) {
+	t.Nine = nine
+	t.require(typeFieldNine)
+}
+
+// SetTen sets the Ten field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTen(ten []int) {
+	t.Ten = ten
+	t.require(typeFieldTen)
+}
+
+// SetEleven sets the Eleven field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetEleven(eleven []float64) {
+	t.Eleven = eleven
+	t.require(typeFieldEleven)
+}
+
+// SetTwelve sets the Twelve field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwelve(twelve map[string]bool) {
+	t.Twelve = twelve
+	t.require(typeFieldTwelve)
+}
+
+// SetThirteen sets the Thirteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetThirteen(thirteen *int64) {
+	t.Thirteen = thirteen
+	t.require(typeFieldThirteen)
+}
+
+// SetFourteen sets the Fourteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetFourteen(fourteen interface{}) {
+	t.Fourteen = fourteen
+	t.require(typeFieldFourteen)
+}
+
+// SetFifteen sets the Fifteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetFifteen(fifteen [][]int) {
+	t.Fifteen = fifteen
+	t.require(typeFieldFifteen)
+}
+
+// SetSixteen sets the Sixteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetSixteen(sixteen []map[string]int) {
+	t.Sixteen = sixteen
+	t.require(typeFieldSixteen)
+}
+
+// SetSeventeen sets the Seventeen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetSeventeen(seventeen []*uuid.UUID) {
+	t.Seventeen = seventeen
+	t.require(typeFieldSeventeen)
+}
+
+// SetNineteen sets the Nineteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetNineteen(nineteen *Name) {
+	t.Nineteen = nineteen
+	t.require(typeFieldNineteen)
+}
+
+// SetTwenty sets the Twenty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwenty(twenty int) {
+	t.Twenty = twenty
+	t.require(typeFieldTwenty)
+}
+
+// SetTwentyone sets the Twentyone field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwentyone(twentyone int64) {
+	t.Twentyone = twentyone
+	t.require(typeFieldTwentyone)
+}
+
+// SetTwentytwo sets the Twentytwo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwentytwo(twentytwo float64) {
+	t.Twentytwo = twentytwo
+	t.require(typeFieldTwentytwo)
+}
+
+// SetTwentythree sets the Twentythree field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwentythree(twentythree string) {
+	t.Twentythree = twentythree
+	t.require(typeFieldTwentythree)
+}
+
+// SetTwentyfour sets the Twentyfour field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwentyfour(twentyfour *time.Time) {
+	t.Twentyfour = twentyfour
+	t.require(typeFieldTwentyfour)
+}
+
+// SetTwentyfive sets the Twentyfive field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *Type) SetTwentyfive(twentyfive *time.Time) {
+	t.Twentyfive = twentyfive
+	t.require(typeFieldTwentyfive)
+}
+
 func (t *Type) UnmarshalJSON(data []byte) error {
 	type embed Type
 	var unmarshaler = struct {
@@ -313,7 +559,8 @@ func (t *Type) MarshalJSON() ([]byte, error) {
 		Twentyfive: internal.NewOptionalDate(t.Twentyfive),
 		Eighteen:   "eighteen",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Type) String() string {

--- a/seed/go-fiber/objects-with-imports/file.go
+++ b/seed/go-fiber/objects-with-imports/file.go
@@ -6,12 +6,22 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/objects-with-imports/fern/internal"
+	big "math/big"
+)
+
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+	fileFieldInfo     = big.NewInt(1 << 2)
 )
 
 type File struct {
 	Name     string   `json:"name" url:"name"`
 	Contents string   `json:"contents" url:"contents"`
 	Info     FileInfo `json:"info" url:"info"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -41,6 +51,34 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
+// SetInfo sets the Info field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *File) SetInfo(info FileInfo) {
+	f.Info = info
+	f.require(fileFieldInfo)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -54,6 +92,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	}
 	f.extraProperties = extraProperties
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {

--- a/seed/go-fiber/objects-with-imports/internal/explicit_fields.go
+++ b/seed/go-fiber/objects-with-imports/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/objects-with-imports/internal/explicit_fields_test.go
+++ b/seed/go-fiber/objects-with-imports/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/optional/internal/explicit_fields.go
+++ b/seed/go-fiber/optional/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/optional/internal/explicit_fields_test.go
+++ b/seed/go-fiber/optional/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/package-yml/internal/explicit_fields.go
+++ b/seed/go-fiber/package-yml/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/package-yml/internal/explicit_fields_test.go
+++ b/seed/go-fiber/package-yml/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/package-yml/types.go
+++ b/seed/go-fiber/package-yml/types.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/package-yml/fern/internal"
+	big "math/big"
+)
+
+var (
+	echoRequestFieldName = big.NewInt(1 << 0)
+	echoRequestFieldSize = big.NewInt(1 << 1)
 )
 
 type EchoRequest struct {
 	Name string `json:"name" url:"name"`
 	Size int    `json:"size" url:"size"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (e *EchoRequest) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *EchoRequest) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *EchoRequest) SetName(name string) {
+	e.Name = name
+	e.require(echoRequestFieldName)
+}
+
+// SetSize sets the Size field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (e *EchoRequest) SetSize(size int) {
+	e.Size = size
+	e.require(echoRequestFieldSize)
+}
+
 func (e *EchoRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler EchoRequest
 	var value unmarshaler
@@ -46,6 +76,17 @@ func (e *EchoRequest) UnmarshalJSON(data []byte) error {
 	}
 	e.extraProperties = extraProperties
 	return nil
+}
+
+func (e *EchoRequest) MarshalJSON() ([]byte, error) {
+	type embed EchoRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *EchoRequest) String() string {

--- a/seed/go-fiber/pagination-custom/internal/explicit_fields.go
+++ b/seed/go-fiber/pagination-custom/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/pagination-custom/internal/explicit_fields_test.go
+++ b/seed/go-fiber/pagination-custom/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/pagination/complex.go
+++ b/seed/go-fiber/pagination/complex.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/pagination/fern/internal"
+	big "math/big"
+)
+
+var (
+	conversationFieldFoo = big.NewInt(1 << 0)
 )
 
 type Conversation struct {
 	Foo string `json:"foo" url:"foo"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -23,6 +31,20 @@ func (c *Conversation) GetFoo() string {
 
 func (c *Conversation) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *Conversation) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Conversation) SetFoo(foo string) {
+	c.Foo = foo
+	c.require(conversationFieldFoo)
 }
 
 func (c *Conversation) UnmarshalJSON(data []byte) error {
@@ -40,6 +62,17 @@ func (c *Conversation) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Conversation) MarshalJSON() ([]byte, error) {
+	type embed Conversation
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Conversation) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -47,12 +80,22 @@ func (c *Conversation) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	cursorPagesFieldNext       = big.NewInt(1 << 0)
+	cursorPagesFieldPage       = big.NewInt(1 << 1)
+	cursorPagesFieldPerPage    = big.NewInt(1 << 2)
+	cursorPagesFieldTotalPages = big.NewInt(1 << 3)
+)
+
 type CursorPages struct {
 	Next       *StartingAfterPaging `json:"next,omitempty" url:"next,omitempty"`
 	Page       *int                 `json:"page,omitempty" url:"page,omitempty"`
 	PerPage    *int                 `json:"per_page,omitempty" url:"per_page,omitempty"`
 	TotalPages *int                 `json:"total_pages,omitempty" url:"total_pages,omitempty"`
-	type_      string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 }
@@ -93,6 +136,41 @@ func (c *CursorPages) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CursorPages) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CursorPages) SetNext(next *StartingAfterPaging) {
+	c.Next = next
+	c.require(cursorPagesFieldNext)
+}
+
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CursorPages) SetPage(page *int) {
+	c.Page = page
+	c.require(cursorPagesFieldPage)
+}
+
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CursorPages) SetPerPage(perPage *int) {
+	c.PerPage = perPage
+	c.require(cursorPagesFieldPerPage)
+}
+
+// SetTotalPages sets the TotalPages field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CursorPages) SetTotalPages(totalPages *int) {
+	c.TotalPages = totalPages
+	c.require(cursorPagesFieldTotalPages)
+}
+
 func (c *CursorPages) UnmarshalJSON(data []byte) error {
 	type embed CursorPages
 	var unmarshaler = struct {
@@ -126,7 +204,8 @@ func (c *CursorPages) MarshalJSON() ([]byte, error) {
 		embed: embed(*c),
 		Type:  "pages",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (c *CursorPages) String() string {
@@ -136,9 +215,17 @@ func (c *CursorPages) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	multipleFilterSearchRequestFieldOperator = big.NewInt(1 << 0)
+	multipleFilterSearchRequestFieldValue    = big.NewInt(1 << 1)
+)
+
 type MultipleFilterSearchRequest struct {
 	Operator *MultipleFilterSearchRequestOperator `json:"operator,omitempty" url:"operator,omitempty"`
 	Value    *MultipleFilterSearchRequestValue    `json:"value,omitempty" url:"value,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -161,6 +248,27 @@ func (m *MultipleFilterSearchRequest) GetExtraProperties() map[string]interface{
 	return m.extraProperties
 }
 
+func (m *MultipleFilterSearchRequest) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetOperator sets the Operator field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *MultipleFilterSearchRequest) SetOperator(operator *MultipleFilterSearchRequestOperator) {
+	m.Operator = operator
+	m.require(multipleFilterSearchRequestFieldOperator)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *MultipleFilterSearchRequest) SetValue(value *MultipleFilterSearchRequestValue) {
+	m.Value = value
+	m.require(multipleFilterSearchRequestFieldValue)
+}
+
 func (m *MultipleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler MultipleFilterSearchRequest
 	var value unmarshaler
@@ -174,6 +282,17 @@ func (m *MultipleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	}
 	m.extraProperties = extraProperties
 	return nil
+}
+
+func (m *MultipleFilterSearchRequest) MarshalJSON() ([]byte, error) {
+	type embed MultipleFilterSearchRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *MultipleFilterSearchRequest) String() string {
@@ -267,11 +386,20 @@ func (m *MultipleFilterSearchRequestValue) Accept(visitor MultipleFilterSearchRe
 	return fmt.Errorf("type %T does not include a non-empty union type", m)
 }
 
+var (
+	paginatedConversationResponseFieldConversations = big.NewInt(1 << 0)
+	paginatedConversationResponseFieldPages         = big.NewInt(1 << 1)
+	paginatedConversationResponseFieldTotalCount    = big.NewInt(1 << 2)
+)
+
 type PaginatedConversationResponse struct {
 	Conversations []*Conversation `json:"conversations" url:"conversations"`
 	Pages         *CursorPages    `json:"pages,omitempty" url:"pages,omitempty"`
 	TotalCount    int             `json:"total_count" url:"total_count"`
-	type_         string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 }
@@ -303,6 +431,34 @@ func (p *PaginatedConversationResponse) Type() string {
 
 func (p *PaginatedConversationResponse) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PaginatedConversationResponse) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetConversations sets the Conversations field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedConversationResponse) SetConversations(conversations []*Conversation) {
+	p.Conversations = conversations
+	p.require(paginatedConversationResponseFieldConversations)
+}
+
+// SetPages sets the Pages field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedConversationResponse) SetPages(pages *CursorPages) {
+	p.Pages = pages
+	p.require(paginatedConversationResponseFieldPages)
+}
+
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PaginatedConversationResponse) SetTotalCount(totalCount int) {
+	p.TotalCount = totalCount
+	p.require(paginatedConversationResponseFieldTotalCount)
 }
 
 func (p *PaginatedConversationResponse) UnmarshalJSON(data []byte) error {
@@ -338,7 +494,8 @@ func (p *PaginatedConversationResponse) MarshalJSON() ([]byte, error) {
 		embed: embed(*p),
 		Type:  "conversation.list",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *PaginatedConversationResponse) String() string {
@@ -348,9 +505,17 @@ func (p *PaginatedConversationResponse) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	searchRequestFieldPagination = big.NewInt(1 << 0)
+	searchRequestFieldQuery      = big.NewInt(1 << 1)
+)
+
 type SearchRequest struct {
 	Pagination *StartingAfterPaging `json:"pagination,omitempty" url:"pagination,omitempty"`
 	Query      *SearchRequestQuery  `json:"query" url:"query"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -373,6 +538,27 @@ func (s *SearchRequest) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SearchRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetPagination sets the Pagination field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SearchRequest) SetPagination(pagination *StartingAfterPaging) {
+	s.Pagination = pagination
+	s.require(searchRequestFieldPagination)
+}
+
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SearchRequest) SetQuery(query *SearchRequestQuery) {
+	s.Query = query
+	s.require(searchRequestFieldQuery)
+}
+
 func (s *SearchRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler SearchRequest
 	var value unmarshaler
@@ -386,6 +572,17 @@ func (s *SearchRequest) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *SearchRequest) MarshalJSON() ([]byte, error) {
+	type embed SearchRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SearchRequest) String() string {
@@ -457,10 +654,19 @@ func (s *SearchRequestQuery) Accept(visitor SearchRequestQueryVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", s)
 }
 
+var (
+	singleFilterSearchRequestFieldField    = big.NewInt(1 << 0)
+	singleFilterSearchRequestFieldOperator = big.NewInt(1 << 1)
+	singleFilterSearchRequestFieldValue    = big.NewInt(1 << 2)
+)
+
 type SingleFilterSearchRequest struct {
 	Field    *string                            `json:"field,omitempty" url:"field,omitempty"`
 	Operator *SingleFilterSearchRequestOperator `json:"operator,omitempty" url:"operator,omitempty"`
 	Value    *string                            `json:"value,omitempty" url:"value,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -490,6 +696,34 @@ func (s *SingleFilterSearchRequest) GetExtraProperties() map[string]interface{} 
 	return s.extraProperties
 }
 
+func (s *SingleFilterSearchRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetField sets the Field field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SingleFilterSearchRequest) SetField(field *string) {
+	s.Field = field
+	s.require(singleFilterSearchRequestFieldField)
+}
+
+// SetOperator sets the Operator field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SingleFilterSearchRequest) SetOperator(operator *SingleFilterSearchRequestOperator) {
+	s.Operator = operator
+	s.require(singleFilterSearchRequestFieldOperator)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SingleFilterSearchRequest) SetValue(value *string) {
+	s.Value = value
+	s.require(singleFilterSearchRequestFieldValue)
+}
+
 func (s *SingleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler SingleFilterSearchRequest
 	var value unmarshaler
@@ -503,6 +737,17 @@ func (s *SingleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *SingleFilterSearchRequest) MarshalJSON() ([]byte, error) {
+	type embed SingleFilterSearchRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SingleFilterSearchRequest) String() string {
@@ -558,9 +803,17 @@ func (s SingleFilterSearchRequestOperator) Ptr() *SingleFilterSearchRequestOpera
 	return &s
 }
 
+var (
+	startingAfterPagingFieldPerPage       = big.NewInt(1 << 0)
+	startingAfterPagingFieldStartingAfter = big.NewInt(1 << 1)
+)
+
 type StartingAfterPaging struct {
 	PerPage       int     `json:"per_page" url:"per_page"`
 	StartingAfter *string `json:"starting_after,omitempty" url:"starting_after,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -583,6 +836,27 @@ func (s *StartingAfterPaging) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StartingAfterPaging) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *StartingAfterPaging) SetPerPage(perPage int) {
+	s.PerPage = perPage
+	s.require(startingAfterPagingFieldPerPage)
+}
+
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *StartingAfterPaging) SetStartingAfter(startingAfter *string) {
+	s.StartingAfter = startingAfter
+	s.require(startingAfterPagingFieldStartingAfter)
+}
+
 func (s *StartingAfterPaging) UnmarshalJSON(data []byte) error {
 	type unmarshaler StartingAfterPaging
 	var value unmarshaler
@@ -596,6 +870,17 @@ func (s *StartingAfterPaging) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *StartingAfterPaging) MarshalJSON() ([]byte, error) {
+	type embed StartingAfterPaging
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StartingAfterPaging) String() string {

--- a/seed/go-fiber/pagination/internal/explicit_fields.go
+++ b/seed/go-fiber/pagination/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/pagination/internal/explicit_fields_test.go
+++ b/seed/go-fiber/pagination/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/pagination/users.go
+++ b/seed/go-fiber/pagination/users.go
@@ -7,6 +7,7 @@ import (
 	fmt "fmt"
 	uuid "github.com/google/uuid"
 	internal "github.com/pagination/fern/internal"
+	big "math/big"
 )
 
 type ListUsernamesRequest struct {
@@ -96,8 +97,15 @@ type ListUsersOffsetStepPaginationRequest struct {
 	Order *Order `query:"order"`
 }
 
+var (
+	usernameCursorFieldCursor = big.NewInt(1 << 0)
+)
+
 type UsernameCursor struct {
 	Cursor *UsernamePage `json:"cursor" url:"cursor"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -111,6 +119,20 @@ func (u *UsernameCursor) GetCursor() *UsernamePage {
 
 func (u *UsernameCursor) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UsernameCursor) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetCursor sets the Cursor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UsernameCursor) SetCursor(cursor *UsernamePage) {
+	u.Cursor = cursor
+	u.require(usernameCursorFieldCursor)
 }
 
 func (u *UsernameCursor) UnmarshalJSON(data []byte) error {
@@ -128,6 +150,17 @@ func (u *UsernameCursor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UsernameCursor) MarshalJSON() ([]byte, error) {
+	type embed UsernameCursor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UsernameCursor) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -135,9 +168,17 @@ func (u *UsernameCursor) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	usernamePageFieldAfter = big.NewInt(1 << 0)
+	usernamePageFieldData  = big.NewInt(1 << 1)
+)
+
 type UsernamePage struct {
 	After *string  `json:"after,omitempty" url:"after,omitempty"`
 	Data  []string `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -160,6 +201,27 @@ func (u *UsernamePage) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UsernamePage) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetAfter sets the After field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UsernamePage) SetAfter(after *string) {
+	u.After = after
+	u.require(usernamePageFieldAfter)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UsernamePage) SetData(data []string) {
+	u.Data = data
+	u.require(usernamePageFieldData)
+}
+
 func (u *UsernamePage) UnmarshalJSON(data []byte) error {
 	type unmarshaler UsernamePage
 	var value unmarshaler
@@ -175,6 +237,17 @@ func (u *UsernamePage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UsernamePage) MarshalJSON() ([]byte, error) {
+	type embed UsernamePage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UsernamePage) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -182,11 +255,20 @@ func (u *UsernamePage) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	listUsersExtendedOptionalListResponseFieldData       = big.NewInt(1 << 0)
+	listUsersExtendedOptionalListResponseFieldNext       = big.NewInt(1 << 1)
+	listUsersExtendedOptionalListResponseFieldTotalCount = big.NewInt(1 << 2)
+)
+
 type ListUsersExtendedOptionalListResponse struct {
 	Data *UserOptionalListContainer `json:"data" url:"data"`
 	Next *uuid.UUID                 `json:"next,omitempty" url:"next,omitempty"`
 	// The totall number of /users
 	TotalCount int `json:"total_count" url:"total_count"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -216,6 +298,34 @@ func (l *ListUsersExtendedOptionalListResponse) GetExtraProperties() map[string]
 	return l.extraProperties
 }
 
+func (l *ListUsersExtendedOptionalListResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersExtendedOptionalListResponse) SetData(data *UserOptionalListContainer) {
+	l.Data = data
+	l.require(listUsersExtendedOptionalListResponseFieldData)
+}
+
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersExtendedOptionalListResponse) SetNext(next *uuid.UUID) {
+	l.Next = next
+	l.require(listUsersExtendedOptionalListResponseFieldNext)
+}
+
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersExtendedOptionalListResponse) SetTotalCount(totalCount int) {
+	l.TotalCount = totalCount
+	l.require(listUsersExtendedOptionalListResponseFieldTotalCount)
+}
+
 func (l *ListUsersExtendedOptionalListResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersExtendedOptionalListResponse
 	var value unmarshaler
@@ -231,6 +341,17 @@ func (l *ListUsersExtendedOptionalListResponse) UnmarshalJSON(data []byte) error
 	return nil
 }
 
+func (l *ListUsersExtendedOptionalListResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersExtendedOptionalListResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersExtendedOptionalListResponse) String() string {
 	if value, err := internal.StringifyJSON(l); err == nil {
 		return value
@@ -238,11 +359,20 @@ func (l *ListUsersExtendedOptionalListResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	listUsersExtendedResponseFieldData       = big.NewInt(1 << 0)
+	listUsersExtendedResponseFieldNext       = big.NewInt(1 << 1)
+	listUsersExtendedResponseFieldTotalCount = big.NewInt(1 << 2)
+)
+
 type ListUsersExtendedResponse struct {
 	Data *UserListContainer `json:"data" url:"data"`
 	Next *uuid.UUID         `json:"next,omitempty" url:"next,omitempty"`
 	// The totall number of /users
 	TotalCount int `json:"total_count" url:"total_count"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -272,6 +402,34 @@ func (l *ListUsersExtendedResponse) GetExtraProperties() map[string]interface{} 
 	return l.extraProperties
 }
 
+func (l *ListUsersExtendedResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersExtendedResponse) SetData(data *UserListContainer) {
+	l.Data = data
+	l.require(listUsersExtendedResponseFieldData)
+}
+
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersExtendedResponse) SetNext(next *uuid.UUID) {
+	l.Next = next
+	l.require(listUsersExtendedResponseFieldNext)
+}
+
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersExtendedResponse) SetTotalCount(totalCount int) {
+	l.TotalCount = totalCount
+	l.require(listUsersExtendedResponseFieldTotalCount)
+}
+
 func (l *ListUsersExtendedResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersExtendedResponse
 	var value unmarshaler
@@ -287,6 +445,17 @@ func (l *ListUsersExtendedResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *ListUsersExtendedResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersExtendedResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersExtendedResponse) String() string {
 	if value, err := internal.StringifyJSON(l); err == nil {
 		return value
@@ -294,9 +463,17 @@ func (l *ListUsersExtendedResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	listUsersMixedTypePaginationResponseFieldNext = big.NewInt(1 << 0)
+	listUsersMixedTypePaginationResponseFieldData = big.NewInt(1 << 1)
+)
+
 type ListUsersMixedTypePaginationResponse struct {
 	Next string  `json:"next" url:"next"`
 	Data []*User `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -319,6 +496,27 @@ func (l *ListUsersMixedTypePaginationResponse) GetExtraProperties() map[string]i
 	return l.extraProperties
 }
 
+func (l *ListUsersMixedTypePaginationResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersMixedTypePaginationResponse) SetNext(next string) {
+	l.Next = next
+	l.require(listUsersMixedTypePaginationResponseFieldNext)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersMixedTypePaginationResponse) SetData(data []*User) {
+	l.Data = data
+	l.require(listUsersMixedTypePaginationResponseFieldData)
+}
+
 func (l *ListUsersMixedTypePaginationResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersMixedTypePaginationResponse
 	var value unmarshaler
@@ -334,6 +532,17 @@ func (l *ListUsersMixedTypePaginationResponse) UnmarshalJSON(data []byte) error 
 	return nil
 }
 
+func (l *ListUsersMixedTypePaginationResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersMixedTypePaginationResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersMixedTypePaginationResponse) String() string {
 	if value, err := internal.StringifyJSON(l); err == nil {
 		return value
@@ -341,12 +550,22 @@ func (l *ListUsersMixedTypePaginationResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	listUsersPaginationResponseFieldHasNextPage = big.NewInt(1 << 0)
+	listUsersPaginationResponseFieldPage        = big.NewInt(1 << 1)
+	listUsersPaginationResponseFieldTotalCount  = big.NewInt(1 << 2)
+	listUsersPaginationResponseFieldData        = big.NewInt(1 << 3)
+)
+
 type ListUsersPaginationResponse struct {
 	HasNextPage *bool `json:"hasNextPage,omitempty" url:"hasNextPage,omitempty"`
 	Page        *Page `json:"page,omitempty" url:"page,omitempty"`
 	// The totall number of /users
 	TotalCount int     `json:"total_count" url:"total_count"`
 	Data       []*User `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -383,6 +602,41 @@ func (l *ListUsersPaginationResponse) GetExtraProperties() map[string]interface{
 	return l.extraProperties
 }
 
+func (l *ListUsersPaginationResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+// SetHasNextPage sets the HasNextPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersPaginationResponse) SetHasNextPage(hasNextPage *bool) {
+	l.HasNextPage = hasNextPage
+	l.require(listUsersPaginationResponseFieldHasNextPage)
+}
+
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersPaginationResponse) SetPage(page *Page) {
+	l.Page = page
+	l.require(listUsersPaginationResponseFieldPage)
+}
+
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersPaginationResponse) SetTotalCount(totalCount int) {
+	l.TotalCount = totalCount
+	l.require(listUsersPaginationResponseFieldTotalCount)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *ListUsersPaginationResponse) SetData(data []*User) {
+	l.Data = data
+	l.require(listUsersPaginationResponseFieldData)
+}
+
 func (l *ListUsersPaginationResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersPaginationResponse
 	var value unmarshaler
@@ -398,6 +652,17 @@ func (l *ListUsersPaginationResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *ListUsersPaginationResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersPaginationResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersPaginationResponse) String() string {
 	if value, err := internal.StringifyJSON(l); err == nil {
 		return value
@@ -405,9 +670,17 @@ func (l *ListUsersPaginationResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	nextPageFieldPage          = big.NewInt(1 << 0)
+	nextPageFieldStartingAfter = big.NewInt(1 << 1)
+)
+
 type NextPage struct {
 	Page          int    `json:"page" url:"page"`
 	StartingAfter string `json:"starting_after" url:"starting_after"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -430,6 +703,27 @@ func (n *NextPage) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NextPage) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NextPage) SetPage(page int) {
+	n.Page = page
+	n.require(nextPageFieldPage)
+}
+
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NextPage) SetStartingAfter(startingAfter string) {
+	n.StartingAfter = startingAfter
+	n.require(nextPageFieldStartingAfter)
+}
+
 func (n *NextPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler NextPage
 	var value unmarshaler
@@ -443,6 +737,17 @@ func (n *NextPage) UnmarshalJSON(data []byte) error {
 	}
 	n.extraProperties = extraProperties
 	return nil
+}
+
+func (n *NextPage) MarshalJSON() ([]byte, error) {
+	type embed NextPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (n *NextPage) String() string {
@@ -474,12 +779,22 @@ func (o Order) Ptr() *Order {
 	return &o
 }
 
+var (
+	pageFieldPage      = big.NewInt(1 << 0)
+	pageFieldNext      = big.NewInt(1 << 1)
+	pageFieldPerPage   = big.NewInt(1 << 2)
+	pageFieldTotalPage = big.NewInt(1 << 3)
+)
+
 type Page struct {
 	// The current page
 	Page      int       `json:"page" url:"page"`
 	Next      *NextPage `json:"next,omitempty" url:"next,omitempty"`
 	PerPage   int       `json:"per_page" url:"per_page"`
 	TotalPage int       `json:"total_page" url:"total_page"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -516,6 +831,41 @@ func (p *Page) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Page) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Page) SetPage(page int) {
+	p.Page = page
+	p.require(pageFieldPage)
+}
+
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Page) SetNext(next *NextPage) {
+	p.Next = next
+	p.require(pageFieldNext)
+}
+
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Page) SetPerPage(perPage int) {
+	p.PerPage = perPage
+	p.require(pageFieldPerPage)
+}
+
+// SetTotalPage sets the TotalPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Page) SetTotalPage(totalPage int) {
+	p.TotalPage = totalPage
+	p.require(pageFieldTotalPage)
+}
+
 func (p *Page) UnmarshalJSON(data []byte) error {
 	type unmarshaler Page
 	var value unmarshaler
@@ -531,6 +881,17 @@ func (p *Page) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *Page) MarshalJSON() ([]byte, error) {
+	type embed Page
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *Page) String() string {
 	if value, err := internal.StringifyJSON(p); err == nil {
 		return value
@@ -538,9 +899,17 @@ func (p *Page) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldId   = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name string `json:"name" url:"name"`
 	Id   int    `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -563,6 +932,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id int) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -578,6 +968,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *User) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -585,8 +986,15 @@ func (u *User) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userListContainerFieldUsers = big.NewInt(1 << 0)
+)
+
 type UserListContainer struct {
 	Users []*User `json:"users" url:"users"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -600,6 +1008,20 @@ func (u *UserListContainer) GetUsers() []*User {
 
 func (u *UserListContainer) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UserListContainer) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserListContainer) SetUsers(users []*User) {
+	u.Users = users
+	u.require(userListContainerFieldUsers)
 }
 
 func (u *UserListContainer) UnmarshalJSON(data []byte) error {
@@ -617,6 +1039,17 @@ func (u *UserListContainer) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserListContainer) MarshalJSON() ([]byte, error) {
+	type embed UserListContainer
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserListContainer) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -624,8 +1057,15 @@ func (u *UserListContainer) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userOptionalListContainerFieldUsers = big.NewInt(1 << 0)
+)
+
 type UserOptionalListContainer struct {
 	Users []*User `json:"users,omitempty" url:"users,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -639,6 +1079,20 @@ func (u *UserOptionalListContainer) GetUsers() []*User {
 
 func (u *UserOptionalListContainer) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UserOptionalListContainer) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserOptionalListContainer) SetUsers(users []*User) {
+	u.Users = users
+	u.require(userOptionalListContainerFieldUsers)
 }
 
 func (u *UserOptionalListContainer) UnmarshalJSON(data []byte) error {
@@ -656,6 +1110,17 @@ func (u *UserOptionalListContainer) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserOptionalListContainer) MarshalJSON() ([]byte, error) {
+	type embed UserOptionalListContainer
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserOptionalListContainer) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -663,9 +1128,17 @@ func (u *UserOptionalListContainer) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userOptionalListPageFieldData = big.NewInt(1 << 0)
+	userOptionalListPageFieldNext = big.NewInt(1 << 1)
+)
+
 type UserOptionalListPage struct {
 	Data *UserOptionalListContainer `json:"data" url:"data"`
 	Next *uuid.UUID                 `json:"next,omitempty" url:"next,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -688,6 +1161,27 @@ func (u *UserOptionalListPage) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserOptionalListPage) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserOptionalListPage) SetData(data *UserOptionalListContainer) {
+	u.Data = data
+	u.require(userOptionalListPageFieldData)
+}
+
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserOptionalListPage) SetNext(next *uuid.UUID) {
+	u.Next = next
+	u.require(userOptionalListPageFieldNext)
+}
+
 func (u *UserOptionalListPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler UserOptionalListPage
 	var value unmarshaler
@@ -703,6 +1197,17 @@ func (u *UserOptionalListPage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserOptionalListPage) MarshalJSON() ([]byte, error) {
+	type embed UserOptionalListPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserOptionalListPage) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -710,9 +1215,17 @@ func (u *UserOptionalListPage) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userPageFieldData = big.NewInt(1 << 0)
+	userPageFieldNext = big.NewInt(1 << 1)
+)
+
 type UserPage struct {
 	Data *UserListContainer `json:"data" url:"data"`
 	Next *uuid.UUID         `json:"next,omitempty" url:"next,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -735,6 +1248,27 @@ func (u *UserPage) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserPage) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserPage) SetData(data *UserListContainer) {
+	u.Data = data
+	u.require(userPageFieldData)
+}
+
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserPage) SetNext(next *uuid.UUID) {
+	u.Next = next
+	u.require(userPageFieldNext)
+}
+
 func (u *UserPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler UserPage
 	var value unmarshaler
@@ -750,6 +1284,17 @@ func (u *UserPage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserPage) MarshalJSON() ([]byte, error) {
+	type embed UserPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserPage) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -757,8 +1302,15 @@ func (u *UserPage) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	usernameContainerFieldResults = big.NewInt(1 << 0)
+)
+
 type UsernameContainer struct {
 	Results []string `json:"results" url:"results"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -772,6 +1324,20 @@ func (u *UsernameContainer) GetResults() []string {
 
 func (u *UsernameContainer) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UsernameContainer) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UsernameContainer) SetResults(results []string) {
+	u.Results = results
+	u.require(usernameContainerFieldResults)
 }
 
 func (u *UsernameContainer) UnmarshalJSON(data []byte) error {
@@ -789,6 +1355,17 @@ func (u *UsernameContainer) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UsernameContainer) MarshalJSON() ([]byte, error) {
+	type embed UsernameContainer
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UsernameContainer) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -796,8 +1373,15 @@ func (u *UsernameContainer) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	withCursorFieldCursor = big.NewInt(1 << 0)
+)
+
 type WithCursor struct {
 	Cursor *string `json:"cursor,omitempty" url:"cursor,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -811,6 +1395,20 @@ func (w *WithCursor) GetCursor() *string {
 
 func (w *WithCursor) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
+}
+
+func (w *WithCursor) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+// SetCursor sets the Cursor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (w *WithCursor) SetCursor(cursor *string) {
+	w.Cursor = cursor
+	w.require(withCursorFieldCursor)
 }
 
 func (w *WithCursor) UnmarshalJSON(data []byte) error {
@@ -828,6 +1426,17 @@ func (w *WithCursor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (w *WithCursor) MarshalJSON() ([]byte, error) {
+	type embed WithCursor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (w *WithCursor) String() string {
 	if value, err := internal.StringifyJSON(w); err == nil {
 		return value
@@ -835,8 +1444,15 @@ func (w *WithCursor) String() string {
 	return fmt.Sprintf("%#v", w)
 }
 
+var (
+	withPageFieldPage = big.NewInt(1 << 0)
+)
+
 type WithPage struct {
 	Page *int `json:"page,omitempty" url:"page,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -852,6 +1468,20 @@ func (w *WithPage) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
 }
 
+func (w *WithPage) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (w *WithPage) SetPage(page *int) {
+	w.Page = page
+	w.require(withPageFieldPage)
+}
+
 func (w *WithPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler WithPage
 	var value unmarshaler
@@ -865,6 +1495,17 @@ func (w *WithPage) UnmarshalJSON(data []byte) error {
 	}
 	w.extraProperties = extraProperties
 	return nil
+}
+
+func (w *WithPage) MarshalJSON() ([]byte, error) {
+	type embed WithPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (w *WithPage) String() string {

--- a/seed/go-fiber/path-parameters/internal/explicit_fields.go
+++ b/seed/go-fiber/path-parameters/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/path-parameters/internal/explicit_fields_test.go
+++ b/seed/go-fiber/path-parameters/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/path-parameters/user.go
+++ b/seed/go-fiber/path-parameters/user.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/path-parameters/fern/internal"
+	big "math/big"
 )
 
 type GetUsersRequest struct {
@@ -15,9 +16,17 @@ type SearchUsersRequest struct {
 	Limit *int `query:"limit"`
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags" url:"tags"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -40,6 +49,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -53,6 +83,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/plain-text/internal/explicit_fields.go
+++ b/seed/go-fiber/plain-text/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/plain-text/internal/explicit_fields_test.go
+++ b/seed/go-fiber/plain-text/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/property-access/internal/explicit_fields.go
+++ b/seed/go-fiber/property-access/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/property-access/internal/explicit_fields_test.go
+++ b/seed/go-fiber/property-access/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/public-object/internal/explicit_fields.go
+++ b/seed/go-fiber/public-object/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/public-object/internal/explicit_fields_test.go
+++ b/seed/go-fiber/public-object/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/query-parameters-openapi-as-objects/internal/explicit_fields.go
+++ b/seed/go-fiber/query-parameters-openapi-as-objects/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/query-parameters-openapi-as-objects/internal/explicit_fields_test.go
+++ b/seed/go-fiber/query-parameters-openapi-as-objects/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/query-parameters-openapi-as-objects/types.go
+++ b/seed/go-fiber/query-parameters-openapi-as-objects/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/query-parameters-openapi-as-objects/fern/internal"
+	big "math/big"
 	time "time"
 )
 
@@ -28,9 +29,17 @@ type SearchRequest struct {
 	NeighborRequired *SearchRequestNeighborRequired `query:"neighborRequired"`
 }
 
+var (
+	nestedUserFieldName = big.NewInt(1 << 0)
+	nestedUserFieldUser = big.NewInt(1 << 1)
+)
+
 type NestedUser struct {
 	Name *string `json:"name,omitempty" url:"name,omitempty"`
 	User *User   `json:"user,omitempty" url:"user,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -53,6 +62,27 @@ func (n *NestedUser) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedUser) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedUser) SetName(name *string) {
+	n.Name = name
+	n.require(nestedUserFieldName)
+}
+
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedUser) SetUser(user *User) {
+	n.User = user
+	n.require(nestedUserFieldUser)
+}
+
 func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedUser
 	var value unmarshaler
@@ -66,6 +96,17 @@ func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	}
 	n.extraProperties = extraProperties
 	return nil
+}
+
+func (n *NestedUser) MarshalJSON() ([]byte, error) {
+	type embed NestedUser
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (n *NestedUser) String() string {
@@ -283,8 +324,15 @@ func (s *SearchRequestNeighborRequired) Accept(visitor SearchRequestNeighborRequ
 	return fmt.Errorf("type %T does not include a non-empty union type", s)
 }
 
+var (
+	searchResponseFieldResults = big.NewInt(1 << 0)
+)
+
 type SearchResponse struct {
 	Results []string `json:"results,omitempty" url:"results,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -298,6 +346,20 @@ func (s *SearchResponse) GetResults() []string {
 
 func (s *SearchResponse) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
+}
+
+func (s *SearchResponse) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SearchResponse) SetResults(results []string) {
+	s.Results = results
+	s.require(searchResponseFieldResults)
 }
 
 func (s *SearchResponse) UnmarshalJSON(data []byte) error {
@@ -315,6 +377,17 @@ func (s *SearchResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SearchResponse) MarshalJSON() ([]byte, error) {
+	type embed SearchResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SearchResponse) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -322,9 +395,17 @@ func (s *SearchResponse) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name *string  `json:"name,omitempty" url:"name,omitempty"`
 	Tags []string `json:"tags,omitempty" url:"tags,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -347,6 +428,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name *string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -360,6 +462,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/query-parameters-openapi/internal/explicit_fields.go
+++ b/seed/go-fiber/query-parameters-openapi/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/query-parameters-openapi/internal/explicit_fields_test.go
+++ b/seed/go-fiber/query-parameters-openapi/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/query-parameters-openapi/types.go
+++ b/seed/go-fiber/query-parameters-openapi/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/query-parameters-openapi/fern/internal"
+	big "math/big"
 	time "time"
 )
 
@@ -28,9 +29,17 @@ type SearchRequest struct {
 	NeighborRequired *SearchRequestNeighborRequired `query:"neighborRequired"`
 }
 
+var (
+	nestedUserFieldName = big.NewInt(1 << 0)
+	nestedUserFieldUser = big.NewInt(1 << 1)
+)
+
 type NestedUser struct {
 	Name *string `json:"name,omitempty" url:"name,omitempty"`
 	User *User   `json:"user,omitempty" url:"user,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -53,6 +62,27 @@ func (n *NestedUser) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedUser) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedUser) SetName(name *string) {
+	n.Name = name
+	n.require(nestedUserFieldName)
+}
+
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NestedUser) SetUser(user *User) {
+	n.User = user
+	n.require(nestedUserFieldUser)
+}
+
 func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedUser
 	var value unmarshaler
@@ -66,6 +96,17 @@ func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	}
 	n.extraProperties = extraProperties
 	return nil
+}
+
+func (n *NestedUser) MarshalJSON() ([]byte, error) {
+	type embed NestedUser
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (n *NestedUser) String() string {
@@ -179,8 +220,15 @@ func (s *SearchRequestNeighborRequired) Accept(visitor SearchRequestNeighborRequ
 	return fmt.Errorf("type %T does not include a non-empty union type", s)
 }
 
+var (
+	searchResponseFieldResults = big.NewInt(1 << 0)
+)
+
 type SearchResponse struct {
 	Results []string `json:"results,omitempty" url:"results,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -194,6 +242,20 @@ func (s *SearchResponse) GetResults() []string {
 
 func (s *SearchResponse) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
+}
+
+func (s *SearchResponse) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SearchResponse) SetResults(results []string) {
+	s.Results = results
+	s.require(searchResponseFieldResults)
 }
 
 func (s *SearchResponse) UnmarshalJSON(data []byte) error {
@@ -211,6 +273,17 @@ func (s *SearchResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SearchResponse) MarshalJSON() ([]byte, error) {
+	type embed SearchResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SearchResponse) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -218,9 +291,17 @@ func (s *SearchResponse) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name *string  `json:"name,omitempty" url:"name,omitempty"`
 	Tags []string `json:"tags,omitempty" url:"tags,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -243,6 +324,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name *string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -256,6 +358,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/query-parameters/internal/explicit_fields.go
+++ b/seed/go-fiber/query-parameters/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/query-parameters/internal/explicit_fields_test.go
+++ b/seed/go-fiber/query-parameters/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/response-property/internal/explicit_fields.go
+++ b/seed/go-fiber/response-property/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/response-property/internal/explicit_fields_test.go
+++ b/seed/go-fiber/response-property/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/response-property/service.go
+++ b/seed/go-fiber/response-property/service.go
@@ -6,12 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/response-property/fern/internal"
+	big "math/big"
 )
 
 type OptionalStringResponse = *StringResponse
 
+var (
+	stringResponseFieldData = big.NewInt(1 << 0)
+)
+
 type StringResponse struct {
 	Data string `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -25,6 +33,20 @@ func (s *StringResponse) GetData() string {
 
 func (s *StringResponse) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
+}
+
+func (s *StringResponse) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *StringResponse) SetData(data string) {
+	s.Data = data
+	s.require(stringResponseFieldData)
 }
 
 func (s *StringResponse) UnmarshalJSON(data []byte) error {
@@ -42,6 +64,17 @@ func (s *StringResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *StringResponse) MarshalJSON() ([]byte, error) {
+	type embed StringResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *StringResponse) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -49,8 +82,15 @@ func (s *StringResponse) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	withMetadataFieldMetadata = big.NewInt(1 << 0)
+)
+
 type WithMetadata struct {
 	Metadata map[string]string `json:"metadata" url:"metadata"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -64,6 +104,20 @@ func (w *WithMetadata) GetMetadata() map[string]string {
 
 func (w *WithMetadata) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
+}
+
+func (w *WithMetadata) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (w *WithMetadata) SetMetadata(metadata map[string]string) {
+	w.Metadata = metadata
+	w.require(withMetadataFieldMetadata)
 }
 
 func (w *WithMetadata) UnmarshalJSON(data []byte) error {
@@ -81,6 +135,17 @@ func (w *WithMetadata) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (w *WithMetadata) MarshalJSON() ([]byte, error) {
+	type embed WithMetadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (w *WithMetadata) String() string {
 	if value, err := internal.StringifyJSON(w); err == nil {
 		return value
@@ -88,9 +153,17 @@ func (w *WithMetadata) String() string {
 	return fmt.Sprintf("%#v", w)
 }
 
+var (
+	movieFieldId   = big.NewInt(1 << 0)
+	movieFieldName = big.NewInt(1 << 1)
+)
+
 type Movie struct {
 	Id   string `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -113,6 +186,27 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetId(id string) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Movie) SetName(name string) {
+	m.Name = name
+	m.require(movieFieldName)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type unmarshaler Movie
 	var value unmarshaler
@@ -128,6 +222,17 @@ func (m *Movie) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *Movie) MarshalJSON() ([]byte, error) {
+	type embed Movie
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *Movie) String() string {
 	if value, err := internal.StringifyJSON(m); err == nil {
 		return value
@@ -137,10 +242,19 @@ func (m *Movie) String() string {
 
 type OptionalWithDocs = *WithDocs
 
+var (
+	responseFieldMetadata = big.NewInt(1 << 0)
+	responseFieldDocs     = big.NewInt(1 << 1)
+	responseFieldData     = big.NewInt(1 << 2)
+)
+
 type Response struct {
 	Metadata map[string]string `json:"metadata" url:"metadata"`
 	Docs     string            `json:"docs" url:"docs"`
 	Data     *Movie            `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -170,6 +284,34 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetMetadata(metadata map[string]string) {
+	r.Metadata = metadata
+	r.require(responseFieldMetadata)
+}
+
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetDocs(docs string) {
+	r.Docs = docs
+	r.require(responseFieldDocs)
+}
+
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *Response) SetData(data *Movie) {
+	r.Data = data
+	r.require(responseFieldData)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -185,6 +327,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -192,8 +345,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	withDocsFieldDocs = big.NewInt(1 << 0)
+)
+
 type WithDocs struct {
 	Docs string `json:"docs" url:"docs"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -209,6 +369,20 @@ func (w *WithDocs) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
 }
 
+func (w *WithDocs) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (w *WithDocs) SetDocs(docs string) {
+	w.Docs = docs
+	w.require(withDocsFieldDocs)
+}
+
 func (w *WithDocs) UnmarshalJSON(data []byte) error {
 	type unmarshaler WithDocs
 	var value unmarshaler
@@ -222,6 +396,17 @@ func (w *WithDocs) UnmarshalJSON(data []byte) error {
 	}
 	w.extraProperties = extraProperties
 	return nil
+}
+
+func (w *WithDocs) MarshalJSON() ([]byte, error) {
+	type embed WithDocs
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (w *WithDocs) String() string {

--- a/seed/go-fiber/server-sent-event-examples/completions.go
+++ b/seed/go-fiber/server-sent-event-examples/completions.go
@@ -6,15 +6,24 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/server-sent-event-examples/fern/internal"
+	big "math/big"
 )
 
 type StreamCompletionRequest struct {
 	Query string `json:"query" url:"-"`
 }
 
+var (
+	streamedCompletionFieldDelta  = big.NewInt(1 << 0)
+	streamedCompletionFieldTokens = big.NewInt(1 << 1)
+)
+
 type StreamedCompletion struct {
 	Delta  string `json:"delta" url:"delta"`
 	Tokens *int   `json:"tokens,omitempty" url:"tokens,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -37,6 +46,27 @@ func (s *StreamedCompletion) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StreamedCompletion) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *StreamedCompletion) SetDelta(delta string) {
+	s.Delta = delta
+	s.require(streamedCompletionFieldDelta)
+}
+
+// SetTokens sets the Tokens field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *StreamedCompletion) SetTokens(tokens *int) {
+	s.Tokens = tokens
+	s.require(streamedCompletionFieldTokens)
+}
+
 func (s *StreamedCompletion) UnmarshalJSON(data []byte) error {
 	type unmarshaler StreamedCompletion
 	var value unmarshaler
@@ -50,6 +80,17 @@ func (s *StreamedCompletion) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *StreamedCompletion) MarshalJSON() ([]byte, error) {
+	type embed StreamedCompletion
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StreamedCompletion) String() string {

--- a/seed/go-fiber/server-sent-event-examples/internal/explicit_fields.go
+++ b/seed/go-fiber/server-sent-event-examples/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/server-sent-event-examples/internal/explicit_fields_test.go
+++ b/seed/go-fiber/server-sent-event-examples/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/server-sent-events/internal/explicit_fields.go
+++ b/seed/go-fiber/server-sent-events/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/server-sent-events/internal/explicit_fields_test.go
+++ b/seed/go-fiber/server-sent-events/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/simple-api/internal/explicit_fields.go
+++ b/seed/go-fiber/simple-api/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/simple-api/internal/explicit_fields_test.go
+++ b/seed/go-fiber/simple-api/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/simple-api/user.go
+++ b/seed/go-fiber/simple-api/user.go
@@ -6,12 +6,22 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/simple-api/fern/internal"
+	big "math/big"
+)
+
+var (
+	userFieldId    = big.NewInt(1 << 0)
+	userFieldName  = big.NewInt(1 << 1)
+	userFieldEmail = big.NewInt(1 << 2)
 )
 
 type User struct {
 	Id    string `json:"id" url:"id"`
 	Name  string `json:"name" url:"name"`
 	Email string `json:"email" url:"email"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -41,6 +51,34 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id string) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetEmail(email string) {
+	u.Email = email
+	u.require(userFieldEmail)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -54,6 +92,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/simple-fhir/internal/explicit_fields.go
+++ b/seed/go-fiber/simple-fhir/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/simple-fhir/internal/explicit_fields_test.go
+++ b/seed/go-fiber/simple-fhir/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/simple-fhir/types.go
+++ b/seed/go-fiber/simple-fhir/types.go
@@ -6,6 +6,16 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/simple-fhir/fern/internal"
+	big "math/big"
+)
+
+var (
+	accountFieldId               = big.NewInt(1 << 0)
+	accountFieldRelatedResources = big.NewInt(1 << 1)
+	accountFieldMemo             = big.NewInt(1 << 2)
+	accountFieldName             = big.NewInt(1 << 3)
+	accountFieldPatient          = big.NewInt(1 << 4)
+	accountFieldPractitioner     = big.NewInt(1 << 5)
 )
 
 type Account struct {
@@ -15,7 +25,10 @@ type Account struct {
 	Name             string          `json:"name" url:"name"`
 	Patient          *Patient        `json:"patient,omitempty" url:"patient,omitempty"`
 	Practitioner     *Practitioner   `json:"practitioner,omitempty" url:"practitioner,omitempty"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 }
@@ -70,6 +83,55 @@ func (a *Account) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Account) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Account) SetId(id string) {
+	a.Id = id
+	a.require(accountFieldId)
+}
+
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Account) SetRelatedResources(relatedResources []*ResourceList) {
+	a.RelatedResources = relatedResources
+	a.require(accountFieldRelatedResources)
+}
+
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Account) SetMemo(memo *Memo) {
+	a.Memo = memo
+	a.require(accountFieldMemo)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Account) SetName(name string) {
+	a.Name = name
+	a.require(accountFieldName)
+}
+
+// SetPatient sets the Patient field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Account) SetPatient(patient *Patient) {
+	a.Patient = patient
+	a.require(accountFieldPatient)
+}
+
+// SetPractitioner sets the Practitioner field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Account) SetPractitioner(practitioner *Practitioner) {
+	a.Practitioner = practitioner
+	a.require(accountFieldPractitioner)
+}
+
 func (a *Account) UnmarshalJSON(data []byte) error {
 	type embed Account
 	var unmarshaler = struct {
@@ -103,7 +165,8 @@ func (a *Account) MarshalJSON() ([]byte, error) {
 		embed:        embed(*a),
 		ResourceType: "Account",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *Account) String() string {
@@ -113,10 +176,19 @@ func (a *Account) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	baseResourceFieldId               = big.NewInt(1 << 0)
+	baseResourceFieldRelatedResources = big.NewInt(1 << 1)
+	baseResourceFieldMemo             = big.NewInt(1 << 2)
+)
+
 type BaseResource struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -146,6 +218,34 @@ func (b *BaseResource) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BaseResource) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BaseResource) SetId(id string) {
+	b.Id = id
+	b.require(baseResourceFieldId)
+}
+
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BaseResource) SetRelatedResources(relatedResources []*ResourceList) {
+	b.RelatedResources = relatedResources
+	b.require(baseResourceFieldRelatedResources)
+}
+
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (b *BaseResource) SetMemo(memo *Memo) {
+	b.Memo = memo
+	b.require(baseResourceFieldMemo)
+}
+
 func (b *BaseResource) UnmarshalJSON(data []byte) error {
 	type unmarshaler BaseResource
 	var value unmarshaler
@@ -161,6 +261,17 @@ func (b *BaseResource) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (b *BaseResource) MarshalJSON() ([]byte, error) {
+	type embed BaseResource
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (b *BaseResource) String() string {
 	if value, err := internal.StringifyJSON(b); err == nil {
 		return value
@@ -168,9 +279,17 @@ func (b *BaseResource) String() string {
 	return fmt.Sprintf("%#v", b)
 }
 
+var (
+	memoFieldDescription = big.NewInt(1 << 0)
+	memoFieldAccount     = big.NewInt(1 << 1)
+)
+
 type Memo struct {
 	Description string   `json:"description" url:"description"`
 	Account     *Account `json:"account,omitempty" url:"account,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -193,6 +312,27 @@ func (m *Memo) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Memo) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetDescription sets the Description field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Memo) SetDescription(description string) {
+	m.Description = description
+	m.require(memoFieldDescription)
+}
+
+// SetAccount sets the Account field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *Memo) SetAccount(account *Account) {
+	m.Account = account
+	m.require(memoFieldAccount)
+}
+
 func (m *Memo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Memo
 	var value unmarshaler
@@ -208,6 +348,17 @@ func (m *Memo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *Memo) MarshalJSON() ([]byte, error) {
+	type embed Memo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *Memo) String() string {
 	if value, err := internal.StringifyJSON(m); err == nil {
 		return value
@@ -215,13 +366,24 @@ func (m *Memo) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	patientFieldId               = big.NewInt(1 << 0)
+	patientFieldRelatedResources = big.NewInt(1 << 1)
+	patientFieldMemo             = big.NewInt(1 << 2)
+	patientFieldName             = big.NewInt(1 << 3)
+	patientFieldScripts          = big.NewInt(1 << 4)
+)
+
 type Patient struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
 	Name             string          `json:"name" url:"name"`
 	Scripts          []*Script       `json:"scripts" url:"scripts"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 }
@@ -269,6 +431,48 @@ func (p *Patient) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Patient) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Patient) SetId(id string) {
+	p.Id = id
+	p.require(patientFieldId)
+}
+
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Patient) SetRelatedResources(relatedResources []*ResourceList) {
+	p.RelatedResources = relatedResources
+	p.require(patientFieldRelatedResources)
+}
+
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Patient) SetMemo(memo *Memo) {
+	p.Memo = memo
+	p.require(patientFieldMemo)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Patient) SetName(name string) {
+	p.Name = name
+	p.require(patientFieldName)
+}
+
+// SetScripts sets the Scripts field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Patient) SetScripts(scripts []*Script) {
+	p.Scripts = scripts
+	p.require(patientFieldScripts)
+}
+
 func (p *Patient) UnmarshalJSON(data []byte) error {
 	type embed Patient
 	var unmarshaler = struct {
@@ -302,7 +506,8 @@ func (p *Patient) MarshalJSON() ([]byte, error) {
 		embed:        embed(*p),
 		ResourceType: "Patient",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *Patient) String() string {
@@ -312,12 +517,22 @@ func (p *Patient) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	practitionerFieldId               = big.NewInt(1 << 0)
+	practitionerFieldRelatedResources = big.NewInt(1 << 1)
+	practitionerFieldMemo             = big.NewInt(1 << 2)
+	practitionerFieldName             = big.NewInt(1 << 3)
+)
+
 type Practitioner struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
 	Name             string          `json:"name" url:"name"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 }
@@ -358,6 +573,41 @@ func (p *Practitioner) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Practitioner) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Practitioner) SetId(id string) {
+	p.Id = id
+	p.require(practitionerFieldId)
+}
+
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Practitioner) SetRelatedResources(relatedResources []*ResourceList) {
+	p.RelatedResources = relatedResources
+	p.require(practitionerFieldRelatedResources)
+}
+
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Practitioner) SetMemo(memo *Memo) {
+	p.Memo = memo
+	p.require(practitionerFieldMemo)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *Practitioner) SetName(name string) {
+	p.Name = name
+	p.require(practitionerFieldName)
+}
+
 func (p *Practitioner) UnmarshalJSON(data []byte) error {
 	type embed Practitioner
 	var unmarshaler = struct {
@@ -391,7 +641,8 @@ func (p *Practitioner) MarshalJSON() ([]byte, error) {
 		embed:        embed(*p),
 		ResourceType: "Practitioner",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *Practitioner) String() string {
@@ -505,12 +756,22 @@ func (r *ResourceList) Accept(visitor ResourceListVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", r)
 }
 
+var (
+	scriptFieldId               = big.NewInt(1 << 0)
+	scriptFieldRelatedResources = big.NewInt(1 << 1)
+	scriptFieldMemo             = big.NewInt(1 << 2)
+	scriptFieldName             = big.NewInt(1 << 3)
+)
+
 type Script struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
 	Name             string          `json:"name" url:"name"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 }
@@ -551,6 +812,41 @@ func (s *Script) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *Script) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *Script) SetId(id string) {
+	s.Id = id
+	s.require(scriptFieldId)
+}
+
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *Script) SetRelatedResources(relatedResources []*ResourceList) {
+	s.RelatedResources = relatedResources
+	s.require(scriptFieldRelatedResources)
+}
+
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *Script) SetMemo(memo *Memo) {
+	s.Memo = memo
+	s.require(scriptFieldMemo)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *Script) SetName(name string) {
+	s.Name = name
+	s.require(scriptFieldName)
+}
+
 func (s *Script) UnmarshalJSON(data []byte) error {
 	type embed Script
 	var unmarshaler = struct {
@@ -584,7 +880,8 @@ func (s *Script) MarshalJSON() ([]byte, error) {
 		embed:        embed(*s),
 		ResourceType: "Script",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *Script) String() string {

--- a/seed/go-fiber/single-url-environment-default/internal/explicit_fields.go
+++ b/seed/go-fiber/single-url-environment-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/single-url-environment-default/internal/explicit_fields_test.go
+++ b/seed/go-fiber/single-url-environment-default/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/single-url-environment-no-default/internal/explicit_fields.go
+++ b/seed/go-fiber/single-url-environment-no-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/single-url-environment-no-default/internal/explicit_fields_test.go
+++ b/seed/go-fiber/single-url-environment-no-default/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/streaming-parameter/internal/explicit_fields.go
+++ b/seed/go-fiber/streaming-parameter/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/streaming-parameter/internal/explicit_fields_test.go
+++ b/seed/go-fiber/streaming-parameter/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/streaming/internal/explicit_fields.go
+++ b/seed/go-fiber/streaming/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/streaming/internal/explicit_fields_test.go
+++ b/seed/go-fiber/streaming/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/undiscriminated-unions/internal/explicit_fields.go
+++ b/seed/go-fiber/undiscriminated-unions/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/undiscriminated-unions/internal/explicit_fields_test.go
+++ b/seed/go-fiber/undiscriminated-unions/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/unions/bigunion.go
+++ b/seed/go-fiber/unions/bigunion.go
@@ -6,11 +6,19 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/unions/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	activeDiamondFieldValue = big.NewInt(1 << 0)
 )
 
 type ActiveDiamond struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -24,6 +32,20 @@ func (a *ActiveDiamond) GetValue() string {
 
 func (a *ActiveDiamond) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
+}
+
+func (a *ActiveDiamond) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *ActiveDiamond) SetValue(value string) {
+	a.Value = value
+	a.require(activeDiamondFieldValue)
 }
 
 func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
@@ -41,6 +63,17 @@ func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *ActiveDiamond) MarshalJSON() ([]byte, error) {
+	type embed ActiveDiamond
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *ActiveDiamond) String() string {
 	if value, err := internal.StringifyJSON(a); err == nil {
 		return value
@@ -48,8 +81,15 @@ func (a *ActiveDiamond) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	attractiveScriptFieldValue = big.NewInt(1 << 0)
+)
+
 type AttractiveScript struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -65,6 +105,20 @@ func (a *AttractiveScript) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *AttractiveScript) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *AttractiveScript) SetValue(value string) {
+	a.Value = value
+	a.require(attractiveScriptFieldValue)
+}
+
 func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	type unmarshaler AttractiveScript
 	var value unmarshaler
@@ -78,6 +132,17 @@ func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	}
 	a.extraProperties = extraProperties
 	return nil
+}
+
+func (a *AttractiveScript) MarshalJSON() ([]byte, error) {
+	type embed AttractiveScript
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *AttractiveScript) String() string {
@@ -882,8 +947,15 @@ func (b *BigUnion) validate() error {
 	return nil
 }
 
+var (
+	circularCardFieldValue = big.NewInt(1 << 0)
+)
+
 type CircularCard struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -897,6 +969,20 @@ func (c *CircularCard) GetValue() string {
 
 func (c *CircularCard) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CircularCard) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *CircularCard) SetValue(value string) {
+	c.Value = value
+	c.require(circularCardFieldValue)
 }
 
 func (c *CircularCard) UnmarshalJSON(data []byte) error {
@@ -914,6 +1000,17 @@ func (c *CircularCard) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CircularCard) MarshalJSON() ([]byte, error) {
+	type embed CircularCard
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CircularCard) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -921,8 +1018,15 @@ func (c *CircularCard) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	colorfulCoverFieldValue = big.NewInt(1 << 0)
+)
+
 type ColorfulCover struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -936,6 +1040,20 @@ func (c *ColorfulCover) GetValue() string {
 
 func (c *ColorfulCover) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *ColorfulCover) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *ColorfulCover) SetValue(value string) {
+	c.Value = value
+	c.require(colorfulCoverFieldValue)
 }
 
 func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
@@ -953,6 +1071,17 @@ func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *ColorfulCover) MarshalJSON() ([]byte, error) {
+	type embed ColorfulCover
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *ColorfulCover) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -960,8 +1089,15 @@ func (c *ColorfulCover) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	diligentDealFieldValue = big.NewInt(1 << 0)
+)
+
 type DiligentDeal struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -975,6 +1111,20 @@ func (d *DiligentDeal) GetValue() string {
 
 func (d *DiligentDeal) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DiligentDeal) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DiligentDeal) SetValue(value string) {
+	d.Value = value
+	d.require(diligentDealFieldValue)
 }
 
 func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
@@ -992,6 +1142,17 @@ func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DiligentDeal) MarshalJSON() ([]byte, error) {
+	type embed DiligentDeal
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DiligentDeal) String() string {
 	if value, err := internal.StringifyJSON(d); err == nil {
 		return value
@@ -999,8 +1160,15 @@ func (d *DiligentDeal) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	disloyalValueFieldValue = big.NewInt(1 << 0)
+)
+
 type DisloyalValue struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1014,6 +1182,20 @@ func (d *DisloyalValue) GetValue() string {
 
 func (d *DisloyalValue) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DisloyalValue) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DisloyalValue) SetValue(value string) {
+	d.Value = value
+	d.require(disloyalValueFieldValue)
 }
 
 func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
@@ -1031,6 +1213,17 @@ func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DisloyalValue) MarshalJSON() ([]byte, error) {
+	type embed DisloyalValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DisloyalValue) String() string {
 	if value, err := internal.StringifyJSON(d); err == nil {
 		return value
@@ -1038,8 +1231,15 @@ func (d *DisloyalValue) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	distinctFailureFieldValue = big.NewInt(1 << 0)
+)
+
 type DistinctFailure struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1053,6 +1253,20 @@ func (d *DistinctFailure) GetValue() string {
 
 func (d *DistinctFailure) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DistinctFailure) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (d *DistinctFailure) SetValue(value string) {
+	d.Value = value
+	d.require(distinctFailureFieldValue)
 }
 
 func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
@@ -1070,6 +1284,17 @@ func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DistinctFailure) MarshalJSON() ([]byte, error) {
+	type embed DistinctFailure
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DistinctFailure) String() string {
 	if value, err := internal.StringifyJSON(d); err == nil {
 		return value
@@ -1077,8 +1302,15 @@ func (d *DistinctFailure) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	falseMirrorFieldValue = big.NewInt(1 << 0)
+)
+
 type FalseMirror struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1092,6 +1324,20 @@ func (f *FalseMirror) GetValue() string {
 
 func (f *FalseMirror) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FalseMirror) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *FalseMirror) SetValue(value string) {
+	f.Value = value
+	f.require(falseMirrorFieldValue)
 }
 
 func (f *FalseMirror) UnmarshalJSON(data []byte) error {
@@ -1109,6 +1355,17 @@ func (f *FalseMirror) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FalseMirror) MarshalJSON() ([]byte, error) {
+	type embed FalseMirror
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FalseMirror) String() string {
 	if value, err := internal.StringifyJSON(f); err == nil {
 		return value
@@ -1116,8 +1373,15 @@ func (f *FalseMirror) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	frozenSleepFieldValue = big.NewInt(1 << 0)
+)
+
 type FrozenSleep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1131,6 +1395,20 @@ func (f *FrozenSleep) GetValue() string {
 
 func (f *FrozenSleep) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FrozenSleep) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *FrozenSleep) SetValue(value string) {
+	f.Value = value
+	f.require(frozenSleepFieldValue)
 }
 
 func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
@@ -1148,6 +1426,17 @@ func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FrozenSleep) MarshalJSON() ([]byte, error) {
+	type embed FrozenSleep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FrozenSleep) String() string {
 	if value, err := internal.StringifyJSON(f); err == nil {
 		return value
@@ -1155,8 +1444,15 @@ func (f *FrozenSleep) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	gaseousRoadFieldValue = big.NewInt(1 << 0)
+)
+
 type GaseousRoad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1170,6 +1466,20 @@ func (g *GaseousRoad) GetValue() string {
 
 func (g *GaseousRoad) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GaseousRoad) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (g *GaseousRoad) SetValue(value string) {
+	g.Value = value
+	g.require(gaseousRoadFieldValue)
 }
 
 func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
@@ -1187,6 +1497,17 @@ func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GaseousRoad) MarshalJSON() ([]byte, error) {
+	type embed GaseousRoad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GaseousRoad) String() string {
 	if value, err := internal.StringifyJSON(g); err == nil {
 		return value
@@ -1194,8 +1515,15 @@ func (g *GaseousRoad) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	gruesomeCoachFieldValue = big.NewInt(1 << 0)
+)
+
 type GruesomeCoach struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1209,6 +1537,20 @@ func (g *GruesomeCoach) GetValue() string {
 
 func (g *GruesomeCoach) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GruesomeCoach) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (g *GruesomeCoach) SetValue(value string) {
+	g.Value = value
+	g.require(gruesomeCoachFieldValue)
 }
 
 func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
@@ -1226,6 +1568,17 @@ func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GruesomeCoach) MarshalJSON() ([]byte, error) {
+	type embed GruesomeCoach
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GruesomeCoach) String() string {
 	if value, err := internal.StringifyJSON(g); err == nil {
 		return value
@@ -1233,8 +1586,15 @@ func (g *GruesomeCoach) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	harmoniousPlayFieldValue = big.NewInt(1 << 0)
+)
+
 type HarmoniousPlay struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1248,6 +1608,20 @@ func (h *HarmoniousPlay) GetValue() string {
 
 func (h *HarmoniousPlay) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HarmoniousPlay) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (h *HarmoniousPlay) SetValue(value string) {
+	h.Value = value
+	h.require(harmoniousPlayFieldValue)
 }
 
 func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
@@ -1265,6 +1639,17 @@ func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HarmoniousPlay) MarshalJSON() ([]byte, error) {
+	type embed HarmoniousPlay
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HarmoniousPlay) String() string {
 	if value, err := internal.StringifyJSON(h); err == nil {
 		return value
@@ -1272,8 +1657,15 @@ func (h *HarmoniousPlay) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hastyPainFieldValue = big.NewInt(1 << 0)
+)
+
 type HastyPain struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1287,6 +1679,20 @@ func (h *HastyPain) GetValue() string {
 
 func (h *HastyPain) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HastyPain) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (h *HastyPain) SetValue(value string) {
+	h.Value = value
+	h.require(hastyPainFieldValue)
 }
 
 func (h *HastyPain) UnmarshalJSON(data []byte) error {
@@ -1304,6 +1710,17 @@ func (h *HastyPain) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HastyPain) MarshalJSON() ([]byte, error) {
+	type embed HastyPain
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HastyPain) String() string {
 	if value, err := internal.StringifyJSON(h); err == nil {
 		return value
@@ -1311,8 +1728,15 @@ func (h *HastyPain) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hoarseMouseFieldValue = big.NewInt(1 << 0)
+)
+
 type HoarseMouse struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1326,6 +1750,20 @@ func (h *HoarseMouse) GetValue() string {
 
 func (h *HoarseMouse) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HoarseMouse) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (h *HoarseMouse) SetValue(value string) {
+	h.Value = value
+	h.require(hoarseMouseFieldValue)
 }
 
 func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
@@ -1343,6 +1781,17 @@ func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HoarseMouse) MarshalJSON() ([]byte, error) {
+	type embed HoarseMouse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HoarseMouse) String() string {
 	if value, err := internal.StringifyJSON(h); err == nil {
 		return value
@@ -1350,8 +1799,15 @@ func (h *HoarseMouse) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	jumboEndFieldValue = big.NewInt(1 << 0)
+)
+
 type JumboEnd struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1365,6 +1821,20 @@ func (j *JumboEnd) GetValue() string {
 
 func (j *JumboEnd) GetExtraProperties() map[string]interface{} {
 	return j.extraProperties
+}
+
+func (j *JumboEnd) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (j *JumboEnd) SetValue(value string) {
+	j.Value = value
+	j.require(jumboEndFieldValue)
 }
 
 func (j *JumboEnd) UnmarshalJSON(data []byte) error {
@@ -1382,6 +1852,17 @@ func (j *JumboEnd) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (j *JumboEnd) MarshalJSON() ([]byte, error) {
+	type embed JumboEnd
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*j),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, j.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (j *JumboEnd) String() string {
 	if value, err := internal.StringifyJSON(j); err == nil {
 		return value
@@ -1389,8 +1870,15 @@ func (j *JumboEnd) String() string {
 	return fmt.Sprintf("%#v", j)
 }
 
+var (
+	limpingStepFieldValue = big.NewInt(1 << 0)
+)
+
 type LimpingStep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1404,6 +1892,20 @@ func (l *LimpingStep) GetValue() string {
 
 func (l *LimpingStep) GetExtraProperties() map[string]interface{} {
 	return l.extraProperties
+}
+
+func (l *LimpingStep) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (l *LimpingStep) SetValue(value string) {
+	l.Value = value
+	l.require(limpingStepFieldValue)
 }
 
 func (l *LimpingStep) UnmarshalJSON(data []byte) error {
@@ -1421,6 +1923,17 @@ func (l *LimpingStep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *LimpingStep) MarshalJSON() ([]byte, error) {
+	type embed LimpingStep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *LimpingStep) String() string {
 	if value, err := internal.StringifyJSON(l); err == nil {
 		return value
@@ -1428,8 +1941,15 @@ func (l *LimpingStep) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	mistySnowFieldValue = big.NewInt(1 << 0)
+)
+
 type MistySnow struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1443,6 +1963,20 @@ func (m *MistySnow) GetValue() string {
 
 func (m *MistySnow) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MistySnow) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (m *MistySnow) SetValue(value string) {
+	m.Value = value
+	m.require(mistySnowFieldValue)
 }
 
 func (m *MistySnow) UnmarshalJSON(data []byte) error {
@@ -1460,6 +1994,17 @@ func (m *MistySnow) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MistySnow) MarshalJSON() ([]byte, error) {
+	type embed MistySnow
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MistySnow) String() string {
 	if value, err := internal.StringifyJSON(m); err == nil {
 		return value
@@ -1467,8 +2012,15 @@ func (m *MistySnow) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	normalSweetFieldValue = big.NewInt(1 << 0)
+)
+
 type NormalSweet struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1482,6 +2034,20 @@ func (n *NormalSweet) GetValue() string {
 
 func (n *NormalSweet) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
+}
+
+func (n *NormalSweet) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (n *NormalSweet) SetValue(value string) {
+	n.Value = value
+	n.require(normalSweetFieldValue)
 }
 
 func (n *NormalSweet) UnmarshalJSON(data []byte) error {
@@ -1499,6 +2065,17 @@ func (n *NormalSweet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NormalSweet) MarshalJSON() ([]byte, error) {
+	type embed NormalSweet
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NormalSweet) String() string {
 	if value, err := internal.StringifyJSON(n); err == nil {
 		return value
@@ -1506,8 +2083,15 @@ func (n *NormalSweet) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	popularLimitFieldValue = big.NewInt(1 << 0)
+)
+
 type PopularLimit struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1521,6 +2105,20 @@ func (p *PopularLimit) GetValue() string {
 
 func (p *PopularLimit) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PopularLimit) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PopularLimit) SetValue(value string) {
+	p.Value = value
+	p.require(popularLimitFieldValue)
 }
 
 func (p *PopularLimit) UnmarshalJSON(data []byte) error {
@@ -1538,6 +2136,17 @@ func (p *PopularLimit) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PopularLimit) MarshalJSON() ([]byte, error) {
+	type embed PopularLimit
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PopularLimit) String() string {
 	if value, err := internal.StringifyJSON(p); err == nil {
 		return value
@@ -1545,8 +2154,15 @@ func (p *PopularLimit) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	potableBadFieldValue = big.NewInt(1 << 0)
+)
+
 type PotableBad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1560,6 +2176,20 @@ func (p *PotableBad) GetValue() string {
 
 func (p *PotableBad) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PotableBad) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PotableBad) SetValue(value string) {
+	p.Value = value
+	p.require(potableBadFieldValue)
 }
 
 func (p *PotableBad) UnmarshalJSON(data []byte) error {
@@ -1577,6 +2207,17 @@ func (p *PotableBad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PotableBad) MarshalJSON() ([]byte, error) {
+	type embed PotableBad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PotableBad) String() string {
 	if value, err := internal.StringifyJSON(p); err == nil {
 		return value
@@ -1584,8 +2225,15 @@ func (p *PotableBad) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	practicalPrincipleFieldValue = big.NewInt(1 << 0)
+)
+
 type PracticalPrinciple struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1599,6 +2247,20 @@ func (p *PracticalPrinciple) GetValue() string {
 
 func (p *PracticalPrinciple) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PracticalPrinciple) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PracticalPrinciple) SetValue(value string) {
+	p.Value = value
+	p.require(practicalPrincipleFieldValue)
 }
 
 func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
@@ -1616,6 +2278,17 @@ func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PracticalPrinciple) MarshalJSON() ([]byte, error) {
+	type embed PracticalPrinciple
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PracticalPrinciple) String() string {
 	if value, err := internal.StringifyJSON(p); err == nil {
 		return value
@@ -1623,8 +2296,15 @@ func (p *PracticalPrinciple) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	primaryBlockFieldValue = big.NewInt(1 << 0)
+)
+
 type PrimaryBlock struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1638,6 +2318,20 @@ func (p *PrimaryBlock) GetValue() string {
 
 func (p *PrimaryBlock) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PrimaryBlock) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (p *PrimaryBlock) SetValue(value string) {
+	p.Value = value
+	p.require(primaryBlockFieldValue)
 }
 
 func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
@@ -1655,6 +2349,17 @@ func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PrimaryBlock) MarshalJSON() ([]byte, error) {
+	type embed PrimaryBlock
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PrimaryBlock) String() string {
 	if value, err := internal.StringifyJSON(p); err == nil {
 		return value
@@ -1662,8 +2367,15 @@ func (p *PrimaryBlock) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	rotatingRatioFieldValue = big.NewInt(1 << 0)
+)
+
 type RotatingRatio struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1677,6 +2389,20 @@ func (r *RotatingRatio) GetValue() string {
 
 func (r *RotatingRatio) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RotatingRatio) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *RotatingRatio) SetValue(value string) {
+	r.Value = value
+	r.require(rotatingRatioFieldValue)
 }
 
 func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
@@ -1694,6 +2420,17 @@ func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RotatingRatio) MarshalJSON() ([]byte, error) {
+	type embed RotatingRatio
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RotatingRatio) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -1701,8 +2438,15 @@ func (r *RotatingRatio) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	thankfulFactorFieldValue = big.NewInt(1 << 0)
+)
+
 type ThankfulFactor struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1716,6 +2460,20 @@ func (t *ThankfulFactor) GetValue() string {
 
 func (t *ThankfulFactor) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *ThankfulFactor) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *ThankfulFactor) SetValue(value string) {
+	t.Value = value
+	t.require(thankfulFactorFieldValue)
 }
 
 func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
@@ -1733,6 +2491,17 @@ func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *ThankfulFactor) MarshalJSON() ([]byte, error) {
+	type embed ThankfulFactor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *ThankfulFactor) String() string {
 	if value, err := internal.StringifyJSON(t); err == nil {
 		return value
@@ -1740,8 +2509,15 @@ func (t *ThankfulFactor) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	totalWorkFieldValue = big.NewInt(1 << 0)
+)
+
 type TotalWork struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1755,6 +2531,20 @@ func (t *TotalWork) GetValue() string {
 
 func (t *TotalWork) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TotalWork) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TotalWork) SetValue(value string) {
+	t.Value = value
+	t.require(totalWorkFieldValue)
 }
 
 func (t *TotalWork) UnmarshalJSON(data []byte) error {
@@ -1772,6 +2562,17 @@ func (t *TotalWork) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TotalWork) MarshalJSON() ([]byte, error) {
+	type embed TotalWork
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TotalWork) String() string {
 	if value, err := internal.StringifyJSON(t); err == nil {
 		return value
@@ -1779,8 +2580,15 @@ func (t *TotalWork) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	triangularRepairFieldValue = big.NewInt(1 << 0)
+)
+
 type TriangularRepair struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1794,6 +2602,20 @@ func (t *TriangularRepair) GetValue() string {
 
 func (t *TriangularRepair) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TriangularRepair) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TriangularRepair) SetValue(value string) {
+	t.Value = value
+	t.require(triangularRepairFieldValue)
 }
 
 func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
@@ -1811,6 +2633,17 @@ func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TriangularRepair) MarshalJSON() ([]byte, error) {
+	type embed TriangularRepair
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TriangularRepair) String() string {
 	if value, err := internal.StringifyJSON(t); err == nil {
 		return value
@@ -1818,8 +2651,15 @@ func (t *TriangularRepair) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	uniqueStressFieldValue = big.NewInt(1 << 0)
+)
+
 type UniqueStress struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1833,6 +2673,20 @@ func (u *UniqueStress) GetValue() string {
 
 func (u *UniqueStress) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UniqueStress) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UniqueStress) SetValue(value string) {
+	u.Value = value
+	u.require(uniqueStressFieldValue)
 }
 
 func (u *UniqueStress) UnmarshalJSON(data []byte) error {
@@ -1850,6 +2704,17 @@ func (u *UniqueStress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UniqueStress) MarshalJSON() ([]byte, error) {
+	type embed UniqueStress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UniqueStress) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -1857,8 +2722,15 @@ func (u *UniqueStress) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	unwillingSmokeFieldValue = big.NewInt(1 << 0)
+)
+
 type UnwillingSmoke struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1872,6 +2744,20 @@ func (u *UnwillingSmoke) GetValue() string {
 
 func (u *UnwillingSmoke) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UnwillingSmoke) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UnwillingSmoke) SetValue(value string) {
+	u.Value = value
+	u.require(unwillingSmokeFieldValue)
 }
 
 func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
@@ -1889,6 +2775,17 @@ func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UnwillingSmoke) MarshalJSON() ([]byte, error) {
+	type embed UnwillingSmoke
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UnwillingSmoke) String() string {
 	if value, err := internal.StringifyJSON(u); err == nil {
 		return value
@@ -1896,8 +2793,15 @@ func (u *UnwillingSmoke) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	vibrantExcitementFieldValue = big.NewInt(1 << 0)
+)
+
 type VibrantExcitement struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -1913,6 +2817,20 @@ func (v *VibrantExcitement) GetExtraProperties() map[string]interface{} {
 	return v.extraProperties
 }
 
+func (v *VibrantExcitement) require(field *big.Int) {
+	if v.explicitFields == nil {
+		v.explicitFields = big.NewInt(0)
+	}
+	v.explicitFields.Or(v.explicitFields, field)
+}
+
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (v *VibrantExcitement) SetValue(value string) {
+	v.Value = value
+	v.require(vibrantExcitementFieldValue)
+}
+
 func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	type unmarshaler VibrantExcitement
 	var value unmarshaler
@@ -1926,6 +2844,17 @@ func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	}
 	v.extraProperties = extraProperties
 	return nil
+}
+
+func (v *VibrantExcitement) MarshalJSON() ([]byte, error) {
+	type embed VibrantExcitement
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*v),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, v.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (v *VibrantExcitement) String() string {

--- a/seed/go-fiber/unions/internal/explicit_fields.go
+++ b/seed/go-fiber/unions/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/unions/internal/explicit_fields_test.go
+++ b/seed/go-fiber/unions/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/unions/union.go
+++ b/seed/go-fiber/unions/union.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/unions/fern/internal"
+	big "math/big"
+)
+
+var (
+	circleFieldRadius = big.NewInt(1 << 0)
 )
 
 type Circle struct {
 	Radius float64 `json:"radius" url:"radius"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -23,6 +31,20 @@ func (c *Circle) GetRadius() float64 {
 
 func (c *Circle) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *Circle) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+// SetRadius sets the Radius field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (c *Circle) SetRadius(radius float64) {
+	c.Radius = radius
+	c.require(circleFieldRadius)
 }
 
 func (c *Circle) UnmarshalJSON(data []byte) error {
@@ -40,6 +62,17 @@ func (c *Circle) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Circle) MarshalJSON() ([]byte, error) {
+	type embed Circle
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Circle) String() string {
 	if value, err := internal.StringifyJSON(c); err == nil {
 		return value
@@ -47,8 +80,15 @@ func (c *Circle) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	getShapeRequestFieldId = big.NewInt(1 << 0)
+)
+
 type GetShapeRequest struct {
 	Id string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -64,6 +104,20 @@ func (g *GetShapeRequest) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
 }
 
+func (g *GetShapeRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (g *GetShapeRequest) SetId(id string) {
+	g.Id = id
+	g.require(getShapeRequestFieldId)
+}
+
 func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler GetShapeRequest
 	var value unmarshaler
@@ -77,6 +131,17 @@ func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	}
 	g.extraProperties = extraProperties
 	return nil
+}
+
+func (g *GetShapeRequest) MarshalJSON() ([]byte, error) {
+	type embed GetShapeRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (g *GetShapeRequest) String() string {
@@ -223,8 +288,15 @@ func (s *Shape) validate() error {
 	return nil
 }
 
+var (
+	squareFieldLength = big.NewInt(1 << 0)
+)
+
 type Square struct {
 	Length float64 `json:"length" url:"length"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -238,6 +310,20 @@ func (s *Square) GetLength() float64 {
 
 func (s *Square) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
+}
+
+func (s *Square) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *Square) SetLength(length float64) {
+	s.Length = length
+	s.require(squareFieldLength)
 }
 
 func (s *Square) UnmarshalJSON(data []byte) error {
@@ -255,6 +341,17 @@ func (s *Square) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *Square) MarshalJSON() ([]byte, error) {
+	type embed Square
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *Square) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -262,8 +359,15 @@ func (s *Square) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	withNameFieldName = big.NewInt(1 << 0)
+)
+
 type WithName struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -279,6 +383,20 @@ func (w *WithName) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
 }
 
+func (w *WithName) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (w *WithName) SetName(name string) {
+	w.Name = name
+	w.require(withNameFieldName)
+}
+
 func (w *WithName) UnmarshalJSON(data []byte) error {
 	type unmarshaler WithName
 	var value unmarshaler
@@ -292,6 +410,17 @@ func (w *WithName) UnmarshalJSON(data []byte) error {
 	}
 	w.extraProperties = extraProperties
 	return nil
+}
+
+func (w *WithName) MarshalJSON() ([]byte, error) {
+	type embed WithName
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (w *WithName) String() string {

--- a/seed/go-fiber/unknown/internal/explicit_fields.go
+++ b/seed/go-fiber/unknown/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/unknown/internal/explicit_fields_test.go
+++ b/seed/go-fiber/unknown/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/validation/internal/explicit_fields.go
+++ b/seed/go-fiber/validation/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/validation/internal/explicit_fields_test.go
+++ b/seed/go-fiber/validation/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/variables/internal/explicit_fields.go
+++ b/seed/go-fiber/variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/variables/internal/explicit_fields_test.go
+++ b/seed/go-fiber/variables/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/version-no-default/internal/explicit_fields.go
+++ b/seed/go-fiber/version-no-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/version-no-default/internal/explicit_fields_test.go
+++ b/seed/go-fiber/version-no-default/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/version-no-default/user.go
+++ b/seed/go-fiber/version-no-default/user.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/version-no-default/fern/internal"
+	big "math/big"
+)
+
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
 )
 
 type User struct {
 	Id   UserId `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id UserId) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -46,6 +76,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/version/internal/explicit_fields.go
+++ b/seed/go-fiber/version/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/version/internal/explicit_fields_test.go
+++ b/seed/go-fiber/version/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/version/user.go
+++ b/seed/go-fiber/version/user.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/version/fern/internal"
+	big "math/big"
+)
+
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
 )
 
 type User struct {
 	Id   UserId `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id UserId) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -46,6 +76,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	}
 	u.extraProperties = extraProperties
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-fiber/websocket-bearer-auth/internal/explicit_fields.go
+++ b/seed/go-fiber/websocket-bearer-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/websocket-bearer-auth/internal/explicit_fields_test.go
+++ b/seed/go-fiber/websocket-bearer-auth/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/websocket-bearer-auth/realtime.go
+++ b/seed/go-fiber/websocket-bearer-auth/realtime.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket-bearer-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	receiveEventFieldAlpha = big.NewInt(1 << 0)
+	receiveEventFieldBeta  = big.NewInt(1 << 1)
 )
 
 type ReceiveEvent struct {
 	Alpha string `json:"alpha" url:"alpha"`
 	Beta  int    `json:"beta" url:"beta"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (r *ReceiveEvent) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetAlpha sets the Alpha field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent) SetAlpha(alpha string) {
+	r.Alpha = alpha
+	r.require(receiveEventFieldAlpha)
+}
+
+// SetBeta sets the Beta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent) SetBeta(beta int) {
+	r.Beta = beta
+	r.require(receiveEventFieldBeta)
+}
+
 func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent
 	var value unmarshaler
@@ -48,6 +78,17 @@ func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -55,10 +96,19 @@ func (r *ReceiveEvent) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent2FieldGamma   = big.NewInt(1 << 0)
+	receiveEvent2FieldDelta   = big.NewInt(1 << 1)
+	receiveEvent2FieldEpsilon = big.NewInt(1 << 2)
+)
+
 type ReceiveEvent2 struct {
 	Gamma   string `json:"gamma" url:"gamma"`
 	Delta   int    `json:"delta" url:"delta"`
 	Epsilon bool   `json:"epsilon" url:"epsilon"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -88,6 +138,34 @@ func (r *ReceiveEvent2) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent2) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetGamma sets the Gamma field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetGamma(gamma string) {
+	r.Gamma = gamma
+	r.require(receiveEvent2FieldGamma)
+}
+
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetDelta(delta int) {
+	r.Delta = delta
+	r.require(receiveEvent2FieldDelta)
+}
+
+// SetEpsilon sets the Epsilon field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
+	r.Epsilon = epsilon
+	r.require(receiveEvent2FieldEpsilon)
+}
+
 func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent2
 	var value unmarshaler
@@ -103,6 +181,17 @@ func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent2) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent2) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -110,8 +199,15 @@ func (r *ReceiveEvent2) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent3FieldReceiveText3 = big.NewInt(1 << 0)
+)
+
 type ReceiveEvent3 struct {
 	ReceiveText3 string `json:"receiveText3" url:"receiveText3"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -125,6 +221,20 @@ func (r *ReceiveEvent3) GetReceiveText3() string {
 
 func (r *ReceiveEvent3) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ReceiveEvent3) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetReceiveText3 sets the ReceiveText3 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
+	r.ReceiveText3 = receiveText3
+	r.require(receiveEvent3FieldReceiveText3)
 }
 
 func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
@@ -142,6 +252,17 @@ func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent3) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent3
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent3) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -149,9 +270,17 @@ func (r *ReceiveEvent3) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendEventFieldSendText  = big.NewInt(1 << 0)
+	sendEventFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendEvent struct {
 	SendText  string `json:"sendText" url:"sendText"`
 	SendParam int    `json:"sendParam" url:"sendParam"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -174,6 +303,27 @@ func (s *SendEvent) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendEventFieldSendText)
+}
+
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendEventFieldSendParam)
+}
+
 func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent
 	var value unmarshaler
@@ -189,6 +339,17 @@ func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent) MarshalJSON() ([]byte, error) {
+	type embed SendEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -196,9 +357,17 @@ func (s *SendEvent) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	sendEvent2FieldSendText2  = big.NewInt(1 << 0)
+	sendEvent2FieldSendParam2 = big.NewInt(1 << 1)
+)
+
 type SendEvent2 struct {
 	SendText2  string `json:"sendText2" url:"sendText2"`
 	SendParam2 bool   `json:"sendParam2" url:"sendParam2"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -221,6 +390,27 @@ func (s *SendEvent2) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent2) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText2 sets the SendText2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent2) SetSendText2(sendText2 string) {
+	s.SendText2 = sendText2
+	s.require(sendEvent2FieldSendText2)
+}
+
+// SetSendParam2 sets the SendParam2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
+	s.SendParam2 = sendParam2
+	s.require(sendEvent2FieldSendParam2)
+}
+
 func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent2
 	var value unmarshaler
@@ -236,6 +426,17 @@ func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent2) MarshalJSON() ([]byte, error) {
+	type embed SendEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent2) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -243,9 +444,17 @@ func (s *SendEvent2) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	receiveSnakeCaseFieldReceiveText = big.NewInt(1 << 0)
+	receiveSnakeCaseFieldReceiveInt  = big.NewInt(1 << 1)
+)
+
 type ReceiveSnakeCase struct {
 	ReceiveText string `json:"receive_text" url:"receive_text"`
 	ReceiveInt  int    `json:"receive_int" url:"receive_int"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -268,6 +477,27 @@ func (r *ReceiveSnakeCase) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveSnakeCase) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetReceiveText sets the ReceiveText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
+	r.ReceiveText = receiveText
+	r.require(receiveSnakeCaseFieldReceiveText)
+}
+
+// SetReceiveInt sets the ReceiveInt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
+	r.ReceiveInt = receiveInt
+	r.require(receiveSnakeCaseFieldReceiveInt)
+}
+
 func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveSnakeCase
 	var value unmarshaler
@@ -283,6 +513,17 @@ func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed ReceiveSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveSnakeCase) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -290,9 +531,17 @@ func (r *ReceiveSnakeCase) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendSnakeCaseFieldSendText  = big.NewInt(1 << 0)
+	sendSnakeCaseFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendSnakeCase struct {
 	SendText  string `json:"send_text" url:"send_text"`
 	SendParam int    `json:"send_param" url:"send_param"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -315,6 +564,27 @@ func (s *SendSnakeCase) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendSnakeCase) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendSnakeCase) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendSnakeCaseFieldSendText)
+}
+
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendSnakeCase) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendSnakeCaseFieldSendParam)
+}
+
 func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendSnakeCase
 	var value unmarshaler
@@ -328,6 +598,17 @@ func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *SendSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed SendSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SendSnakeCase) String() string {

--- a/seed/go-fiber/websocket-inferred-auth/auth.go
+++ b/seed/go-fiber/websocket-inferred-auth/auth.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket-inferred-auth/fern/internal"
+	big "math/big"
 )
 
 type GetTokenRequest struct {
@@ -96,9 +97,17 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 1)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -121,6 +130,27 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -134,6 +164,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	}
 	t.extraProperties = extraProperties
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-fiber/websocket-inferred-auth/internal/explicit_fields.go
+++ b/seed/go-fiber/websocket-inferred-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/websocket-inferred-auth/internal/explicit_fields_test.go
+++ b/seed/go-fiber/websocket-inferred-auth/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/websocket-inferred-auth/realtime.go
+++ b/seed/go-fiber/websocket-inferred-auth/realtime.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket-inferred-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	receiveEventFieldAlpha = big.NewInt(1 << 0)
+	receiveEventFieldBeta  = big.NewInt(1 << 1)
 )
 
 type ReceiveEvent struct {
 	Alpha string `json:"alpha" url:"alpha"`
 	Beta  int    `json:"beta" url:"beta"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (r *ReceiveEvent) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetAlpha sets the Alpha field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent) SetAlpha(alpha string) {
+	r.Alpha = alpha
+	r.require(receiveEventFieldAlpha)
+}
+
+// SetBeta sets the Beta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent) SetBeta(beta int) {
+	r.Beta = beta
+	r.require(receiveEventFieldBeta)
+}
+
 func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent
 	var value unmarshaler
@@ -48,6 +78,17 @@ func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -55,10 +96,19 @@ func (r *ReceiveEvent) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent2FieldGamma   = big.NewInt(1 << 0)
+	receiveEvent2FieldDelta   = big.NewInt(1 << 1)
+	receiveEvent2FieldEpsilon = big.NewInt(1 << 2)
+)
+
 type ReceiveEvent2 struct {
 	Gamma   string `json:"gamma" url:"gamma"`
 	Delta   int    `json:"delta" url:"delta"`
 	Epsilon bool   `json:"epsilon" url:"epsilon"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -88,6 +138,34 @@ func (r *ReceiveEvent2) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent2) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetGamma sets the Gamma field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetGamma(gamma string) {
+	r.Gamma = gamma
+	r.require(receiveEvent2FieldGamma)
+}
+
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetDelta(delta int) {
+	r.Delta = delta
+	r.require(receiveEvent2FieldDelta)
+}
+
+// SetEpsilon sets the Epsilon field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
+	r.Epsilon = epsilon
+	r.require(receiveEvent2FieldEpsilon)
+}
+
 func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent2
 	var value unmarshaler
@@ -103,6 +181,17 @@ func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent2) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent2) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -110,8 +199,15 @@ func (r *ReceiveEvent2) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent3FieldReceiveText3 = big.NewInt(1 << 0)
+)
+
 type ReceiveEvent3 struct {
 	ReceiveText3 string `json:"receiveText3" url:"receiveText3"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -125,6 +221,20 @@ func (r *ReceiveEvent3) GetReceiveText3() string {
 
 func (r *ReceiveEvent3) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ReceiveEvent3) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetReceiveText3 sets the ReceiveText3 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
+	r.ReceiveText3 = receiveText3
+	r.require(receiveEvent3FieldReceiveText3)
 }
 
 func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
@@ -142,6 +252,17 @@ func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent3) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent3
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent3) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -149,9 +270,17 @@ func (r *ReceiveEvent3) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendEventFieldSendText  = big.NewInt(1 << 0)
+	sendEventFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendEvent struct {
 	SendText  string `json:"sendText" url:"sendText"`
 	SendParam int    `json:"sendParam" url:"sendParam"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -174,6 +303,27 @@ func (s *SendEvent) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendEventFieldSendText)
+}
+
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendEventFieldSendParam)
+}
+
 func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent
 	var value unmarshaler
@@ -189,6 +339,17 @@ func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent) MarshalJSON() ([]byte, error) {
+	type embed SendEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -196,9 +357,17 @@ func (s *SendEvent) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	sendEvent2FieldSendText2  = big.NewInt(1 << 0)
+	sendEvent2FieldSendParam2 = big.NewInt(1 << 1)
+)
+
 type SendEvent2 struct {
 	SendText2  string `json:"sendText2" url:"sendText2"`
 	SendParam2 bool   `json:"sendParam2" url:"sendParam2"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -221,6 +390,27 @@ func (s *SendEvent2) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent2) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText2 sets the SendText2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent2) SetSendText2(sendText2 string) {
+	s.SendText2 = sendText2
+	s.require(sendEvent2FieldSendText2)
+}
+
+// SetSendParam2 sets the SendParam2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
+	s.SendParam2 = sendParam2
+	s.require(sendEvent2FieldSendParam2)
+}
+
 func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent2
 	var value unmarshaler
@@ -236,6 +426,17 @@ func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent2) MarshalJSON() ([]byte, error) {
+	type embed SendEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent2) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -243,9 +444,17 @@ func (s *SendEvent2) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	receiveSnakeCaseFieldReceiveText = big.NewInt(1 << 0)
+	receiveSnakeCaseFieldReceiveInt  = big.NewInt(1 << 1)
+)
+
 type ReceiveSnakeCase struct {
 	ReceiveText string `json:"receive_text" url:"receive_text"`
 	ReceiveInt  int    `json:"receive_int" url:"receive_int"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -268,6 +477,27 @@ func (r *ReceiveSnakeCase) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveSnakeCase) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetReceiveText sets the ReceiveText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
+	r.ReceiveText = receiveText
+	r.require(receiveSnakeCaseFieldReceiveText)
+}
+
+// SetReceiveInt sets the ReceiveInt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
+	r.ReceiveInt = receiveInt
+	r.require(receiveSnakeCaseFieldReceiveInt)
+}
+
 func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveSnakeCase
 	var value unmarshaler
@@ -283,6 +513,17 @@ func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed ReceiveSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveSnakeCase) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -290,9 +531,17 @@ func (r *ReceiveSnakeCase) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendSnakeCaseFieldSendText  = big.NewInt(1 << 0)
+	sendSnakeCaseFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendSnakeCase struct {
 	SendText  string `json:"send_text" url:"send_text"`
 	SendParam int    `json:"send_param" url:"send_param"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -315,6 +564,27 @@ func (s *SendSnakeCase) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendSnakeCase) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendSnakeCase) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendSnakeCaseFieldSendText)
+}
+
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendSnakeCase) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendSnakeCaseFieldSendParam)
+}
+
 func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendSnakeCase
 	var value unmarshaler
@@ -328,6 +598,17 @@ func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *SendSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed SendSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SendSnakeCase) String() string {

--- a/seed/go-fiber/websocket/internal/explicit_fields.go
+++ b/seed/go-fiber/websocket/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-fiber/websocket/internal/explicit_fields_test.go
+++ b/seed/go-fiber/websocket/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-fiber/websocket/realtime.go
+++ b/seed/go-fiber/websocket/realtime.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket/fern/internal"
+	big "math/big"
+)
+
+var (
+	receiveEventFieldAlpha = big.NewInt(1 << 0)
+	receiveEventFieldBeta  = big.NewInt(1 << 1)
 )
 
 type ReceiveEvent struct {
 	Alpha string `json:"alpha" url:"alpha"`
 	Beta  int    `json:"beta" url:"beta"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -33,6 +42,27 @@ func (r *ReceiveEvent) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetAlpha sets the Alpha field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent) SetAlpha(alpha string) {
+	r.Alpha = alpha
+	r.require(receiveEventFieldAlpha)
+}
+
+// SetBeta sets the Beta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent) SetBeta(beta int) {
+	r.Beta = beta
+	r.require(receiveEventFieldBeta)
+}
+
 func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent
 	var value unmarshaler
@@ -48,6 +78,17 @@ func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -55,10 +96,19 @@ func (r *ReceiveEvent) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent2FieldGamma   = big.NewInt(1 << 0)
+	receiveEvent2FieldDelta   = big.NewInt(1 << 1)
+	receiveEvent2FieldEpsilon = big.NewInt(1 << 2)
+)
+
 type ReceiveEvent2 struct {
 	Gamma   string `json:"gamma" url:"gamma"`
 	Delta   int    `json:"delta" url:"delta"`
 	Epsilon bool   `json:"epsilon" url:"epsilon"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -88,6 +138,34 @@ func (r *ReceiveEvent2) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent2) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetGamma sets the Gamma field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetGamma(gamma string) {
+	r.Gamma = gamma
+	r.require(receiveEvent2FieldGamma)
+}
+
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetDelta(delta int) {
+	r.Delta = delta
+	r.require(receiveEvent2FieldDelta)
+}
+
+// SetEpsilon sets the Epsilon field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
+	r.Epsilon = epsilon
+	r.require(receiveEvent2FieldEpsilon)
+}
+
 func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent2
 	var value unmarshaler
@@ -103,6 +181,17 @@ func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent2) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent2) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -110,8 +199,15 @@ func (r *ReceiveEvent2) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent3FieldReceiveText3 = big.NewInt(1 << 0)
+)
+
 type ReceiveEvent3 struct {
 	ReceiveText3 string `json:"receiveText3" url:"receiveText3"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -125,6 +221,20 @@ func (r *ReceiveEvent3) GetReceiveText3() string {
 
 func (r *ReceiveEvent3) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ReceiveEvent3) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetReceiveText3 sets the ReceiveText3 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
+	r.ReceiveText3 = receiveText3
+	r.require(receiveEvent3FieldReceiveText3)
 }
 
 func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
@@ -142,6 +252,17 @@ func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent3) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent3
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent3) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -149,9 +270,17 @@ func (r *ReceiveEvent3) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendEventFieldSendText  = big.NewInt(1 << 0)
+	sendEventFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendEvent struct {
 	SendText  string `json:"sendText" url:"sendText"`
 	SendParam int    `json:"sendParam" url:"sendParam"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -174,6 +303,27 @@ func (s *SendEvent) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendEventFieldSendText)
+}
+
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendEventFieldSendParam)
+}
+
 func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent
 	var value unmarshaler
@@ -189,6 +339,17 @@ func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent) MarshalJSON() ([]byte, error) {
+	type embed SendEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -196,9 +357,17 @@ func (s *SendEvent) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	sendEvent2FieldSendText2  = big.NewInt(1 << 0)
+	sendEvent2FieldSendParam2 = big.NewInt(1 << 1)
+)
+
 type SendEvent2 struct {
 	SendText2  string `json:"sendText2" url:"sendText2"`
 	SendParam2 bool   `json:"sendParam2" url:"sendParam2"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -221,6 +390,27 @@ func (s *SendEvent2) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent2) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText2 sets the SendText2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent2) SetSendText2(sendText2 string) {
+	s.SendText2 = sendText2
+	s.require(sendEvent2FieldSendText2)
+}
+
+// SetSendParam2 sets the SendParam2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
+	s.SendParam2 = sendParam2
+	s.require(sendEvent2FieldSendParam2)
+}
+
 func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent2
 	var value unmarshaler
@@ -236,6 +426,17 @@ func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent2) MarshalJSON() ([]byte, error) {
+	type embed SendEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent2) String() string {
 	if value, err := internal.StringifyJSON(s); err == nil {
 		return value
@@ -243,9 +444,17 @@ func (s *SendEvent2) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	receiveSnakeCaseFieldReceiveText = big.NewInt(1 << 0)
+	receiveSnakeCaseFieldReceiveInt  = big.NewInt(1 << 1)
+)
+
 type ReceiveSnakeCase struct {
 	ReceiveText string `json:"receive_text" url:"receive_text"`
 	ReceiveInt  int    `json:"receive_int" url:"receive_int"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -268,6 +477,27 @@ func (r *ReceiveSnakeCase) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveSnakeCase) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+// SetReceiveText sets the ReceiveText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
+	r.ReceiveText = receiveText
+	r.require(receiveSnakeCaseFieldReceiveText)
+}
+
+// SetReceiveInt sets the ReceiveInt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
+	r.ReceiveInt = receiveInt
+	r.require(receiveSnakeCaseFieldReceiveInt)
+}
+
 func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveSnakeCase
 	var value unmarshaler
@@ -283,6 +513,17 @@ func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed ReceiveSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveSnakeCase) String() string {
 	if value, err := internal.StringifyJSON(r); err == nil {
 		return value
@@ -290,9 +531,17 @@ func (r *ReceiveSnakeCase) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendSnakeCaseFieldSendText  = big.NewInt(1 << 0)
+	sendSnakeCaseFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendSnakeCase struct {
 	SendText  string `json:"send_text" url:"send_text"`
 	SendParam int    `json:"send_param" url:"send_param"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 }
@@ -315,6 +564,27 @@ func (s *SendSnakeCase) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendSnakeCase) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendSnakeCase) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendSnakeCaseFieldSendText)
+}
+
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (s *SendSnakeCase) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendSnakeCaseFieldSendParam)
+}
+
 func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendSnakeCase
 	var value unmarshaler
@@ -328,6 +598,17 @@ func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	}
 	s.extraProperties = extraProperties
 	return nil
+}
+
+func (s *SendSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed SendSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SendSnakeCase) String() string {

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/explicit_fields.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/explicit_fields_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/property-access/internal/explicit_fields.go
+++ b/seed/go-sdk/property-access/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/property-access/internal/explicit_fields_test.go
+++ b/seed/go-sdk/property-access/internal/explicit_fields_test.go
@@ -1,0 +1,496 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Test types for nested struct explicit fields testing
+type testNestedStruct struct {
+	NestedName     *string `json:"nested_name,omitempty"`
+	NestedCode     *string `json:"nested_code,omitempty"`
+	explicitFields *big.Int `json:"-"`
+}
+
+type testParentStruct struct {
+	ParentName     *string           `json:"parent_name,omitempty"`
+	Nested         *testNestedStruct `json:"nested,omitempty"`
+	explicitFields *big.Int          `json:"-"`
+}
+
+var (
+	nestedFieldName = big.NewInt(1 << 0)
+	nestedFieldCode = big.NewInt(1 << 1)
+)
+
+var (
+	parentFieldName   = big.NewInt(1 << 0)
+	parentFieldNested = big.NewInt(1 << 1)
+)
+
+func (n *testNestedStruct) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *testNestedStruct) SetNestedName(name *string) {
+	n.NestedName = name
+	n.require(nestedFieldName)
+}
+
+func (n *testNestedStruct) SetNestedCode(code *string) {
+	n.NestedCode = code
+	n.require(nestedFieldCode)
+}
+
+func (n *testNestedStruct) MarshalJSON() ([]byte, error) {
+	type embed testNestedStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, n.explicitFields))
+}
+
+func (p *testParentStruct) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *testParentStruct) SetParentName(name *string) {
+	p.ParentName = name
+	p.require(parentFieldName)
+}
+
+func (p *testParentStruct) SetNested(nested *testNestedStruct) {
+	p.Nested = nested
+	p.require(parentFieldNested)
+}
+
+func (p *testParentStruct) MarshalJSON() ([]byte, error) {
+	type embed testParentStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, p.explicitFields))
+}
+
+func TestHandleExplicitFieldsNestedStruct(t *testing.T) {
+	tests := []struct {
+		desc      string
+		setupFunc func() *testParentStruct
+		wantBytes []byte
+	}{
+		{
+			desc: "nested struct with explicit nil in nested object",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{
+					NestedName: stringPtr("implicit-nested"),
+				}
+				nested.SetNestedCode(nil) // explicit nil
+
+				return &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+					Nested:     nested,
+				}
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":{"nested_name":"implicit-nested","nested_code":null}}`),
+		},
+		{
+			desc: "parent with explicit nil nested struct",
+			setupFunc: func() *testParentStruct {
+				parent := &testParentStruct{
+					ParentName: stringPtr("implicit-parent"),
+				}
+				parent.SetNested(nil) // explicit nil nested struct
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":"implicit-parent","nested":null}`),
+		},
+		{
+			desc: "all explicit fields in nested structure",
+			setupFunc: func() *testParentStruct {
+				nested := &testNestedStruct{}
+				nested.SetNestedName(stringPtr("explicit-nested"))
+				nested.SetNestedCode(nil) // explicit nil
+
+				parent := &testParentStruct{}
+				parent.SetParentName(nil) // explicit nil
+				parent.SetNested(nested)  // explicit nested struct
+
+				return parent
+			},
+			wantBytes: []byte(`{"parent_name":null,"nested":{"nested_name":"explicit-nested","nested_code":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			parent := tt.setupFunc()
+			bytes, err := parent.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/property-access/types.go
+++ b/seed/go-sdk/property-access/types.go
@@ -6,9 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/property-access/fern/internal"
+	big "math/big"
 )
 
 // Admin user object
+var (
+	adminFieldId         = big.NewInt(1 << 0)
+	adminFieldEmail      = big.NewInt(1 << 1)
+	adminFieldPassword   = big.NewInt(1 << 2)
+	adminFieldProfile    = big.NewInt(1 << 3)
+	adminFieldAdminLevel = big.NewInt(1 << 4)
+)
+
 type Admin struct {
 	// The unique identifier for the user.
 	Id string `json:"id" url:"id"`
@@ -20,6 +29,9 @@ type Admin struct {
 	Profile *UserProfile `json:"profile" url:"profile"`
 	// The level of admin privileges.
 	AdminLevel string `json:"adminLevel" url:"adminLevel"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -64,6 +76,48 @@ func (a *Admin) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Admin) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Admin) SetId(id string) {
+	a.Id = id
+	a.require(adminFieldId)
+}
+
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Admin) SetEmail(email string) {
+	a.Email = email
+	a.require(adminFieldEmail)
+}
+
+// SetPassword sets the Password field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Admin) SetPassword(password string) {
+	a.Password = password
+	a.require(adminFieldPassword)
+}
+
+// SetProfile sets the Profile field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Admin) SetProfile(profile *UserProfile) {
+	a.Profile = profile
+	a.require(adminFieldProfile)
+}
+
+// SetAdminLevel sets the AdminLevel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (a *Admin) SetAdminLevel(adminLevel string) {
+	a.AdminLevel = adminLevel
+	a.require(adminFieldAdminLevel)
+}
+
 func (a *Admin) UnmarshalJSON(data []byte) error {
 	type unmarshaler Admin
 	var value unmarshaler
@@ -80,6 +134,17 @@ func (a *Admin) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Admin) MarshalJSON() ([]byte, error) {
+	type embed Admin
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Admin) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -92,10 +157,19 @@ func (a *Admin) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	fooFieldNormal = big.NewInt(1 << 0)
+	fooFieldRead   = big.NewInt(1 << 1)
+	fooFieldWrite  = big.NewInt(1 << 2)
+)
+
 type Foo struct {
 	Normal string `json:"normal" url:"normal"`
 	Read   string `json:"read" url:"read"`
 	Write  string `json:"write" url:"write"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -126,6 +200,34 @@ func (f *Foo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Foo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+// SetNormal sets the Normal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *Foo) SetNormal(normal string) {
+	f.Normal = normal
+	f.require(fooFieldNormal)
+}
+
+// SetRead sets the Read field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *Foo) SetRead(read string) {
+	f.Read = read
+	f.require(fooFieldRead)
+}
+
+// SetWrite sets the Write field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (f *Foo) SetWrite(write string) {
+	f.Write = write
+	f.require(fooFieldWrite)
+}
+
 func (f *Foo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Foo
 	var value unmarshaler
@@ -142,6 +244,17 @@ func (f *Foo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *Foo) MarshalJSON() ([]byte, error) {
+	type embed Foo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *Foo) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -155,6 +268,13 @@ func (f *Foo) String() string {
 }
 
 // User object
+var (
+	userFieldId       = big.NewInt(1 << 0)
+	userFieldEmail    = big.NewInt(1 << 1)
+	userFieldPassword = big.NewInt(1 << 2)
+	userFieldProfile  = big.NewInt(1 << 3)
+)
+
 type User struct {
 	// The unique identifier for the user.
 	Id string `json:"id" url:"id"`
@@ -164,6 +284,9 @@ type User struct {
 	Password string `json:"password" url:"password"`
 	// User profile object
 	Profile *UserProfile `json:"profile" url:"profile"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -201,6 +324,41 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetId(id string) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetEmail(email string) {
+	u.Email = email
+	u.require(userFieldEmail)
+}
+
+// SetPassword sets the Password field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetPassword(password string) {
+	u.Password = password
+	u.require(userFieldPassword)
+}
+
+// SetProfile sets the Profile field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *User) SetProfile(profile *UserProfile) {
+	u.Profile = profile
+	u.require(userFieldProfile)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -215,6 +373,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {
@@ -521,6 +690,12 @@ func (u *UserOrAdminDiscriminated) validate() error {
 }
 
 // User profile object
+var (
+	userProfileFieldName         = big.NewInt(1 << 0)
+	userProfileFieldVerification = big.NewInt(1 << 1)
+	userProfileFieldSsn          = big.NewInt(1 << 2)
+)
+
 type UserProfile struct {
 	// The name of the user.
 	Name string `json:"name" url:"name"`
@@ -528,6 +703,9 @@ type UserProfile struct {
 	Verification *UserProfileVerification `json:"verification" url:"verification"`
 	// The social security number of the user.
 	Ssn string `json:"ssn" url:"ssn"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -558,6 +736,34 @@ func (u *UserProfile) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserProfile) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserProfile) SetName(name string) {
+	u.Name = name
+	u.require(userProfileFieldName)
+}
+
+// SetVerification sets the Verification field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserProfile) SetVerification(verification *UserProfileVerification) {
+	u.Verification = verification
+	u.require(userProfileFieldVerification)
+}
+
+// SetSsn sets the Ssn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserProfile) SetSsn(ssn string) {
+	u.Ssn = ssn
+	u.require(userProfileFieldSsn)
+}
+
 func (u *UserProfile) UnmarshalJSON(data []byte) error {
 	type unmarshaler UserProfile
 	var value unmarshaler
@@ -574,6 +780,17 @@ func (u *UserProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserProfile) MarshalJSON() ([]byte, error) {
+	type embed UserProfile
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserProfile) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -587,9 +804,16 @@ func (u *UserProfile) String() string {
 }
 
 // User profile verification object
+var (
+	userProfileVerificationFieldVerified = big.NewInt(1 << 0)
+)
+
 type UserProfileVerification struct {
 	// User profile verification status
 	Verified string `json:"verified" url:"verified"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -606,6 +830,20 @@ func (u *UserProfileVerification) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserProfileVerification) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+// SetVerified sets the Verified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (u *UserProfileVerification) SetVerified(verified string) {
+	u.Verified = verified
+	u.require(userProfileVerificationFieldVerified)
+}
+
 func (u *UserProfileVerification) UnmarshalJSON(data []byte) error {
 	type unmarshaler UserProfileVerification
 	var value unmarshaler
@@ -620,6 +858,17 @@ func (u *UserProfileVerification) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *UserProfileVerification) MarshalJSON() ([]byte, error) {
+	type embed UserProfileVerification
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UserProfileVerification) String() string {

--- a/seed/go-sdk/unions/v0/union.go
+++ b/seed/go-sdk/unions/v0/union.go
@@ -390,8 +390,15 @@ func (s *Square) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	withNameFieldName = big.NewInt(1 << 0)
+)
+
 type WithName struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -408,6 +415,20 @@ func (w *WithName) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
 }
 
+func (w *WithName) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
+func (w *WithName) SetName(name string) {
+	w.Name = name
+	w.require(withNameFieldName)
+}
+
 func (w *WithName) UnmarshalJSON(data []byte) error {
 	type unmarshaler WithName
 	var value unmarshaler
@@ -422,6 +443,17 @@ func (w *WithName) UnmarshalJSON(data []byte) error {
 	w.extraProperties = extraProperties
 	w.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (w *WithName) MarshalJSON() ([]byte, error) {
+	type embed WithName
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (w *WithName) String() string {


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6497/ci-handle-seed-generation-and-update-at-pr-level-instead-of-merge
Added new workflow path for updating seed at the PR level instead of waiting for it to merge
Resolves FER-6497

## Changes Made
- Added two new flags, `create-artifacts` and `create-pr` in `auto-update-seed/action.yaml`. These are used to pick specific jobs depending on if we are using the legacy workflow (creating PRs after merge to main to update seed) or using the newly added workflow (committing directly to PR)
- Added repository_dispatch trigger to seed.yml, which will be used in later pushes
- Added setup job to update-seed.yml workflow to clean up some code downstream
- Added job to update-seed.yml to commit changes when creating in patch files via auto-update-seed action file
- Added job to trigger snapshot tests after commits are posted (needs further testing, will be used in later commits/PRs)

## Testing
Testing with CI, verified:
1. When PR trigger uncommented, seed will run and commit changes to PR that started the job
2. No errors when there are no changes to be committed
