### PR TITLE
fix(ci): Fix ruby-sdk and go-fiber jobs for updating seed

### DIFF
--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -83,8 +83,8 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: ruby-sdk
           generator-path: generators/ruby
@@ -323,8 +323,8 @@ jobs:
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
         with:
           generator-name: go-fiber
           generator-path: generators/go
@@ -362,6 +362,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
+
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:
@@ -441,6 +442,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.FERN_GITHUB_PAT }}
+
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
         with:


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6577/ci-fix-job-for-seed-updates-to-go-fiber-and-ruby-sdk
Closes FER-6577
Error from a previous change, want all jobs in update-seed workflow to call auto-update seed action, not the seed test action

## Changes Made
- Updated go-fiber job and ruby-sdk job to call correct action

## Testing
Verified already with other workflows, updated for ones that were updated incorrectly
