### PR TITLE
fix(ruby): Properly fall back to default environment if specified

### DIFF
--- a/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
@@ -37,7 +37,6 @@ export class RawClient {
             writer.write(" || ");
             writer.writeNode(this.context.getDefaultEnvironmentClassReference());
         }
-        writer.writeNewLineIfLastLineNot();
     }
 
     public sendRequest({

--- a/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
@@ -30,6 +30,16 @@ export class RawClient {
         this.context = context;
     }
 
+    private writeBaseUrlDeclaration(writer: ruby.Writer): void {
+        // Write base URL declaration, including default environment if specified
+        writer.write("base_url: request_options[:base_url]");
+        if (this.context.ir.environments?.defaultEnvironment != null) {
+            writer.write(" || ");
+            writer.writeNode(this.context.getDefaultEnvironmentClassReference());
+        }
+        writer.writeNewLineIfLastLineNot();
+    }
+
     public sendRequest({
         baseUrl,
         endpoint,
@@ -46,9 +56,8 @@ export class RawClient {
                         `${RAW_CLIENT_REQUEST_VARIABLE_NAME} = ${this.context.getReferenceToInternalJSONRequest()}.new(`
                     );
                     writer.indent();
-                    writer.writeLine(
-                        `base_url: request_options[:base_url] || ${this.context.getEnvironmentsClassReference().toString()}::SANDBOX,`
-                    );
+                    this.writeBaseUrlDeclaration(writer);
+                    writer.writeLine(",");
                     writer.writeLine(`method: "${endpoint.method.toUpperCase()}",`);
                     writer.write(`path: `);
                     this.writePathString({ writer, endpoint, pathParameterReferences });
@@ -95,9 +104,8 @@ export class RawClient {
                 `${RAW_CLIENT_REQUEST_VARIABLE_NAME} = ${this.context.getReferenceToInternalJSONRequest()}.new(`
             );
             writer.indent();
-            writer.writeLine(
-                `base_url: request_options[:base_url] || ${this.context.getEnvironmentsClassReference().toString()}::SANDBOX,`
-            );
+            this.writeBaseUrlDeclaration(writer);
+            writer.writeLine(",");
             writer.writeLine(`method: "${endpoint.method.toUpperCase()}",`);
             writer.write(`path: `);
             this.writePathString({ writer, endpoint, pathParameterReferences });

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc23
+  createdAt: "2025-09-16"
+  changelogEntry:
+    - type: fix
+      summary: Properly fall back to default environment if specified.
+  irVersion: 58
 
 - version: 1.0.0-rc22
   createdAt: "2025-09-15"

--- a/seed/ruby-sdk-v2/accept-header/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/accept-header/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -8,21 +9,17 @@ module Seed
       end
 
       # @return [untyped]
-      def endpoint(request_options: {}, **params)
+      def endpoint(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "DELETE",
           path: "/container/"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/accept-header/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/accept-header/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -9,17 +8,21 @@ module Seed
       end
 
       # @return [untyped]
-      def endpoint(request_options: {}, **_params)
+      def endpoint(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "DELETE",
           path: "/container/"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/user/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Array[Seed::User::Types::User]]
       def get(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "users"
         )

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -10,19 +11,15 @@ module Seed
       # @return [untyped]
       def post(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/test/#{params[:pathParam]}/#{params[:serviceParam]}/#{params[:endpointParam]}/#{params[:resourceParam]}"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -11,15 +10,19 @@ module Seed
       # @return [untyped]
       def post(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/test/#{params[:pathParam]}/#{params[:serviceParam]}/#{params[:endpointParam]}/#{params[:resourceParam]}"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/audiences/lib/seed/folder_a/service/client.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/folder_a/service/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::FolderA::Service::Types::Response]
         def get_direct_thread(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: ""
           )

--- a/seed/ruby-sdk-v2/audiences/lib/seed/folder_d/service/client.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/folder_d/service/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::FolderD::Service::Types::Response]
         def get_direct_thread(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/partner-path"
           )

--- a/seed/ruby-sdk-v2/audiences/lib/seed/foo/client.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/foo/client.rb
@@ -18,7 +18,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "",
           query: _query,

--- a/seed/ruby-sdk-v2/auth-environment-variables/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/auth-environment-variables/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -11,32 +10,39 @@ module Seed
       # GET request with custom api key
       #
       # @return [String]
-      def get_with_api_key(request_options: {}, **_params)
+      def get_with_api_key(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "apiKey"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # GET request with custom api key
       #
       # @return [String]
-      def get_with_header(request_options: {}, **_params)
+      def get_with_header(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
-          path: "apiKeyInHeader"
+          path: "apiKeyInHeader",
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/auth-environment-variables/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/auth-environment-variables/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -10,39 +11,32 @@ module Seed
       # GET request with custom api key
       #
       # @return [String]
-      def get_with_api_key(request_options: {}, **params)
+      def get_with_api_key(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "apiKey"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # GET request with custom api key
       #
       # @return [String]
-      def get_with_header(request_options: {}, **params)
+      def get_with_header(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
-          path: "apiKeyInHeader",
+          path: "apiKeyInHeader"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/basic_auth/client.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/basic_auth/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [bool]
       def get_with_basic_auth(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "basic-auth"
         )
@@ -28,7 +28,7 @@ module Seed
       # @return [bool]
       def post_with_basic_auth(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "basic-auth",
           body: params

--- a/seed/ruby-sdk-v2/basic-auth/lib/seed/basic_auth/client.rb
+++ b/seed/ruby-sdk-v2/basic-auth/lib/seed/basic_auth/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [bool]
       def get_with_basic_auth(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "basic-auth"
         )
@@ -28,7 +28,7 @@ module Seed
       # @return [bool]
       def post_with_basic_auth(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "basic-auth",
           body: params

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -11,17 +10,21 @@ module Seed
       # GET request with custom api key
       #
       # @return [String]
-      def get_with_bearer_token(request_options: {}, **_params)
+      def get_with_bearer_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "apiKey"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -10,21 +11,17 @@ module Seed
       # GET request with custom api key
       #
       # @return [String]
-      def get_with_bearer_token(request_options: {}, **params)
+      def get_with_bearer_token(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "apiKey"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -11,15 +10,18 @@ module Seed
       # @return [untyped]
       def download(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "download-content/#{params[:id]}"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -10,18 +11,15 @@ module Seed
       # @return [untyped]
       def download(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "download-content/#{params[:id]}"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/bytes-upload/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -8,21 +9,17 @@ module Seed
       end
 
       # @return [untyped]
-      def upload(request_options: {}, **params)
+      def upload(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "upload-content"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/bytes-upload/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -9,17 +8,21 @@ module Seed
       end
 
       # @return [untyped]
-      def upload(request_options: {}, **_params)
+      def upload(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "upload-content"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/client-side-params/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/client-side-params/lib/seed/service/client.rb
@@ -20,7 +20,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/resources",
           query: _query
@@ -43,7 +43,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/resources/#{params[:resourceId]}",
           query: _query
@@ -66,7 +66,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/api/resources/search",
           query: _query,
@@ -92,7 +92,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/users",
           query: _query
@@ -117,7 +117,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/users/#{params[:userId]}",
           query: _query
@@ -133,7 +133,7 @@ module Seed
       # @return [Seed::Types::Types::User]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/api/users",
           body: Seed::Types::Types::CreateUserRequest.new(params).to_h
@@ -149,7 +149,7 @@ module Seed
       # @return [Seed::Types::Types::User]
       def update_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "/api/users/#{params[:userId]}",
           body: Seed::Types::Types::UpdateUserRequest.new(params).to_h
@@ -165,7 +165,7 @@ module Seed
       # @return [untyped]
       def delete_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "DELETE",
           path: "/api/users/#{params[:userId]}"
         )
@@ -187,7 +187,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/connections",
           query: _query
@@ -210,7 +210,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/connections/#{params[:connectionId]}",
           query: _query
@@ -233,7 +233,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/clients",
           query: _query
@@ -258,7 +258,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/clients/#{params[:clientId]}",
           query: _query

--- a/seed/ruby-sdk-v2/content-type/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -11,15 +10,18 @@ module Seed
       # @return [untyped]
       def patch(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PATCH",
           path: "",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # Update with JSON merge patch - complex types.
@@ -32,15 +34,18 @@ module Seed
         _path_param_names = ["id"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PATCH",
           path: "complex/#{params[:id]}",
-          body: params.except(*_path_param_names)
+          body: params.except(*_path_param_names),
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # Named request with mixed optional/nullable fields and merge-patch content type.
@@ -51,15 +56,18 @@ module Seed
         _path_param_names = ["id"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PATCH",
           path: "named-mixed/#{params[:id]}",
-          body: params.except(*_path_param_names)
+          body: params.except(*_path_param_names),
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # Test endpoint to verify Optional field initialization and JsonSetter with Nulls.SKIP.
@@ -70,15 +78,18 @@ module Seed
       # @return [untyped]
       def optional_merge_patch_test(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PATCH",
           path: "optional-merge-patch-test",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # Regular PATCH endpoint without merge-patch semantics
@@ -88,16 +99,20 @@ module Seed
         _path_param_names = ["id"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PATCH",
           path: "regular/#{params[:id]}",
-          body: params.except(*_path_param_names)
+          body: params.except(*_path_param_names),
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/content-type/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -10,18 +11,15 @@ module Seed
       # @return [untyped]
       def patch(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Update with JSON merge patch - complex types.
@@ -34,18 +32,15 @@ module Seed
         _path_param_names = ["id"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "complex/#{params[:id]}",
-          body: params.except(*_path_param_names),
+          body: params.except(*_path_param_names)
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Named request with mixed optional/nullable fields and merge-patch content type.
@@ -56,18 +51,15 @@ module Seed
         _path_param_names = ["id"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "named-mixed/#{params[:id]}",
-          body: params.except(*_path_param_names),
+          body: params.except(*_path_param_names)
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Test endpoint to verify Optional field initialization and JsonSetter with Nulls.SKIP.
@@ -78,18 +70,15 @@ module Seed
       # @return [untyped]
       def optional_merge_patch_test(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "optional-merge-patch-test",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Regular PATCH endpoint without merge-patch semantics
@@ -99,20 +88,16 @@ module Seed
         _path_param_names = ["id"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "regular/#{params[:id]}",
-          body: params.except(*_path_param_names),
+          body: params.except(*_path_param_names)
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/folder_a/service/client.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/folder_a/service/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::FolderA::Service::Types::Response]
         def get_direct_thread(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: ""
           )

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/folder_d/service/client.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/folder_d/service/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::FolderD::Service::Types::Response]
         def get_direct_thread(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: ""
           )

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/foo/client.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/foo/client.rb
@@ -18,7 +18,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "",
           query: _query,

--- a/seed/ruby-sdk-v2/custom-auth/lib/seed/custom_auth/client.rb
+++ b/seed/ruby-sdk-v2/custom-auth/lib/seed/custom_auth/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [bool]
       def get_with_custom_auth(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "custom-auth"
         )
@@ -28,7 +28,7 @@ module Seed
       # @return [bool]
       def post_with_custom_auth(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "custom-auth",
           body: params

--- a/seed/ruby-sdk-v2/enum/lib/seed/headers/client.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/headers/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def send_(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "headers"
         )

--- a/seed/ruby-sdk-v2/enum/lib/seed/inlined_request/client.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/inlined_request/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def send_(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "inlined",
           body: params

--- a/seed/ruby-sdk-v2/enum/lib/seed/path_param/client.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/path_param/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def send_(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "path/#{params[:operand]}/#{params[:operandOrColor]}"
         )

--- a/seed/ruby-sdk-v2/enum/lib/seed/query_param/client.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/query_param/client.rb
@@ -18,7 +18,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "query",
           query: _query
@@ -39,7 +39,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "query-list",
           query: _query

--- a/seed/ruby-sdk-v2/error-property/lib/seed/property_based_error/client.rb
+++ b/seed/ruby-sdk-v2/error-property/lib/seed/property_based_error/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [String]
       def throw_error(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "property-based-error"
         )

--- a/seed/ruby-sdk-v2/errors/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/errors/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Simple::Types::FooResponse]
       def foo_without_endpoint_error(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "foo1",
           body: Seed::Simple::Types::FooRequest.new(params).to_h
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Simple::Types::FooResponse]
       def foo(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "foo2",
           body: Seed::Simple::Types::FooRequest.new(params).to_h
@@ -43,7 +43,7 @@ module Seed
       # @return [Seed::Simple::Types::FooResponse]
       def foo_with_examples(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "foo3",
           body: Seed::Simple::Types::FooRequest.new(params).to_h

--- a/seed/ruby-sdk-v2/examples/lib/seed/file/notification/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/lib/seed/file/notification/service/client.rb
@@ -13,7 +13,7 @@ module Seed
           # @return [Seed::Types::Types::Exception]
           def get_exception(request_options: {}, **params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+              base_url: request_options[:base_url],
               method: "GET",
               path: "/file/notification/#{params[:notificationId]}"
             )

--- a/seed/ruby-sdk-v2/examples/lib/seed/file/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/lib/seed/file/service/client.rb
@@ -14,7 +14,7 @@ module Seed
         # @return [Seed::Types::Types::File]
         def get_file(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/file/#{params[:filename]}"
           )

--- a/seed/ruby-sdk-v2/examples/lib/seed/health/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/lib/seed/health/service/client.rb
@@ -14,7 +14,7 @@ module Seed
         # @return [untyped]
         def check(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/check/#{params[:id]}"
           )
@@ -29,7 +29,7 @@ module Seed
         # @return [bool]
         def ping(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/ping"
           )

--- a/seed/ruby-sdk-v2/examples/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/examples/lib/seed/service/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Types::Types::Movie]
       def get_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/movie/#{params[:movieId]}"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [String]
       def create_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/movie",
           body: Seed::Types::Types::Movie.new(params).to_h
@@ -45,7 +45,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/metadata",
           query: _query
@@ -59,7 +59,7 @@ module Seed
       # @return [Seed::Types::Types::Response]
       def create_big_entity(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/big-entity",
           body: Seed::Types::Types::BigEntity.new(params).to_h
@@ -73,7 +73,7 @@ module Seed
       # @return [untyped]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/refresh-token",
           body: params

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/container/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/container/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Array[String]]
         def get_and_return_list_of_primitives(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/container/list-of-primitives",
             body: params
@@ -26,7 +26,7 @@ module Seed
         # @return [Array[Seed::Types::Object_::Types::ObjectWithRequiredField]]
         def get_and_return_list_of_objects(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/container/list-of-objects",
             body: params
@@ -40,7 +40,7 @@ module Seed
         # @return [Array[String]]
         def get_and_return_set_of_primitives(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/container/set-of-primitives",
             body: params
@@ -54,7 +54,7 @@ module Seed
         # @return [Array[Seed::Types::Object_::Types::ObjectWithRequiredField]]
         def get_and_return_set_of_objects(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/container/set-of-objects",
             body: params
@@ -68,7 +68,7 @@ module Seed
         # @return [Hash[String, String]]
         def get_and_return_map_prim_to_prim(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/container/map-prim-to-prim",
             body: params
@@ -82,7 +82,7 @@ module Seed
         # @return [Hash[String, Seed::Types::Object_::Types::ObjectWithRequiredField]]
         def get_and_return_map_of_prim_to_object(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/container/map-prim-to-object",
             body: params
@@ -96,7 +96,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::ObjectWithRequiredField | nil]
         def get_and_return_optional(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/container/opt-objects",
             body: params

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/content_type/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/content_type/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def post_json_patch_content_type(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/foo/bar",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params).to_h
@@ -26,7 +26,7 @@ module Seed
         # @return [untyped]
         def post_json_patch_content_with_charset_type(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/foo/baz",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params).to_h

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/enum/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/enum/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::Types::Enum::Types::WeatherReport]
         def get_and_return_enum(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/enum",
             body: Seed::Types::Enum::Types::WeatherReport.new(params).to_h

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/http_methods/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/http_methods/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [String]
         def test_get(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/http-methods/#{params[:id]}"
           )
@@ -25,7 +25,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def test_post(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/http-methods",
             body: Seed::Types::Object_::Types::ObjectWithRequiredField.new(params).to_h
@@ -41,7 +41,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def test_put(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "PUT",
             path: "/http-methods/#{params[:id]}",
             body: Seed::Types::Object_::Types::ObjectWithRequiredField.new(params).to_h
@@ -57,7 +57,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def test_patch(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "PATCH",
             path: "/http-methods/#{params[:id]}",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params).to_h
@@ -73,7 +73,7 @@ module Seed
         # @return [bool]
         def test_delete(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "DELETE",
             path: "/http-methods/#{params[:id]}"
           )

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/object/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/object/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
         def get_and_return_with_optional_field(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/object/get-and-return-with-optional-field",
             body: Seed::Types::Object_::Types::ObjectWithOptionalField.new(params).to_h
@@ -28,7 +28,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::ObjectWithRequiredField]
         def get_and_return_with_required_field(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/object/get-and-return-with-required-field",
             body: Seed::Types::Object_::Types::ObjectWithRequiredField.new(params).to_h
@@ -44,7 +44,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::ObjectWithMapOfMap]
         def get_and_return_with_map_of_map(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/object/get-and-return-with-map-of-map",
             body: Seed::Types::Object_::Types::ObjectWithMapOfMap.new(params).to_h
@@ -60,7 +60,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::NestedObjectWithOptionalField]
         def get_and_return_nested_with_optional_field(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/object/get-and-return-nested-with-optional-field",
             body: Seed::Types::Object_::Types::NestedObjectWithOptionalField.new(params).to_h
@@ -76,7 +76,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::NestedObjectWithRequiredField]
         def get_and_return_nested_with_required_field(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/object/get-and-return-nested-with-required-field/#{params[:string]}",
             body: Seed::Types::Object_::Types::NestedObjectWithRequiredField.new(params).to_h
@@ -92,7 +92,7 @@ module Seed
         # @return [Seed::Types::Object_::Types::NestedObjectWithRequiredField]
         def get_and_return_nested_with_required_field_as_list(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/object/get-and-return-nested-with-required-field-list",
             body: params

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/params/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/params/client.rb
@@ -14,7 +14,7 @@ module Seed
         # @return [String]
         def get_with_path(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/params/path/#{params[:param]}"
           )
@@ -29,7 +29,7 @@ module Seed
         # @return [String]
         def get_with_inline_path(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/params/path/#{params[:param]}"
           )
@@ -51,7 +51,7 @@ module Seed
           params.except(*_query_param_names)
 
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/params",
             query: _query
@@ -74,7 +74,7 @@ module Seed
           params.except(*_query_param_names)
 
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/params",
             query: _query
@@ -97,7 +97,7 @@ module Seed
           params = params.except(*_query_param_names)
 
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/params/path-query/#{params[:param]}",
             query: _query
@@ -120,7 +120,7 @@ module Seed
           params = params.except(*_query_param_names)
 
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/params/path-query/#{params[:param]}",
             query: _query
@@ -136,7 +136,7 @@ module Seed
         # @return [String]
         def modify_with_path(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "PUT",
             path: "/params/path/#{params[:param]}",
             body: params
@@ -154,7 +154,7 @@ module Seed
           _path_param_names = ["param"]
 
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "PUT",
             path: "/params/path/#{params[:param]}",
             body: params.except(*_path_param_names)

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/primitive/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/primitive/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [String]
         def get_and_return_string(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/string",
             body: params
@@ -26,7 +26,7 @@ module Seed
         # @return [Integer]
         def get_and_return_int(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/integer",
             body: params
@@ -40,7 +40,7 @@ module Seed
         # @return [Integer]
         def get_and_return_long(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/long",
             body: params
@@ -54,7 +54,7 @@ module Seed
         # @return [Integer]
         def get_and_return_double(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/double",
             body: params
@@ -68,7 +68,7 @@ module Seed
         # @return [bool]
         def get_and_return_bool(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/boolean",
             body: params
@@ -82,7 +82,7 @@ module Seed
         # @return [String]
         def get_and_return_datetime(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/datetime",
             body: params
@@ -96,7 +96,7 @@ module Seed
         # @return [String]
         def get_and_return_date(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/date",
             body: params
@@ -110,7 +110,7 @@ module Seed
         # @return [String]
         def get_and_return_uuid(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/uuid",
             body: params
@@ -124,7 +124,7 @@ module Seed
         # @return [String]
         def get_and_return_base_64(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/primitive/base64",
             body: params

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/put/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/put/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::Endpoints::Put::Types::PutResponse]
         def add(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "PUT",
             path: params[:id].to_s
           )

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/union/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/union/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [Seed::Types::Union::Types::Animal]
         def get_and_return_union(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/union",
             body: Seed::Types::Union::Types::Animal.new(params).to_h

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/urls/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/endpoints/urls/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [String]
         def with_mixed_case(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/urls/MixedCase"
           )
@@ -25,7 +25,7 @@ module Seed
         # @return [String]
         def no_ending_slash(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/urls/no-ending-slash"
           )
@@ -38,7 +38,7 @@ module Seed
         # @return [String]
         def with_ending_slash(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/urls/with-ending-slash/"
           )
@@ -51,7 +51,7 @@ module Seed
         # @return [String]
         def with_underscores(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/urls/with_underscores"
           )

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/inlined_requests/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/inlined_requests/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
       def post_with_object_bodyand_response(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/req-bodies/object",
           body: params

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/no_auth/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/no_auth/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [bool]
       def post_with_no_auth(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/no-auth",
           body: params

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/no_req_body/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/no_req_body/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Types::Object_::Types::ObjectWithOptionalField]
       def get_with_no_request_body(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/no-req-body"
         )
@@ -26,7 +26,7 @@ module Seed
       # @return [String]
       def post_with_no_request_body(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/no-req-body"
         )

--- a/seed/ruby-sdk-v2/exhaustive/lib/seed/req_with_headers/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/lib/seed/req_with_headers/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_with_custom_header(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/test-headers/custom-header",
           body: params

--- a/seed/ruby-sdk-v2/extra-properties/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/extra-properties/lib/seed/user/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::User::Types::User]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/user",
           body: params

--- a/seed/ruby-sdk-v2/file-download/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/file-download/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -8,36 +9,30 @@ module Seed
       end
 
       # @return [untyped]
-      def simple(request_options: {}, **params)
+      def simple(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/snippet"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        raise _response.body unless _response.code >= "200" && _response.code < "300"
+
+        nil
       end
 
       # @return [untyped]
-      def download_file(request_options: {}, **params)
+      def download_file(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: ""
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/file-download/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/file-download/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -9,30 +8,36 @@ module Seed
       end
 
       # @return [untyped]
-      def simple(request_options: {}, **_params)
+      def simple(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/snippet"
         )
         _response = @client.send(_request)
-        raise _response.body unless _response.code >= "200" && _response.code < "300"
-
-        nil
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
-      def download_file(request_options: {}, **_params)
+      def download_file(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: ""
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/file-upload/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/file-upload/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -10,82 +11,74 @@ module Seed
       # @return [untyped]
       def post(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
+
         if params[:maybe_string]
           body.add(
-            name: 'maybe_string',
+            name: "maybe_string",
             value: params[:maybe_string]
           )
         end
         if params[:integer]
           body.add(
-            name: 'integer',
+            name: "integer",
             value: params[:integer]
           )
         end
-        if params[:file]
-          body.add_part(params[:file].to_form_data_part(name: "file"))
-        end
-        if params[:file_list]
-          body.add_part(params[:file_list].to_form_data_part(name: "file_list"))
-        end
-        if params[:maybe_file]
-          body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file"))
-        end
-        if params[:maybe_file_list]
-          body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list"))
-        end
+        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
+        body.add_part(params[:file_list].to_form_data_part(name: "file_list")) if params[:file_list]
+        body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file")) if params[:maybe_file]
+        body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list")) if params[:maybe_file_list]
         if params[:maybe_integer]
           body.add(
-            name: 'maybe_integer',
+            name: "maybe_integer",
             value: params[:maybe_integer]
           )
         end
         if params[:optional_list_of_strings]
           body.add(
-            name: 'optional_list_of_strings',
+            name: "optional_list_of_strings",
             value: params[:optional_list_of_strings]
           )
         end
         if params[:list_of_objects]
           body.add(
-            name: 'list_of_objects',
+            name: "list_of_objects",
             value: params[:list_of_objects]
           )
         end
         if params[:optional_metadata]
           body.add(
-            name: 'optional_metadata',
+            name: "optional_metadata",
             value: params[:optional_metadata]
           )
         end
         if params[:optional_object_type]
           body.add(
-            name: 'optional_object_type',
+            name: "optional_object_type",
             value: params[:optional_object_type]
           )
         end
         if params[:optional_id]
           body.add(
-            name: 'optional_id',
+            name: "optional_id",
             value: params[:optional_id]
           )
         end
         if params[:alias_object]
           body.add(
-            name: 'alias_object',
+            name: "alias_object",
             value: params[:alias_object]
           )
         end
         if params[:list_of_alias_object]
           body.add(
-            name: 'list_of_alias_object',
+            name: "list_of_alias_object",
             value: params[:list_of_alias_object]
           )
         end
         if params[:alias_list_of_object]
           body.add(
-            name: 'alias_list_of_object',
+            name: "alias_list_of_object",
             value: params[:alias_list_of_object]
           )
         end
@@ -93,272 +86,238 @@ module Seed
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [untyped]
       def just_file(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
-        if params[:file]
-          body.add_part(params[:file].to_form_data_part(name: "file"))
-        end
+
+        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/just-file",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [untyped]
       def just_file_with_query_params(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
-        if params[:file]
-          body.add_part(params[:file].to_form_data_part(name: "file"))
-        end
+
+        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/just-file-with-query-params",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [untyped]
       def with_content_type(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
-        if params[:file]
-          body.add_part(params[:file].to_form_data_part(name: "file"))
-        end
+
+        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
         if params[:foo]
           body.add(
-            name: 'foo',
+            name: "foo",
             value: params[:foo]
           )
         end
         if params[:bar]
           body.add(
-            name: 'bar',
+            name: "bar",
             value: JSON.generate(Seed::Service::Types::MyObject.new(params[:bar]).to_h),
-            content_type: 'application/json'
+            content_type: "application/json"
           )
         end
         if params[:foo_bar]
           body.add(
-            name: 'foo_bar',
+            name: "foo_bar",
             value: JSON.generate(params[:foo_bar]),
-            content_type: 'application/json'
+            content_type: "application/json"
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/with-content-type",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [untyped]
       def with_form_encoding(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
-        if params[:file]
-          body.add_part(params[:file].to_form_data_part(name: "file"))
-        end
+
+        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
         if params[:foo]
           body.add(
-            name: 'foo',
-            value: 
+            name: "foo",
+            value:
           )
         end
         if params[:bar]
           body.add(
-            name: 'bar',
-            value: 
+            name: "bar",
+            value:
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/with-form-encoding",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [untyped]
       def with_form_encoded_containers(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
+
         if params[:maybe_string]
           body.add(
-            name: 'maybe_string',
-            value: 
+            name: "maybe_string",
+            value:
           )
         end
         if params[:integer]
           body.add(
-            name: 'integer',
-            value: 
+            name: "integer",
+            value:
           )
         end
-        if params[:file]
-          body.add_part(params[:file].to_form_data_part(name: "file"))
-        end
-        if params[:file_list]
-          body.add_part(params[:file_list].to_form_data_part(name: "file_list"))
-        end
-        if params[:maybe_file]
-          body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file"))
-        end
-        if params[:maybe_file_list]
-          body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list"))
-        end
+        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
+        body.add_part(params[:file_list].to_form_data_part(name: "file_list")) if params[:file_list]
+        body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file")) if params[:maybe_file]
+        body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list")) if params[:maybe_file_list]
         if params[:maybe_integer]
           body.add(
-            name: 'maybe_integer',
-            value: 
+            name: "maybe_integer",
+            value:
           )
         end
         if params[:optional_list_of_strings]
           body.add(
-            name: 'optional_list_of_strings',
-            value: 
+            name: "optional_list_of_strings",
+            value:
           )
         end
         if params[:list_of_objects]
           body.add(
-            name: 'list_of_objects',
-            value: 
+            name: "list_of_objects",
+            value:
           )
         end
         if params[:optional_metadata]
           body.add(
-            name: 'optional_metadata',
-            value: 
+            name: "optional_metadata",
+            value:
           )
         end
         if params[:optional_object_type]
           body.add(
-            name: 'optional_object_type',
-            value: 
+            name: "optional_object_type",
+            value:
           )
         end
         if params[:optional_id]
           body.add(
-            name: 'optional_id',
-            value: 
+            name: "optional_id",
+            value:
           )
         end
         if params[:list_of_objects_with_optionals]
           body.add(
-            name: 'list_of_objects_with_optionals',
-            value: 
+            name: "list_of_objects_with_optionals",
+            value:
           )
         end
         if params[:alias_object]
           body.add(
-            name: 'alias_object',
-            value: 
+            name: "alias_object",
+            value:
           )
         end
         if params[:list_of_alias_object]
           body.add(
-            name: 'list_of_alias_object',
-            value: 
+            name: "list_of_alias_object",
+            value:
           )
         end
         if params[:alias_list_of_object]
           body.add(
-            name: 'alias_list_of_object',
-            value: 
+            name: "alias_list_of_object",
+            value:
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [String]
       def optional_args(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
-        if params[:image_file]
-          body.add_part(params[:image_file].to_form_data_part(name: "image_file"))
-        end
+
+        body.add_part(params[:image_file].to_form_data_part(name: "image_file")) if params[:image_file]
         if params[:request]
           body.add(
-            name: 'request',
+            name: "request",
             value: JSON.generate(params[:request]),
-            content_type: 'application/json; charset=utf-8'
+            content_type: "application/json; charset=utf-8"
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/optional-args",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [String]
       def with_inline_type(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-        
-        if params[:file]
-          body.add_part(params[:file].to_form_data_part(name: "file"))
-        end
+
+        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
         if params[:request]
           body.add(
-            name: 'request',
+            name: "request",
             value: params[:request]
           )
         end
@@ -366,32 +325,26 @@ module Seed
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/inline-type",
-          body: body,
+          body: body
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [untyped]
-      def simple(request_options: {}, **params)
+      def simple(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/snippet"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/file-upload/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/file-upload/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -11,74 +10,82 @@ module Seed
       # @return [untyped]
       def post(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
+        
         if params[:maybe_string]
           body.add(
-            name: "maybe_string",
+            name: 'maybe_string',
             value: params[:maybe_string]
           )
         end
         if params[:integer]
           body.add(
-            name: "integer",
+            name: 'integer',
             value: params[:integer]
           )
         end
-        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
-        body.add_part(params[:file_list].to_form_data_part(name: "file_list")) if params[:file_list]
-        body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file")) if params[:maybe_file]
-        body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list")) if params[:maybe_file_list]
+        if params[:file]
+          body.add_part(params[:file].to_form_data_part(name: "file"))
+        end
+        if params[:file_list]
+          body.add_part(params[:file_list].to_form_data_part(name: "file_list"))
+        end
+        if params[:maybe_file]
+          body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file"))
+        end
+        if params[:maybe_file_list]
+          body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list"))
+        end
         if params[:maybe_integer]
           body.add(
-            name: "maybe_integer",
+            name: 'maybe_integer',
             value: params[:maybe_integer]
           )
         end
         if params[:optional_list_of_strings]
           body.add(
-            name: "optional_list_of_strings",
+            name: 'optional_list_of_strings',
             value: params[:optional_list_of_strings]
           )
         end
         if params[:list_of_objects]
           body.add(
-            name: "list_of_objects",
+            name: 'list_of_objects',
             value: params[:list_of_objects]
           )
         end
         if params[:optional_metadata]
           body.add(
-            name: "optional_metadata",
+            name: 'optional_metadata',
             value: params[:optional_metadata]
           )
         end
         if params[:optional_object_type]
           body.add(
-            name: "optional_object_type",
+            name: 'optional_object_type',
             value: params[:optional_object_type]
           )
         end
         if params[:optional_id]
           body.add(
-            name: "optional_id",
+            name: 'optional_id',
             value: params[:optional_id]
           )
         end
         if params[:alias_object]
           body.add(
-            name: "alias_object",
+            name: 'alias_object',
             value: params[:alias_object]
           )
         end
         if params[:list_of_alias_object]
           body.add(
-            name: "list_of_alias_object",
+            name: 'list_of_alias_object',
             value: params[:list_of_alias_object]
           )
         end
         if params[:alias_list_of_object]
           body.add(
-            name: "alias_list_of_object",
+            name: 'alias_list_of_object',
             value: params[:alias_list_of_object]
           )
         end
@@ -86,238 +93,272 @@ module Seed
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
       def just_file(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
-        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
+        
+        if params[:file]
+          body.add_part(params[:file].to_form_data_part(name: "file"))
+        end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/just-file",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
       def just_file_with_query_params(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
-        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
+        
+        if params[:file]
+          body.add_part(params[:file].to_form_data_part(name: "file"))
+        end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/just-file-with-query-params",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
       def with_content_type(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
-        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
+        
+        if params[:file]
+          body.add_part(params[:file].to_form_data_part(name: "file"))
+        end
         if params[:foo]
           body.add(
-            name: "foo",
+            name: 'foo',
             value: params[:foo]
           )
         end
         if params[:bar]
           body.add(
-            name: "bar",
+            name: 'bar',
             value: JSON.generate(Seed::Service::Types::MyObject.new(params[:bar]).to_h),
-            content_type: "application/json"
+            content_type: 'application/json'
           )
         end
         if params[:foo_bar]
           body.add(
-            name: "foo_bar",
+            name: 'foo_bar',
             value: JSON.generate(params[:foo_bar]),
-            content_type: "application/json"
+            content_type: 'application/json'
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/with-content-type",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
       def with_form_encoding(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
-        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
+        
+        if params[:file]
+          body.add_part(params[:file].to_form_data_part(name: "file"))
+        end
         if params[:foo]
           body.add(
-            name: "foo",
-            value:
+            name: 'foo',
+            value: 
           )
         end
         if params[:bar]
           body.add(
-            name: "bar",
-            value:
+            name: 'bar',
+            value: 
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/with-form-encoding",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
       def with_form_encoded_containers(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
+        
         if params[:maybe_string]
           body.add(
-            name: "maybe_string",
-            value:
+            name: 'maybe_string',
+            value: 
           )
         end
         if params[:integer]
           body.add(
-            name: "integer",
-            value:
+            name: 'integer',
+            value: 
           )
         end
-        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
-        body.add_part(params[:file_list].to_form_data_part(name: "file_list")) if params[:file_list]
-        body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file")) if params[:maybe_file]
-        body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list")) if params[:maybe_file_list]
+        if params[:file]
+          body.add_part(params[:file].to_form_data_part(name: "file"))
+        end
+        if params[:file_list]
+          body.add_part(params[:file_list].to_form_data_part(name: "file_list"))
+        end
+        if params[:maybe_file]
+          body.add_part(params[:maybe_file].to_form_data_part(name: "maybe_file"))
+        end
+        if params[:maybe_file_list]
+          body.add_part(params[:maybe_file_list].to_form_data_part(name: "maybe_file_list"))
+        end
         if params[:maybe_integer]
           body.add(
-            name: "maybe_integer",
-            value:
+            name: 'maybe_integer',
+            value: 
           )
         end
         if params[:optional_list_of_strings]
           body.add(
-            name: "optional_list_of_strings",
-            value:
+            name: 'optional_list_of_strings',
+            value: 
           )
         end
         if params[:list_of_objects]
           body.add(
-            name: "list_of_objects",
-            value:
+            name: 'list_of_objects',
+            value: 
           )
         end
         if params[:optional_metadata]
           body.add(
-            name: "optional_metadata",
-            value:
+            name: 'optional_metadata',
+            value: 
           )
         end
         if params[:optional_object_type]
           body.add(
-            name: "optional_object_type",
-            value:
+            name: 'optional_object_type',
+            value: 
           )
         end
         if params[:optional_id]
           body.add(
-            name: "optional_id",
-            value:
+            name: 'optional_id',
+            value: 
           )
         end
         if params[:list_of_objects_with_optionals]
           body.add(
-            name: "list_of_objects_with_optionals",
-            value:
+            name: 'list_of_objects_with_optionals',
+            value: 
           )
         end
         if params[:alias_object]
           body.add(
-            name: "alias_object",
-            value:
+            name: 'alias_object',
+            value: 
           )
         end
         if params[:list_of_alias_object]
           body.add(
-            name: "list_of_alias_object",
-            value:
+            name: 'list_of_alias_object',
+            value: 
           )
         end
         if params[:alias_list_of_object]
           body.add(
-            name: "alias_list_of_object",
-            value:
+            name: 'alias_list_of_object',
+            value: 
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [String]
       def optional_args(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
-        body.add_part(params[:image_file].to_form_data_part(name: "image_file")) if params[:image_file]
+        
+        if params[:image_file]
+          body.add_part(params[:image_file].to_form_data_part(name: "image_file"))
+        end
         if params[:request]
           body.add(
-            name: "request",
+            name: 'request',
             value: JSON.generate(params[:request]),
-            content_type: "application/json; charset=utf-8"
+            content_type: 'application/json; charset=utf-8'
           )
         end
 
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/optional-args",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # @return [String]
       def with_inline_type(request_options: {}, **params)
         body = Internal::Multipart::FormData.new
-
-        body.add_part(params[:file].to_form_data_part(name: "file")) if params[:file]
+        
+        if params[:file]
+          body.add_part(params[:file].to_form_data_part(name: "file"))
+        end
         if params[:request]
           body.add(
-            name: "request",
+            name: 'request',
             value: params[:request]
           )
         end
@@ -325,26 +366,32 @@ module Seed
         _request = Seed::Internal::Multipart::Request.new(
           method: POST,
           path: "/inline-type",
-          body: body
+          body: body,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
-      def simple(request_options: {}, **_params)
+      def simple(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/snippet"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/folders/lib/seed/a/b/client.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/a/b/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def foo(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: ""
           )

--- a/seed/ruby-sdk-v2/folders/lib/seed/a/c/client.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/a/c/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def foo(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: ""
           )

--- a/seed/ruby-sdk-v2/folders/lib/seed/folder/client.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/folder/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def foo(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: ""
         )

--- a/seed/ruby-sdk-v2/folders/lib/seed/folder/service/client.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/folder/service/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def endpoint(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/service"
           )
@@ -25,7 +25,7 @@ module Seed
         # @return [untyped]
         def unknown_request(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "POST",
             path: "/service",
             body: params

--- a/seed/ruby-sdk-v2/http-head/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/http-head/lib/seed/user/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module User
@@ -9,16 +8,19 @@ module Seed
       end
 
       # @return [untyped]
-      def head(request_options: {}, **_params)
+      def head(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "HEAD",
           path: "/users"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
 
       # @return [Array[Seed::User::Types::User]]
@@ -28,19 +30,23 @@ module Seed
           %i[limit]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/users",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/http-head/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/http-head/lib/seed/user/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module User
@@ -8,19 +9,16 @@ module Seed
       end
 
       # @return [untyped]
-      def head(request_options: {}, **params)
+      def head(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "HEAD",
           path: "/users"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [Array[Seed::User::Types::User]]
@@ -30,23 +28,19 @@ module Seed
           %i[limit]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/idempotency-headers/lib/seed/payment/client.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/lib/seed/payment/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Payment
@@ -10,36 +11,29 @@ module Seed
       # @return [String]
       def create(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/payment",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [untyped]
       def delete(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "DELETE",
           path: "/payment/#{params[:paymentId]}"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/idempotency-headers/lib/seed/payment/client.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/lib/seed/payment/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Payment
@@ -11,29 +10,36 @@ module Seed
       # @return [String]
       def create(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/payment",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # @return [untyped]
       def delete(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "DELETE",
           path: "/payment/#{params[:paymentId]}"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Imdb
@@ -12,36 +13,29 @@ module Seed
       # @return [String]
       def create_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/movies/create-movie",
-          body: Seed::Imdb::Types::CreateMovieRequest.new(params).to_h,
+          body: Seed::Imdb::Types::CreateMovieRequest.new(params).to_h
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::Imdb::Types::MovieId.load(_response.body)
-        else
-          raise _response.body
-        end
+        return Seed::Imdb::Types::MovieId.load(_response.body) if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [Seed::Imdb::Types::Movie]
       def get_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/movies/#{params[:movieId]}"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::Imdb::Types::Movie.load(_response.body)
-        else
-          raise _response.body
-        end
-      end
+        return Seed::Imdb::Types::Movie.load(_response.body) if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Imdb
@@ -13,29 +12,36 @@ module Seed
       # @return [String]
       def create_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/movies/create-movie",
-          body: Seed::Imdb::Types::CreateMovieRequest.new(params).to_h
+          body: Seed::Imdb::Types::CreateMovieRequest.new(params).to_h,
         )
         _response = @client.send(_request)
-        return Seed::Imdb::Types::MovieId.load(_response.body) if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::Imdb::Types::MovieId.load(_response.body)
+        else
+          raise _response.body
+        end
       end
 
       # @return [Seed::Imdb::Types::Movie]
       def get_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/movies/#{params[:movieId]}"
         )
         _response = @client.send(_request)
-        return Seed::Imdb::Types::Movie.load(_response.body) if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::Imdb::Types::Movie.load(_response.body)
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token/refresh",
           body: params

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token/refresh",
           body: params

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token/refresh",
           body: params

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/literal/lib/seed/headers/client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/headers/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Types::SendResponse]
       def send_(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "headers",
           body: params

--- a/seed/ruby-sdk-v2/literal/lib/seed/inlined/client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/inlined/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Types::SendResponse]
       def send_(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "inlined",
           body: params

--- a/seed/ruby-sdk-v2/literal/lib/seed/path/client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/path/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Types::SendResponse]
       def send_(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "path/#{params[:id]}"
         )

--- a/seed/ruby-sdk-v2/literal/lib/seed/query/client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/query/client.rb
@@ -20,7 +20,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "query",
           query: _query

--- a/seed/ruby-sdk-v2/literal/lib/seed/reference/client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/reference/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Types::SendResponse]
       def send_(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "reference",
           body: Seed::Reference::Types::SendRequest.new(params).to_h

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -11,36 +10,43 @@ module Seed
       # @return [Seed::Service::Types::Resource]
       def get_resource(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/resource/#{params[:ResourceID]}"
         )
         _response = @client.send(_request)
-        return Seed::Service::Types::Resource.load(_response.body) if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::Service::Types::Resource.load(_response.body)
+        else
+          raise _response.body
+        end
       end
 
       # @return [Array[Seed::Service::Types::Resource]]
       def list_resources(request_options: {}, **params)
         _query_param_names = [
-          %w[page_limit beforeDate],
+          ["page_limit", "beforeDate"],
           %i[page_limit beforeDate]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/resource",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -10,43 +11,36 @@ module Seed
       # @return [Seed::Service::Types::Resource]
       def get_resource(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/resource/#{params[:ResourceID]}"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::Service::Types::Resource.load(_response.body)
-        else
-          raise _response.body
-        end
+        return Seed::Service::Types::Resource.load(_response.body) if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [Array[Seed::Service::Types::Resource]]
       def list_resources(request_options: {}, **params)
         _query_param_names = [
-          ["page_limit", "beforeDate"],
+          %w[page_limit beforeDate],
           %i[page_limit beforeDate]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/resource",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/organization/client.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/organization/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [Seed::Organization::Types::Organization]
       def create(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/organizations/",
           body: Seed::Organization::Types::CreateOrganizationRequest.new(params).to_h

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/user/client.rb
@@ -20,7 +20,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users/",
           query: _query

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/user/events/client.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/user/events/client.rb
@@ -21,7 +21,7 @@ module Seed
           params.except(*_query_param_names)
 
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/users/events/",
             query: _query

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/user/events/metadata/client.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/user/events/metadata/client.rb
@@ -22,7 +22,7 @@ module Seed
             params.except(*_query_param_names)
 
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+              base_url: request_options[:base_url],
               method: "GET",
               path: "/users/events/metadata/",
               query: _query

--- a/seed/ruby-sdk-v2/multi-line-docs/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/lib/seed/user/client.rb
@@ -14,7 +14,7 @@ module Seed
       # @return [untyped]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "users/#{params[:userId]}"
         )
@@ -30,7 +30,7 @@ module Seed
       # @return [Seed::User::Types::User]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "users",
           body: params

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/ec_2/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/ec_2/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def boot_instance(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/ec2/boot",
           body: params

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/s_3/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/s_3/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [String]
       def get_presigned_url(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/s3/presigned-url",
           body: params

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/ec_2/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/ec_2/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def boot_instance(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Production,
           method: "POST",
           path: "/ec2/boot",
           body: params

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/s_3/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/s_3/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [String]
       def get_presigned_url(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Production,
           method: "POST",
           path: "/s3/presigned-url",
           body: params

--- a/seed/ruby-sdk-v2/no-environment/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/no-environment/lib/seed/dummy/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -8,21 +9,17 @@ module Seed
       end
 
       # @return [String]
-      def get_dummy(request_options: {}, **params)
+      def get_dummy(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "dummy"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/no-environment/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/no-environment/lib/seed/dummy/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -9,17 +8,21 @@ module Seed
       end
 
       # @return [String]
-      def get_dummy(request_options: {}, **_params)
+      def get_dummy(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "dummy"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/nullable_optional/client.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/nullable_optional/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module NullableOptional
@@ -13,16 +12,17 @@ module Seed
       # @return [Seed::NullableOptional::Types::UserResponse]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/api/users/#{params[:userId]}"
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::UserResponse.load(_response.body)
+        else
+          raise _response.body
         end
-
-        raise _response.body
       end
 
       # Create a new user
@@ -30,17 +30,18 @@ module Seed
       # @return [Seed::NullableOptional::Types::UserResponse]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/api/users",
-          body: Seed::NullableOptional::Types::CreateUserRequest.new(params).to_h
+          body: Seed::NullableOptional::Types::CreateUserRequest.new(params).to_h,
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::UserResponse.load(_response.body)
+        else
+          raise _response.body
         end
-
-        raise _response.body
       end
 
       # Update a user (partial update)
@@ -48,17 +49,18 @@ module Seed
       # @return [Seed::NullableOptional::Types::UserResponse]
       def update_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PATCH",
           path: "/api/users/#{params[:userId]}",
-          body: Seed::NullableOptional::Types::UpdateUserRequest.new(params).to_h
+          body: Seed::NullableOptional::Types::UpdateUserRequest.new(params).to_h,
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::UserResponse.load(_response.body)
+        else
+          raise _response.body
         end
-
-        raise _response.body
       end
 
       # List all users
@@ -66,22 +68,25 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::UserResponse]]
       def list_users(request_options: {}, **params)
         _query_param_names = [
-          %w[limit offset includeDeleted sortBy],
+          ["limit", "offset", "includeDeleted", "sortBy"],
           %i[limit offset includeDeleted sortBy]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/api/users",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # Search users
@@ -89,22 +94,25 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::UserResponse]]
       def search_users(request_options: {}, **params)
         _query_param_names = [
-          %w[query department role isActive],
+          ["query", "department", "role", "isActive"],
           %i[query department role isActive]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/api/users/search",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # Create a complex profile to test nullable enums and unions
@@ -112,17 +120,18 @@ module Seed
       # @return [Seed::NullableOptional::Types::ComplexProfile]
       def create_complex_profile(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/api/profiles/complex",
-          body: Seed::NullableOptional::Types::ComplexProfile.new(params).to_h
+          body: Seed::NullableOptional::Types::ComplexProfile.new(params).to_h,
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::ComplexProfile.load(_response.body)
+        else
+          raise _response.body
         end
-
-        raise _response.body
       end
 
       # Get a complex profile by ID
@@ -130,16 +139,17 @@ module Seed
       # @return [Seed::NullableOptional::Types::ComplexProfile]
       def get_complex_profile(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/api/profiles/complex/#{params[:profileId]}"
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::ComplexProfile.load(_response.body)
+        else
+          raise _response.body
         end
-
-        raise _response.body
       end
 
       # Update complex profile to test nullable field updates
@@ -149,17 +159,18 @@ module Seed
         _path_param_names = ["profileId"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PATCH",
           path: "/api/profiles/complex/#{params[:profileId]}",
-          body: params.except(*_path_param_names)
+          body: params.except(*_path_param_names),
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::ComplexProfile.load(_response.body)
+        else
+          raise _response.body
         end
-
-        raise _response.body
       end
 
       # Test endpoint for validating null deserialization
@@ -167,17 +178,18 @@ module Seed
       # @return [Seed::NullableOptional::Types::DeserializationTestResponse]
       def test_deserialization(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/api/test/deserialization",
-          body: Seed::NullableOptional::Types::DeserializationTestRequest.new(params).to_h
+          body: Seed::NullableOptional::Types::DeserializationTestRequest.new(params).to_h,
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::DeserializationTestResponse.load(_response.body)
+        else
+          raise _response.body
         end
-
-        raise _response.body
       end
 
       # Filter users by role with nullable enum
@@ -185,22 +197,25 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::UserResponse]]
       def filter_by_role(request_options: {}, **params)
         _query_param_names = [
-          %w[role status secondaryRole],
+          ["role", "status", "secondaryRole"],
           %i[role status secondaryRole]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/api/users/filter",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # Get notification settings which may be null
@@ -208,14 +223,17 @@ module Seed
       # @return [Seed::NullableOptional::Types::NotificationMethod | nil]
       def get_notification_settings(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/api/users/#{params[:userId]}/notifications"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # Update tags to test array handling
@@ -225,15 +243,18 @@ module Seed
         _path_param_names = ["userId"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "PUT",
           path: "/api/users/#{params[:userId]}/tags",
-          body: params.except(*_path_param_names)
+          body: params.except(*_path_param_names),
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # Get search results with nullable unions
@@ -241,16 +262,20 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::SearchResult] | nil]
       def get_search_results(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/api/search",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/nullable_optional/client.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/nullable_optional/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module NullableOptional
@@ -12,17 +13,16 @@ module Seed
       # @return [Seed::NullableOptional::Types::UserResponse]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/users/#{params[:userId]}"
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::UserResponse.load(_response.body)
-        else
-          raise _response.body
         end
+
+        raise _response.body
       end
 
       # Create a new user
@@ -30,18 +30,17 @@ module Seed
       # @return [Seed::NullableOptional::Types::UserResponse]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/api/users",
-          body: Seed::NullableOptional::Types::CreateUserRequest.new(params).to_h,
+          body: Seed::NullableOptional::Types::CreateUserRequest.new(params).to_h
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::UserResponse.load(_response.body)
-        else
-          raise _response.body
         end
+
+        raise _response.body
       end
 
       # Update a user (partial update)
@@ -49,18 +48,17 @@ module Seed
       # @return [Seed::NullableOptional::Types::UserResponse]
       def update_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "/api/users/#{params[:userId]}",
-          body: Seed::NullableOptional::Types::UpdateUserRequest.new(params).to_h,
+          body: Seed::NullableOptional::Types::UpdateUserRequest.new(params).to_h
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::UserResponse.load(_response.body)
-        else
-          raise _response.body
         end
+
+        raise _response.body
       end
 
       # List all users
@@ -68,25 +66,22 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::UserResponse]]
       def list_users(request_options: {}, **params)
         _query_param_names = [
-          ["limit", "offset", "includeDeleted", "sortBy"],
+          %w[limit offset includeDeleted sortBy],
           %i[limit offset includeDeleted sortBy]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/users",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Search users
@@ -94,25 +89,22 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::UserResponse]]
       def search_users(request_options: {}, **params)
         _query_param_names = [
-          ["query", "department", "role", "isActive"],
+          %w[query department role isActive],
           %i[query department role isActive]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/users/search",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Create a complex profile to test nullable enums and unions
@@ -120,18 +112,17 @@ module Seed
       # @return [Seed::NullableOptional::Types::ComplexProfile]
       def create_complex_profile(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/api/profiles/complex",
-          body: Seed::NullableOptional::Types::ComplexProfile.new(params).to_h,
+          body: Seed::NullableOptional::Types::ComplexProfile.new(params).to_h
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::ComplexProfile.load(_response.body)
-        else
-          raise _response.body
         end
+
+        raise _response.body
       end
 
       # Get a complex profile by ID
@@ -139,17 +130,16 @@ module Seed
       # @return [Seed::NullableOptional::Types::ComplexProfile]
       def get_complex_profile(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/profiles/complex/#{params[:profileId]}"
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::ComplexProfile.load(_response.body)
-        else
-          raise _response.body
         end
+
+        raise _response.body
       end
 
       # Update complex profile to test nullable field updates
@@ -159,18 +149,17 @@ module Seed
         _path_param_names = ["profileId"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "/api/profiles/complex/#{params[:profileId]}",
-          body: params.except(*_path_param_names),
+          body: params.except(*_path_param_names)
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::ComplexProfile.load(_response.body)
-        else
-          raise _response.body
         end
+
+        raise _response.body
       end
 
       # Test endpoint for validating null deserialization
@@ -178,18 +167,17 @@ module Seed
       # @return [Seed::NullableOptional::Types::DeserializationTestResponse]
       def test_deserialization(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/api/test/deserialization",
-          body: Seed::NullableOptional::Types::DeserializationTestRequest.new(params).to_h,
+          body: Seed::NullableOptional::Types::DeserializationTestRequest.new(params).to_h
         )
         _response = @client.send(_request)
         if _response.code >= "200" && _response.code < "300"
           return Seed::NullableOptional::Types::DeserializationTestResponse.load(_response.body)
-        else
-          raise _response.body
         end
+
+        raise _response.body
       end
 
       # Filter users by role with nullable enum
@@ -197,25 +185,22 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::UserResponse]]
       def filter_by_role(request_options: {}, **params)
         _query_param_names = [
-          ["role", "status", "secondaryRole"],
+          %w[role status secondaryRole],
           %i[role status secondaryRole]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/users/filter",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Get notification settings which may be null
@@ -223,17 +208,14 @@ module Seed
       # @return [Seed::NullableOptional::Types::NotificationMethod | nil]
       def get_notification_settings(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/api/users/#{params[:userId]}/notifications"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Update tags to test array handling
@@ -243,18 +225,15 @@ module Seed
         _path_param_names = ["userId"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "PUT",
           path: "/api/users/#{params[:userId]}/tags",
-          body: params.except(*_path_param_names),
+          body: params.except(*_path_param_names)
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # Get search results with nullable unions
@@ -262,20 +241,16 @@ module Seed
       # @return [Array[Seed::NullableOptional::Types::SearchResult] | nil]
       def get_search_results(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/api/search",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable/lib/seed/nullable/client.rb
+++ b/seed/ruby-sdk-v2/nullable/lib/seed/nullable/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Nullable
@@ -10,61 +11,51 @@ module Seed
       # @return [Array[Seed::Nullable::Types::User]]
       def get_users(request_options: {}, **params)
         _query_param_names = [
-          ["usernames", "avatar", "activated", "tags", "extra"],
+          %w[usernames avatar activated tags extra],
           %i[usernames avatar activated tags extra]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [Seed::Nullable::Types::User]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/users",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::Nullable::Types::User.load(_response.body)
-        else
-          raise _response.body
-        end
+        return Seed::Nullable::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [bool]
       def delete_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "DELETE",
           path: "/users",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/nullable/lib/seed/nullable/client.rb
+++ b/seed/ruby-sdk-v2/nullable/lib/seed/nullable/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Nullable
@@ -11,51 +10,61 @@ module Seed
       # @return [Array[Seed::Nullable::Types::User]]
       def get_users(request_options: {}, **params)
         _query_param_names = [
-          %w[usernames avatar activated tags extra],
+          ["usernames", "avatar", "activated", "tags", "extra"],
           %i[usernames avatar activated tags extra]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/users",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
 
       # @return [Seed::Nullable::Types::User]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "/users",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return Seed::Nullable::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::Nullable::Types::User.load(_response.body)
+        else
+          raise _response.body
+        end
       end
 
       # @return [bool]
       def delete_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "DELETE",
           path: "/users",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/service/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def post(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/service/#{params[:endpointParam]}"
         )

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/nested/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/nested/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/nested_no_auth/api/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/nested_no_auth/api/client.rb
@@ -12,7 +12,7 @@ module Seed
         # @return [untyped]
         def get_something(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url],
             method: "GET",
             path: "/nested-no-auth/get-something"
           )

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/simple/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/simple/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def get_something(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/get-something"
         )

--- a/seed/ruby-sdk-v2/optional/lib/seed/optional/client.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/optional/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Optional
@@ -10,20 +11,16 @@ module Seed
       # @return [String]
       def send_optional_body(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "send-optional-body",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/optional/lib/seed/optional/client.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/optional/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Optional
@@ -11,16 +10,20 @@ module Seed
       # @return [String]
       def send_optional_body(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "send-optional-body",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/package-yml/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/package-yml/lib/seed/service/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def nop(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:id]}//#{params[:nestedId]}"
         )

--- a/seed/ruby-sdk-v2/pagination-custom/lib/seed/users/client.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/lib/seed/users/client.rb
@@ -18,7 +18,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query

--- a/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Complex::Types::PaginatedConversationResponse]
       def search(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "#{params[:index]}/conversations/search",
           body: Seed::Complex::Types::SearchRequest.new(params).to_h

--- a/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
@@ -18,7 +18,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -41,7 +41,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/users",
           query: _query
@@ -57,7 +57,7 @@ module Seed
       # @return [Seed::Users::Types::ListUsersPaginationResponse]
       def list_with_body_cursor_pagination(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/users",
           body: params
@@ -80,7 +80,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -103,7 +103,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -119,7 +119,7 @@ module Seed
       # @return [Seed::Users::Types::ListUsersPaginationResponse]
       def list_with_body_offset_pagination(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/users",
           body: params
@@ -142,7 +142,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -165,7 +165,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -188,7 +188,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -211,7 +211,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -234,7 +234,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query
@@ -255,7 +255,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users",
           query: _query

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/organizations/client.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/organizations/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Organizations::Types::Organization]
       def get_organization(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:tenant_id]}/organizations/#{params[:organization_id]}/"
         )
@@ -26,7 +26,7 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_organization_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:tenant_id]}/organizations/#{params[:organization_id]}/users/#{params[:user_id]}"
         )
@@ -46,7 +46,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:tenant_id]}/organizations/#{params[:organization_id]}/search",
           query: _query

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/user/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:tenant_id]}/user/#{params[:user_id]}"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [Seed::User::Types::User]
       def create_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/#{params[:tenant_id]}/user/",
           body: Seed::User::Types::User.new(params).to_h
@@ -40,7 +40,7 @@ module Seed
         _path_param_names = %w[tenant_id user_id]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "/#{params[:tenant_id]}/user/#{params[:user_id]}",
           body: params.except(*_path_param_names)
@@ -61,7 +61,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:tenant_id]}/user/#{params[:user_id]}/search",
           query: _query

--- a/seed/ruby-sdk-v2/plain-text/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/plain-text/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -8,20 +9,17 @@ module Seed
       end
 
       # @return [String]
-      def get_text(request_options: {}, **params)
+      def get_text(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "text"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/plain-text/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/plain-text/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -9,17 +8,20 @@ module Seed
       end
 
       # @return [String]
-      def get_text(request_options: {}, **_params)
+      def get_text(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "text"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/public-object/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/public-object/lib/seed/service/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Service
@@ -9,17 +8,20 @@ module Seed
       end
 
       # @return [untyped]
-      def get(request_options: {}, **_params)
+      def get(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/helloworld.txt"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/public-object/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/public-object/lib/seed/service/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Service
@@ -8,20 +9,17 @@ module Seed
       end
 
       # @return [untyped]
-      def get(request_options: {}, **params)
+      def get(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/helloworld.txt"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/user/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module User
@@ -11,25 +10,27 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_username(request_options: {}, **params)
         _query_param_names = [
-          %w[limit id date deadline bytes user userList optionalDeadline keyValue
-             optionalString nestedUser optionalUser excludeUser filter],
-          %i[limit id date deadline bytes user userList optionalDeadline keyValue optionalString nestedUser
-             optionalUser excludeUser filter]
+          ["limit", "id", "date", "deadline", "bytes", "user", "userList", "optionalDeadline", "keyValue", "optionalString", "nestedUser", "optionalUser", "excludeUser", "filter"],
+          %i[limit id date deadline bytes user userList optionalDeadline keyValue optionalString nestedUser optionalUser excludeUser filter]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/user",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return Seed::User::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::User::Types::User.load(_response.body)
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/user/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module User
@@ -10,27 +11,25 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_username(request_options: {}, **params)
         _query_param_names = [
-          ["limit", "id", "date", "deadline", "bytes", "user", "userList", "optionalDeadline", "keyValue", "optionalString", "nestedUser", "optionalUser", "excludeUser", "filter"],
-          %i[limit id date deadline bytes user userList optionalDeadline keyValue optionalString nestedUser optionalUser excludeUser filter]
+          %w[limit id date deadline bytes user userList optionalDeadline keyValue
+             optionalString nestedUser optionalUser excludeUser filter],
+          %i[limit id date deadline bytes user userList optionalDeadline keyValue optionalString nestedUser
+             optionalUser excludeUser filter]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/user",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::User::Types::User.load(_response.body)
-        else
-          raise _response.body
-        end
-      end
+        return Seed::User::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/request-parameters/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/request-parameters/lib/seed/user/client.rb
@@ -18,7 +18,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/user/username",
           query: _query,
@@ -40,7 +40,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/user/username-referenced",
           query: _query,
@@ -64,7 +64,7 @@ module Seed
         params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/user",
           query: _query

--- a/seed/ruby-sdk-v2/reserved-keywords/lib/seed/package/client.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/lib/seed/package/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Package
@@ -14,23 +15,19 @@ module Seed
           %i[for]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params = params.except(*_query_param_names)
+        params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "",
-          query: _query,
+          query: _query
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/reserved-keywords/lib/seed/package/client.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/lib/seed/package/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Package
@@ -15,19 +14,23 @@ module Seed
           %i[for]
         ].flatten
         _query = params.slice(*_query_param_names)
-        params.except(*_query_param_names)
+        params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "",
-          query: _query
+          query: _query,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/response-property/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/response-property/lib/seed/service/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Service::Types::Response]
       def get_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "movie",
           body: params
@@ -25,7 +25,7 @@ module Seed
       # @return [Seed::Service::Types::Response]
       def get_movie_docs(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "movie",
           body: params
@@ -39,7 +39,7 @@ module Seed
       # @return [Seed::Types::StringResponse]
       def get_movie_name(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "movie",
           body: params
@@ -53,7 +53,7 @@ module Seed
       # @return [Seed::Service::Types::Response]
       def get_movie_metadata(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "movie",
           body: params
@@ -67,7 +67,7 @@ module Seed
       # @return [Seed::Service::Types::Response | nil]
       def get_optional_movie(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "movie",
           body: params
@@ -81,7 +81,7 @@ module Seed
       # @return [Seed::Service::Types::WithDocs | nil]
       def get_optional_movie_docs(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "movie",
           body: params
@@ -97,7 +97,7 @@ module Seed
       # @return [Seed::Types::StringResponse | nil]
       def get_optional_movie_name(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "movie",
           body: params

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/service/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Service::Types::Foo]
       def get(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/ruby-reserved-word-properties/getFoo"
         )

--- a/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/completions/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/completions/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Completions
@@ -10,19 +11,16 @@ module Seed
       # @return [untyped]
       def stream(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "stream",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/completions/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/completions/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Completions
@@ -11,16 +10,19 @@ module Seed
       # @return [untyped]
       def stream(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "stream",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/server-sent-events/lib/seed/completions/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/lib/seed/completions/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Completions
@@ -10,19 +11,16 @@ module Seed
       # @return [untyped]
       def stream(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "stream",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/server-sent-events/lib/seed/completions/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/lib/seed/completions/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Completions
@@ -11,16 +10,19 @@ module Seed
       # @return [untyped]
       def stream(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "stream",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/simple-api/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/simple-api/lib/seed/user/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::User::Types::User]
       def get(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users/#{params[:id]}"
         )

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/dummy/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -9,17 +8,21 @@ module Seed
       end
 
       # @return [String]
-      def get_dummy(request_options: {}, **_params)
+      def get_dummy(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Production
+          ,
           method: "GET",
           path: "dummy"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/dummy/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -8,21 +9,17 @@ module Seed
       end
 
       # @return [String]
-      def get_dummy(request_options: {}, **params)
+      def get_dummy(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Production
-          ,
+          base_url: request_options[:base_url] || Seed::Environment::Production,
           method: "GET",
           path: "dummy"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/dummy/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -8,21 +9,17 @@ module Seed
       end
 
       # @return [String]
-      def get_dummy(request_options: {}, **params)
+      def get_dummy(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "dummy"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return 
-        else
-          raise _response.body
-        end
-      end
+        return if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/dummy/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -9,17 +8,21 @@ module Seed
       end
 
       # @return [String]
-      def get_dummy(request_options: {}, **_params)
+      def get_dummy(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "dummy"
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return 
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/streaming-parameter/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/lib/seed/dummy/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def generate(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "generate",
           body: params

--- a/seed/ruby-sdk-v2/streaming/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/streaming/lib/seed/dummy/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -11,30 +10,36 @@ module Seed
       # @return [untyped]
       def generate_stream(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "generate-stream",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        return if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+        else
+          raise _response.body
+        end
       end
 
       # @return [Seed::Dummy::Types::StreamResponse]
       def generate(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "POST",
           path: "generate",
-          body: params
+          body: params,
         )
         _response = @client.send(_request)
-        raise _response.body unless _response.code >= "200" && _response.code < "300"
-
-        Seed::Dummy::Types::StreamResponse.load(_response.body)
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::Dummy::Types::StreamResponse.load(_response.body)
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/streaming/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/streaming/lib/seed/dummy/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module Dummy
@@ -10,36 +11,30 @@ module Seed
       # @return [untyped]
       def generate_stream(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "generate-stream",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-        else
-          raise _response.body
-        end
+        return if _response.code >= "200" && _response.code < "300"
+
+        raise _response.body
       end
 
       # @return [Seed::Dummy::Types::StreamResponse]
       def generate(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "generate",
-          body: params,
+          body: params
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::Dummy::Types::StreamResponse.load(_response.body)
-        else
-          raise _response.body
-        end
-      end
+        raise _response.body unless _response.code >= "200" && _response.code < "300"
 
+        Seed::Dummy::Types::StreamResponse.load(_response.body)
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/trace/lib/seed/admin/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/admin/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def update_test_submission_status(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-test-submission-status/#{params[:submissionId]}",
           body: Seed::Submission::Types::TestSubmissionStatus.new(params).to_h
@@ -25,7 +25,7 @@ module Seed
       # @return [untyped]
       def send_test_submission_update(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-test-submission-status-v2/#{params[:submissionId]}",
           body: Seed::Submission::Types::TestSubmissionUpdate.new(params).to_h
@@ -39,7 +39,7 @@ module Seed
       # @return [untyped]
       def update_workspace_submission_status(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-workspace-submission-status/#{params[:submissionId]}",
           body: Seed::Submission::Types::WorkspaceSubmissionStatus.new(params).to_h
@@ -53,7 +53,7 @@ module Seed
       # @return [untyped]
       def send_workspace_submission_update(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-workspace-submission-status-v2/#{params[:submissionId]}",
           body: Seed::Submission::Types::WorkspaceSubmissionUpdate.new(params).to_h
@@ -69,7 +69,7 @@ module Seed
         _path_param_names = %w[submissionId testCaseId]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-test-trace/submission/#{params[:submissionId]}/testCase/#{params[:testCaseId]}",
           body: params.except(*_path_param_names)
@@ -83,7 +83,7 @@ module Seed
       # @return [untyped]
       def store_traced_test_case_v_2(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-test-trace-v2/submission/#{params[:submissionId]}/testCase/#{params[:testCaseId]}",
           body: params
@@ -99,7 +99,7 @@ module Seed
         _path_param_names = ["submissionId"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-workspace-trace/submission/#{params[:submissionId]}",
           body: params.except(*_path_param_names)
@@ -113,7 +113,7 @@ module Seed
       # @return [untyped]
       def store_traced_workspace_v_2(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/admin/store-workspace-trace-v2/submission/#{params[:submissionId]}",
           body: params

--- a/seed/ruby-sdk-v2/trace/lib/seed/homepage/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/homepage/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Array[String]]
       def get_homepage_problems(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: "/homepage-problems"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [untyped]
       def set_homepage_problems(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/homepage-problems",
           body: params

--- a/seed/ruby-sdk-v2/trace/lib/seed/migration/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/migration/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Array[Seed::Migration::Types::Migration]]
       def get_attempted_migrations(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: "/migration-info/all"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/playlist/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/playlist/client.rb
@@ -22,7 +22,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/v2/playlist/#{params[:serviceParam]}/create",
           query: _query,
@@ -46,7 +46,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: "/v2/playlist/#{params[:serviceParam]}/all",
           query: _query
@@ -62,7 +62,7 @@ module Seed
       # @return [Seed::Playlist::Types::Playlist]
       def get_playlist(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: "/v2/playlist/#{params[:serviceParam]}/#{params[:playlistId]}"
         )
@@ -77,7 +77,7 @@ module Seed
       # @return [Seed::Playlist::Types::Playlist | nil]
       def update_playlist(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "PUT",
           path: "/v2/playlist/#{params[:serviceParam]}/#{params[:playlistId]}",
           body: params
@@ -93,7 +93,7 @@ module Seed
       # @return [untyped]
       def delete_playlist(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "DELETE",
           path: "/v2/playlist/#{params[:serviceParam]}/#{params[:playlist_id]}"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/problem/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [Seed::Problem::Types::CreateProblemResponse]
       def create_problem(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/problem-crud/create",
           body: Seed::Problem::Types::CreateProblemRequest.new(params).to_h
@@ -31,7 +31,7 @@ module Seed
       # @return [Seed::Problem::Types::UpdateProblemResponse]
       def update_problem(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/problem-crud/update/#{params[:problemId]}",
           body: Seed::Problem::Types::CreateProblemRequest.new(params).to_h
@@ -49,7 +49,7 @@ module Seed
       # @return [untyped]
       def delete_problem(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "DELETE",
           path: "/problem-crud/delete/#{params[:problemId]}"
         )
@@ -64,7 +64,7 @@ module Seed
       # @return [Seed::Problem::Types::GetDefaultStarterFilesResponse]
       def get_default_starter_files(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/problem-crud/default-starter-files",
           body: params

--- a/seed/ruby-sdk-v2/trace/lib/seed/submission/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/submission/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [Seed::Submission::Types::ExecutionSessionResponse]
       def create_execution_session(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "POST",
           path: "/sessions/create-session/#{params[:language]}"
         )
@@ -30,7 +30,7 @@ module Seed
       # @return [Seed::Submission::Types::ExecutionSessionResponse | nil]
       def get_execution_session(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: "/sessions/#{params[:sessionId]}"
         )
@@ -45,7 +45,7 @@ module Seed
       # @return [untyped]
       def stop_execution_session(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "DELETE",
           path: "/sessions/stop/#{params[:sessionId]}"
         )
@@ -58,7 +58,7 @@ module Seed
       # @return [Seed::Submission::Types::GetExecutionSessionStateResponse]
       def get_execution_sessions_state(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: "/sessions/execution-sessions-state"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/sysprop/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/sysprop/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def set_num_warm_instances(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "PUT",
           path: "/sysprop/num-warm-instances/#{params[:language]}/#{params[:numWarmInstances]}"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [Hash[Seed::Commons::Types::Language, Integer]]
       def get_num_warm_instances(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: "/sysprop/num-warm-instances"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def test(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url] || Seed::Environment::Prod,
           method: "GET",
           path: ""
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/problem/client.rb
@@ -14,7 +14,7 @@ module Seed
         # @return [Array[Seed::V2::Problem::Types::LightweightProblemInfoV2]]
         def get_lightweight_problems(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url] || Seed::Environment::Prod,
             method: "GET",
             path: "/problems-v2/lightweight-problem-info"
           )
@@ -29,7 +29,7 @@ module Seed
         # @return [Array[Seed::V2::Problem::Types::ProblemInfoV2]]
         def get_problems(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url] || Seed::Environment::Prod,
             method: "GET",
             path: "/problems-v2/problem-info"
           )
@@ -44,7 +44,7 @@ module Seed
         # @return [Seed::V2::Problem::Types::ProblemInfoV2]
         def get_latest_problem(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url] || Seed::Environment::Prod,
             method: "GET",
             path: "/problems-v2/problem-info/#{params[:problemId]}"
           )
@@ -61,7 +61,7 @@ module Seed
         # @return [Seed::V2::Problem::Types::ProblemInfoV2]
         def get_problem_version(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+            base_url: request_options[:base_url] || Seed::Environment::Prod,
             method: "GET",
             path: "/problems-v2/problem-info/#{params[:problemId]}/version/#{params[:problemVersion]}"
           )

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/v_3/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/v_3/problem/client.rb
@@ -15,7 +15,7 @@ module Seed
           # @return [Array[Seed::V2::V3::Problem::Types::LightweightProblemInfoV2]]
           def get_lightweight_problems(request_options: {}, **_params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+              base_url: request_options[:base_url] || Seed::Environment::Prod,
               method: "GET",
               path: "/problems-v2/lightweight-problem-info"
             )
@@ -30,7 +30,7 @@ module Seed
           # @return [Array[Seed::V2::V3::Problem::Types::ProblemInfoV2]]
           def get_problems(request_options: {}, **_params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+              base_url: request_options[:base_url] || Seed::Environment::Prod,
               method: "GET",
               path: "/problems-v2/problem-info"
             )
@@ -45,7 +45,7 @@ module Seed
           # @return [Seed::V2::V3::Problem::Types::ProblemInfoV2]
           def get_latest_problem(request_options: {}, **params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+              base_url: request_options[:base_url] || Seed::Environment::Prod,
               method: "GET",
               path: "/problems-v2/problem-info/#{params[:problemId]}"
             )
@@ -62,7 +62,7 @@ module Seed
           # @return [Seed::V2::V3::Problem::Types::ProblemInfoV2]
           def get_problem_version(request_options: {}, **params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+              base_url: request_options[:base_url] || Seed::Environment::Prod,
               method: "GET",
               path: "/problems-v2/problem-info/#{params[:problemId]}/version/#{params[:problemVersion]}"
             )

--- a/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/union/client.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/union/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Union::Types::MyUnion]
       def get(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "",
           body: Seed::Union::Types::MyUnion.new(params).to_h
@@ -25,7 +25,7 @@ module Seed
       # @return [Hash[Seed::Union::Types::Key, String]]
       def get_metadata(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/metadata"
         )
@@ -38,7 +38,7 @@ module Seed
       # @return [bool]
       def update_metadata(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "PUT",
           path: "/metadata",
           body: Seed::Union::Types::MetadataUnion.new(params).to_h
@@ -52,7 +52,7 @@ module Seed
       # @return [bool]
       def call(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/call",
           body: Seed::Union::Types::Request.new(params).to_h
@@ -66,7 +66,7 @@ module Seed
       # @return [Seed::Union::Types::UnionWithDuplicateTypes]
       def duplicate_types_union(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/duplicate",
           body: Seed::Union::Types::UnionWithDuplicateTypes.new(params).to_h
@@ -82,7 +82,7 @@ module Seed
       # @return [String]
       def nested_unions(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/nested",
           body: Seed::Union::Types::NestedUnionRoot.new(params).to_h

--- a/seed/ruby-sdk-v2/unions/lib/seed/bigunion/client.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/bigunion/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Bigunion::Types::BigUnion]
       def get(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:id]}"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [bool]
       def update(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "",
           body: Seed::Bigunion::Types::BigUnion.new(params).to_h
@@ -38,7 +38,7 @@ module Seed
       # @return [Hash[String, bool]]
       def update_many(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "/many",
           body: params

--- a/seed/ruby-sdk-v2/unions/lib/seed/union/client.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/union/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Union::Types::Shape]
       def get(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/#{params[:id]}"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [bool]
       def update(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "PATCH",
           path: "",
           body: Seed::Union::Types::Shape.new(params).to_h

--- a/seed/ruby-sdk-v2/unknown/lib/seed/unknown/client.rb
+++ b/seed/ruby-sdk-v2/unknown/lib/seed/unknown/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Array[Hash[String, Object]]]
       def post(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "",
           body: params
@@ -25,7 +25,7 @@ module Seed
       # @return [Array[Hash[String, Object]]]
       def post_object(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/with-object",
           body: Seed::Unknown::Types::MyObject.new(params).to_h

--- a/seed/ruby-sdk-v2/variables/lib/seed/service/client.rb
+++ b/seed/ruby-sdk-v2/variables/lib/seed/service/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def post(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/#{params[:endpointParam]}"
         )

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/user/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module User
@@ -11,15 +10,19 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/users/#{params[:userId]}"
         )
         _response = @client.send(_request)
-        return Seed::User::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::User::Types::User.load(_response.body)
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/user/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module User
@@ -10,19 +11,15 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users/#{params[:userId]}"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::User::Types::User.load(_response.body)
-        else
-          raise _response.body
-        end
-      end
+        return Seed::User::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/version/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/user/client.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 module Seed
   module User
@@ -11,15 +10,19 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url]
+          ,
           method: "GET",
           path: "/users/#{params[:userId]}"
         )
         _response = @client.send(_request)
-        return Seed::User::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
-
-        raise _response.body
+        if _response.code >= "200" && _response.code < "300"
+          return Seed::User::Types::User.load(_response.body)
+        else
+          raise _response.body
+        end
       end
+
     end
   end
 end

--- a/seed/ruby-sdk-v2/version/lib/seed/user/client.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/user/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Seed
   module User
@@ -10,19 +11,15 @@ module Seed
       # @return [Seed::User::Types::User]
       def get_user(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url]
-          ,
+          base_url: request_options[:base_url],
           method: "GET",
           path: "/users/#{params[:userId]}"
         )
         _response = @client.send(_request)
-        if _response.code >= "200" && _response.code < "300"
-          return Seed::User::Types::User.load(_response.body)
-        else
-          raise _response.body
-        end
-      end
+        return Seed::User::Types::User.load(_response.body) if _response.code >= "200" && _response.code < "300"
 
+        raise _response.body
+      end
     end
   end
 end

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/auth/client.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/auth/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def get_token_with_client_credentials(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token",
           body: params
@@ -27,7 +27,7 @@ module Seed
       # @return [Seed::Auth::Types::TokenResponse]
       def refresh_token(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::SANDBOX,
+          base_url: request_options[:base_url],
           method: "POST",
           path: "/token/refresh",
           body: params


### PR DESCRIPTION
## Description
Before we were always falling back to `SANDBOX` environment, even if it wasn't specified. Now we fall back to default, or none if not specified.

## Testing
Existing seed fixtures