### PR TITLE
fix(ruby): Fix default environment reference

### DIFF
--- a/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
@@ -158,10 +158,24 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
         });
     }
 
-    public getDefaultEnvironmentClassReference(): ruby.ClassReference {
-        const defaultEnvironmentName = this.ir.environments?.defaultEnvironment ?? "SANDBOX";
+    public getDefaultEnvironmentClassReference() {
+        const defaultEnvironmentId = this.ir.environments?.defaultEnvironment;
+        if (defaultEnvironmentId == null) {
+            return undefined;
+        }
+
+        // Lookup the default environment by id
+        const defaultEnvironment = this.ir.environments?.environments.environments.find(
+            (env) => env.id === defaultEnvironmentId
+        );
+        if (defaultEnvironment == null) {
+            this.logger.warn(`Default environment ${defaultEnvironmentId} not found`);
+            return undefined;
+        }
+
+        // Return the class reference, performing the same casing as the SingleUrlEnvironmentGenerator
         return ruby.classReference({
-            name: defaultEnvironmentName,
+            name: defaultEnvironment.name.screamingSnakeCase.safeName,
             modules: [this.getRootModule().name, "Environment"]
         });
     }

--- a/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/RawClient.ts
@@ -33,9 +33,10 @@ export class RawClient {
     private writeBaseUrlDeclaration(writer: ruby.Writer): void {
         // Write base URL declaration, including default environment if specified
         writer.write("base_url: request_options[:base_url]");
-        if (this.context.ir.environments?.defaultEnvironment != null) {
+        const defaultEnvironmentReference = this.context.getDefaultEnvironmentClassReference();
+        if (defaultEnvironmentReference != null) {
             writer.write(" || ");
-            writer.writeNode(this.context.getDefaultEnvironmentClassReference());
+            writer.writeNode(defaultEnvironmentReference);
         }
     }
 

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.0.0-rc24
+  createdAt: "2025-09-16"
+  changelogEntry:
+    - type: fix
+      summary: Fix reference to the default environment to use SCREAMING_SNAKE_CASE.
+  irVersion: 58
+
 - version: 1.0.0-rc23
   createdAt: "2025-09-16"
   changelogEntry:

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/ec_2/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/ec_2/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def boot_instance(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Production,
+          base_url: request_options[:base_url] || Seed::Environment::PRODUCTION,
           method: "POST",
           path: "/ec2/boot",
           body: params

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/s_3/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/s_3/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [String]
       def get_presigned_url(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Production,
+          base_url: request_options[:base_url] || Seed::Environment::PRODUCTION,
           method: "POST",
           path: "/s3/presigned-url",
           body: params

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/dummy/client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/dummy/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [String]
       def get_dummy(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Production,
+          base_url: request_options[:base_url] || Seed::Environment::PRODUCTION,
           method: "GET",
           path: "dummy"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/admin/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/admin/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def update_test_submission_status(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-test-submission-status/#{params[:submissionId]}",
           body: Seed::Submission::Types::TestSubmissionStatus.new(params).to_h
@@ -25,7 +25,7 @@ module Seed
       # @return [untyped]
       def send_test_submission_update(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-test-submission-status-v2/#{params[:submissionId]}",
           body: Seed::Submission::Types::TestSubmissionUpdate.new(params).to_h
@@ -39,7 +39,7 @@ module Seed
       # @return [untyped]
       def update_workspace_submission_status(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-workspace-submission-status/#{params[:submissionId]}",
           body: Seed::Submission::Types::WorkspaceSubmissionStatus.new(params).to_h
@@ -53,7 +53,7 @@ module Seed
       # @return [untyped]
       def send_workspace_submission_update(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-workspace-submission-status-v2/#{params[:submissionId]}",
           body: Seed::Submission::Types::WorkspaceSubmissionUpdate.new(params).to_h
@@ -69,7 +69,7 @@ module Seed
         _path_param_names = %w[submissionId testCaseId]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-test-trace/submission/#{params[:submissionId]}/testCase/#{params[:testCaseId]}",
           body: params.except(*_path_param_names)
@@ -83,7 +83,7 @@ module Seed
       # @return [untyped]
       def store_traced_test_case_v_2(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-test-trace-v2/submission/#{params[:submissionId]}/testCase/#{params[:testCaseId]}",
           body: params
@@ -99,7 +99,7 @@ module Seed
         _path_param_names = ["submissionId"]
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-workspace-trace/submission/#{params[:submissionId]}",
           body: params.except(*_path_param_names)
@@ -113,7 +113,7 @@ module Seed
       # @return [untyped]
       def store_traced_workspace_v_2(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/admin/store-workspace-trace-v2/submission/#{params[:submissionId]}",
           body: params

--- a/seed/ruby-sdk-v2/trace/lib/seed/homepage/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/homepage/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Array[String]]
       def get_homepage_problems(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: "/homepage-problems"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [untyped]
       def set_homepage_problems(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/homepage-problems",
           body: params

--- a/seed/ruby-sdk-v2/trace/lib/seed/migration/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/migration/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [Array[Seed::Migration::Types::Migration]]
       def get_attempted_migrations(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: "/migration-info/all"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/playlist/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/playlist/client.rb
@@ -22,7 +22,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/v2/playlist/#{params[:serviceParam]}/create",
           query: _query,
@@ -46,7 +46,7 @@ module Seed
         params = params.except(*_query_param_names)
 
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: "/v2/playlist/#{params[:serviceParam]}/all",
           query: _query
@@ -62,7 +62,7 @@ module Seed
       # @return [Seed::Playlist::Types::Playlist]
       def get_playlist(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: "/v2/playlist/#{params[:serviceParam]}/#{params[:playlistId]}"
         )
@@ -77,7 +77,7 @@ module Seed
       # @return [Seed::Playlist::Types::Playlist | nil]
       def update_playlist(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "PUT",
           path: "/v2/playlist/#{params[:serviceParam]}/#{params[:playlistId]}",
           body: params
@@ -93,7 +93,7 @@ module Seed
       # @return [untyped]
       def delete_playlist(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "DELETE",
           path: "/v2/playlist/#{params[:serviceParam]}/#{params[:playlist_id]}"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/problem/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [Seed::Problem::Types::CreateProblemResponse]
       def create_problem(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/problem-crud/create",
           body: Seed::Problem::Types::CreateProblemRequest.new(params).to_h
@@ -31,7 +31,7 @@ module Seed
       # @return [Seed::Problem::Types::UpdateProblemResponse]
       def update_problem(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/problem-crud/update/#{params[:problemId]}",
           body: Seed::Problem::Types::CreateProblemRequest.new(params).to_h
@@ -49,7 +49,7 @@ module Seed
       # @return [untyped]
       def delete_problem(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "DELETE",
           path: "/problem-crud/delete/#{params[:problemId]}"
         )
@@ -64,7 +64,7 @@ module Seed
       # @return [Seed::Problem::Types::GetDefaultStarterFilesResponse]
       def get_default_starter_files(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/problem-crud/default-starter-files",
           body: params

--- a/seed/ruby-sdk-v2/trace/lib/seed/submission/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/submission/client.rb
@@ -13,7 +13,7 @@ module Seed
       # @return [Seed::Submission::Types::ExecutionSessionResponse]
       def create_execution_session(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "POST",
           path: "/sessions/create-session/#{params[:language]}"
         )
@@ -30,7 +30,7 @@ module Seed
       # @return [Seed::Submission::Types::ExecutionSessionResponse | nil]
       def get_execution_session(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: "/sessions/#{params[:sessionId]}"
         )
@@ -45,7 +45,7 @@ module Seed
       # @return [untyped]
       def stop_execution_session(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "DELETE",
           path: "/sessions/stop/#{params[:sessionId]}"
         )
@@ -58,7 +58,7 @@ module Seed
       # @return [Seed::Submission::Types::GetExecutionSessionStateResponse]
       def get_execution_sessions_state(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: "/sessions/execution-sessions-state"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/sysprop/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/sysprop/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def set_num_warm_instances(request_options: {}, **params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "PUT",
           path: "/sysprop/num-warm-instances/#{params[:language]}/#{params[:numWarmInstances]}"
         )
@@ -24,7 +24,7 @@ module Seed
       # @return [Hash[Seed::Commons::Types::Language, Integer]]
       def get_num_warm_instances(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: "/sysprop/num-warm-instances"
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/client.rb
@@ -11,7 +11,7 @@ module Seed
       # @return [untyped]
       def test(request_options: {}, **_params)
         _request = Seed::Internal::JSON::Request.new(
-          base_url: request_options[:base_url] || Seed::Environment::Prod,
+          base_url: request_options[:base_url] || Seed::Environment::PROD,
           method: "GET",
           path: ""
         )

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/problem/client.rb
@@ -14,7 +14,7 @@ module Seed
         # @return [Array[Seed::V2::Problem::Types::LightweightProblemInfoV2]]
         def get_lightweight_problems(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::Prod,
+            base_url: request_options[:base_url] || Seed::Environment::PROD,
             method: "GET",
             path: "/problems-v2/lightweight-problem-info"
           )
@@ -29,7 +29,7 @@ module Seed
         # @return [Array[Seed::V2::Problem::Types::ProblemInfoV2]]
         def get_problems(request_options: {}, **_params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::Prod,
+            base_url: request_options[:base_url] || Seed::Environment::PROD,
             method: "GET",
             path: "/problems-v2/problem-info"
           )
@@ -44,7 +44,7 @@ module Seed
         # @return [Seed::V2::Problem::Types::ProblemInfoV2]
         def get_latest_problem(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::Prod,
+            base_url: request_options[:base_url] || Seed::Environment::PROD,
             method: "GET",
             path: "/problems-v2/problem-info/#{params[:problemId]}"
           )
@@ -61,7 +61,7 @@ module Seed
         # @return [Seed::V2::Problem::Types::ProblemInfoV2]
         def get_problem_version(request_options: {}, **params)
           _request = Seed::Internal::JSON::Request.new(
-            base_url: request_options[:base_url] || Seed::Environment::Prod,
+            base_url: request_options[:base_url] || Seed::Environment::PROD,
             method: "GET",
             path: "/problems-v2/problem-info/#{params[:problemId]}/version/#{params[:problemVersion]}"
           )

--- a/seed/ruby-sdk-v2/trace/lib/seed/v_2/v_3/problem/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/v_2/v_3/problem/client.rb
@@ -15,7 +15,7 @@ module Seed
           # @return [Array[Seed::V2::V3::Problem::Types::LightweightProblemInfoV2]]
           def get_lightweight_problems(request_options: {}, **_params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::Prod,
+              base_url: request_options[:base_url] || Seed::Environment::PROD,
               method: "GET",
               path: "/problems-v2/lightweight-problem-info"
             )
@@ -30,7 +30,7 @@ module Seed
           # @return [Array[Seed::V2::V3::Problem::Types::ProblemInfoV2]]
           def get_problems(request_options: {}, **_params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::Prod,
+              base_url: request_options[:base_url] || Seed::Environment::PROD,
               method: "GET",
               path: "/problems-v2/problem-info"
             )
@@ -45,7 +45,7 @@ module Seed
           # @return [Seed::V2::V3::Problem::Types::ProblemInfoV2]
           def get_latest_problem(request_options: {}, **params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::Prod,
+              base_url: request_options[:base_url] || Seed::Environment::PROD,
               method: "GET",
               path: "/problems-v2/problem-info/#{params[:problemId]}"
             )
@@ -62,7 +62,7 @@ module Seed
           # @return [Seed::V2::V3::Problem::Types::ProblemInfoV2]
           def get_problem_version(request_options: {}, **params)
             _request = Seed::Internal::JSON::Request.new(
-              base_url: request_options[:base_url] || Seed::Environment::Prod,
+              base_url: request_options[:base_url] || Seed::Environment::PROD,
               method: "GET",
               path: "/problems-v2/problem-info/#{params[:problemId]}/version/#{params[:problemVersion]}"
             )


### PR DESCRIPTION
## Description
The reference to the default env made in https://github.com/fern-api/fern/pull/9444 wasn't properly using SCREAMING_SNAKE_CASE, which the env class generator was.

## Changes Made
- Fix change to use SCREAMING_SNAKE_CASE ref
- While here, completely remove hardcoded SANDBOX

## Testing
Existing tests that I didn't look closely enough at