### PR TITLE
feat(go): setters, support for explicit null

### DIFF
--- a/generators/go/internal/generator/file_writer.go
+++ b/generators/go/internal/generator/file_writer.go
@@ -170,7 +170,8 @@ func (f *fileWriter) WriteRaw(s string) {
 	fmt.Fprint(f.buffer, s)
 }
 
-// WriteStructPropertyBitConstants writes bigint constants for each property of a struct.
+// WriteStructPropertyBitConstants writes bigint constants for each property of a struct;
+// these are used when interfacing with explicitFields.
 func (f *fileWriter) WriteStructPropertyBitConstants(typeName string, propertyNames []string) {
 	if len(propertyNames) == 0 {
 		return
@@ -187,7 +188,7 @@ func (f *fileWriter) WriteStructPropertyBitConstants(typeName string, propertyNa
 	f.P()
 }
 
-// WriteSetterMethods writes setter methods for each field that call the require method.
+// WriteSetterMethods writes setter methods for each field.
 func (f *fileWriter) WriteSetterMethods(typeName string, propertyNames []string, propertyTypes []string, propertySafeNames []string) {
 	if len(propertyNames) == 0 {
 		return
@@ -204,6 +205,8 @@ func (f *fileWriter) WriteSetterMethods(typeName string, propertyNames []string,
 		paramName := propertySafeNames[i]
 		propertyType := propertyTypes[i]
 
+		f.P("// ", setterName, " sets the ", propertyName, " field and marks it as non-optional;")
+		f.P("// ", "this prevents an empty or null value for this field from being omitted during serialization.")
 		f.P("func (", receiver, " *", typeName, ") ", setterName, "(", paramName, " ", propertyType, ") {")
 		f.P("\t", receiver, ".", propertyName, " = ", paramName)
 		f.P("\t", receiver, ".require(", fieldConstantName, ")")

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -333,6 +333,8 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 	files = append(files, modelFiles...)
 	files = append(files, newStringerFile(g.coordinator))
 	files = append(files, newTimeFile(g.coordinator))
+	files = append(files, newExplicitFieldsFile(g.coordinator))
+	files = append(files, newExplicitFieldsTestFile(g.coordinator))
 	files = append(files, newExtraPropertiesFile(g.coordinator))
 	files = append(files, newExtraPropertiesTestFile(g.coordinator))
 	// Then handle mode-specific generation tasks.
@@ -1362,6 +1364,22 @@ func newTimeFile(coordinator *coordinator.Client) *File {
 		coordinator,
 		"internal/time.go",
 		[]byte(timeFile),
+	)
+}
+
+func newExplicitFieldsFile(coordinator *coordinator.Client) *File {
+	return NewFile(
+		coordinator,
+		"internal/explicit_fields.go",
+		[]byte(explicitFieldsFile),
+	)
+}
+
+func newExplicitFieldsTestFile(coordinator *coordinator.Client) *File {
+	return NewFile(
+		coordinator,
+		"internal/explicit_fields_test.go",
+		[]byte(explicitFieldsTestFile),
 	)
 }
 

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -35,6 +35,12 @@ var (
 	//go:embed sdk/internal/error_decoder_test.go
 	errorDecoderTestFile string
 
+	//go:embed sdk/internal/explicit_fields.go
+	explicitFieldsFile string
+
+	//go:embed sdk/internal/explicit_fields_test.go
+	explicitFieldsTestFile string
+
 	//go:embed sdk/internal/extra_properties.go
 	extraPropertiesFile string
 

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -2753,6 +2753,59 @@ func (f *fileWriter) WriteRequestType(
 		importPath = fernFilepathToImportPath(f.baseImportPath, fernFilepath)
 	)
 
+	// Collect all property names and types for bigint constants and setters
+	var propertyNames []string
+	var propertyTypes []string
+	var propertySafeNames []string
+
+	// Collect from headers (exclude literals as they don't need setters)
+	for _, header := range append(serviceHeaders, endpoint.Headers...) {
+		if header.ValueType.Container == nil || header.ValueType.Container.Literal == nil {
+			propertyNames = append(propertyNames, header.Name.Name.PascalCase.UnsafeName)
+			propertySafeNames = append(propertySafeNames, header.Name.Name.CamelCase.SafeName)
+			goType := typeReferenceToGoType(header.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
+			propertyTypes = append(propertyTypes, goType)
+		}
+	}
+
+	// Collect from path parameters (always include these)
+	if includePathParametersInWrappedRequest(endpoint, f.inlinePathParameters) {
+		for _, pathParameter := range endpoint.AllPathParameters {
+			propertyNames = append(propertyNames, pathParameter.Name.PascalCase.UnsafeName)
+			propertySafeNames = append(propertySafeNames, pathParameter.Name.CamelCase.SafeName)
+			goType := typeReferenceToGoType(pathParameter.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
+			propertyTypes = append(propertyTypes, goType)
+		}
+	}
+
+	// Collect from query parameters (always include these, exclude literals)
+	for _, queryParam := range endpoint.QueryParameters {
+		if queryParam.ValueType.Container == nil || queryParam.ValueType.Container.Literal == nil {
+			propertyNames = append(propertyNames, queryParam.Name.Name.PascalCase.UnsafeName)
+			propertySafeNames = append(propertySafeNames, queryParam.Name.Name.CamelCase.SafeName)
+			goType := typeReferenceToGoType(queryParam.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
+			if queryParam.AllowMultiple {
+				goType = fmt.Sprintf("[]%s", goType)
+			}
+			propertyTypes = append(propertyTypes, goType)
+		}
+	}
+
+	// Collect from request body properties if it's an inlined request body
+	if endpoint.RequestBody != nil && endpoint.RequestBody.InlinedRequestBody != nil {
+		for _, property := range endpoint.RequestBody.InlinedRequestBody.Properties {
+			if property.ValueType.Container == nil || property.ValueType.Container.Literal == nil {
+				propertyNames = append(propertyNames, property.Name.Name.PascalCase.UnsafeName)
+				propertySafeNames = append(propertySafeNames, property.Name.Name.CamelCase.SafeName)
+				goType := typeReferenceToGoType(property.ValueType, f.types, f.scope, f.baseImportPath, importPath, false)
+				propertyTypes = append(propertyTypes, goType)
+			}
+		}
+	}
+
+	// Write bigint constants for request type properties
+	f.WriteStructPropertyBitConstants(typeName, propertyNames)
+
 	var literals []*literal
 	f.P("type ", typeName, " struct {")
 	for _, header := range append(serviceHeaders, endpoint.Headers...) {
@@ -2800,6 +2853,7 @@ func (f *fileWriter) WriteRequestType(
 		for _, literal := range literals {
 			f.P(literal.Name.Name.CamelCase.SafeName, " ", literalToGoType(literal.Value))
 		}
+		f.WriteExplicitFields()
 		f.P("}")
 		f.P()
 		for _, literal := range literals {
@@ -2808,6 +2862,13 @@ func (f *fileWriter) WriteRequestType(
 			f.P("}")
 			f.P()
 		}
+
+		// Write the require helper method
+		f.WriteRequireMethod(typeName)
+
+		// Write setter methods for all properties
+		f.WriteSetterMethods(typeName, propertyNames, propertyTypes, propertySafeNames)
+
 		return nil
 	}
 	requestBody, err := requestBodyToFieldDeclaration(endpoint.RequestBody, f, importPath, bodyField, includeGenericOptionals, inlineFileProperties)
@@ -2822,6 +2883,7 @@ func (f *fileWriter) WriteRequestType(
 		f.P()
 		f.P("ExtraProperties map[string]interface{} `json:\"-\" url:\"-\"`")
 	}
+	f.WriteExplicitFields()
 	f.P("}")
 	f.P()
 	// Implement the getter methods.
@@ -2831,6 +2893,13 @@ func (f *fileWriter) WriteRequestType(
 		f.P("}")
 		f.P()
 	}
+
+	// Write the require helper method
+	f.WriteRequireMethod(typeName)
+
+	// Write setter methods for all properties
+	fmt.Printf("[DEBUG] WriteRequestType: Writing setters for %s (with request body)\n", typeName)
+	f.WriteSetterMethods(typeName, propertyNames, propertyTypes, propertySafeNames)
 
 	var (
 		referenceType      string
@@ -2918,10 +2987,11 @@ func (f *fileWriter) WriteRequestType(
 			f.P(literal.Name.Name.PascalCase.UnsafeName, ": ", literalToValue(literal.Value), ",")
 		}
 		f.P("}")
+		f.P("explicitMarshaler := internal.HandleExplicitFields(marshaler, ", receiver, ".explicitFields)")
 		if requestBody.extraProperties {
-			f.P("return internal.MarshalJSONWithExtraProperties(marshaler, ", receiver, ".ExtraProperties)")
+			f.P("return internal.MarshalJSONWithExtraProperties(explicitMarshaler, ", receiver, ".ExtraProperties)")
 		} else {
-			f.P("return json.Marshal(marshaler)")
+			f.P("return json.Marshal(explicitMarshaler)")
 		}
 	}
 	f.P("}")

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -2898,7 +2898,6 @@ func (f *fileWriter) WriteRequestType(
 	f.WriteRequireMethod(typeName)
 
 	// Write setter methods for all properties
-	fmt.Printf("[DEBUG] WriteRequestType: Writing setters for %s (with request body)\n", typeName)
 	f.WriteSetterMethods(typeName, propertyNames, propertyTypes, propertySafeNames)
 
 	var (

--- a/generators/go/internal/generator/sdk/internal/explicit_fields.go
+++ b/generators/go/internal/generator/sdk/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/generators/go/internal/generator/sdk/internal/explicit_fields_test.go
+++ b/generators/go/internal/generator/sdk/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.10.0
+  changelogEntry:
+    - summary: |
+        Adds setter methods for all objects; these also mark their respective fields as required,
+        such that you can now specify explicit null values for optional fields.
+      type: feat
+  createdAt: "2025-09-16"
+  irVersion: 59
+
 - version: 1.9.0
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/accept-header/internal/explicit_fields.go
+++ b/seed/go-sdk/accept-header/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/accept-header/internal/explicit_fields_test.go
+++ b/seed/go-sdk/accept-header/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/alias/internal/explicit_fields.go
+++ b/seed/go-sdk/alias/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/alias/internal/explicit_fields_test.go
+++ b/seed/go-sdk/alias/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/alias/types.go
+++ b/seed/go-sdk/alias/types.go
@@ -54,11 +54,15 @@ func (t *Type) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetId(id TypeId) {
 	t.Id = id
 	t.require(typeFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetName(name string) {
 	t.Name = name
 	t.require(typeFieldName)

--- a/seed/go-sdk/alias/types.go
+++ b/seed/go-sdk/alias/types.go
@@ -6,15 +6,24 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/alias/fern/internal"
+	big "math/big"
 )
 
 // Object is an alias for a type.
 type Object = *Type
 
 // A simple type with just a name.
+var (
+	typeFieldId   = big.NewInt(1 << 0)
+	typeFieldName = big.NewInt(1 << 1)
+)
+
 type Type struct {
 	Id   TypeId `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -38,6 +47,23 @@ func (t *Type) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Type) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Type) SetId(id TypeId) {
+	t.Id = id
+	t.require(typeFieldId)
+}
+
+func (t *Type) SetName(name string) {
+	t.Name = name
+	t.require(typeFieldName)
+}
+
 func (t *Type) UnmarshalJSON(data []byte) error {
 	type unmarshaler Type
 	var value unmarshaler
@@ -52,6 +78,17 @@ func (t *Type) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Type) MarshalJSON() ([]byte, error) {
+	type embed Type
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Type) String() string {

--- a/seed/go-sdk/any-auth/auth.go
+++ b/seed/go-sdk/any-auth/auth.go
@@ -41,16 +41,22 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -134,16 +140,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/any-auth/auth.go
+++ b/seed/go-sdk/any-auth/auth.go
@@ -6,6 +6,13 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/any-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	getTokenRequestFieldScope        = big.NewInt(1 << 2)
 )
 
 type GetTokenRequest struct {
@@ -14,6 +21,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -22,6 +32,28 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -47,14 +79,24 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -85,6 +127,28 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -99,6 +163,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/any-auth/internal/explicit_fields.go
+++ b/seed/go-sdk/any-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/any-auth/internal/explicit_fields_test.go
+++ b/seed/go-sdk/any-auth/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/any-auth/user.go
+++ b/seed/go-sdk/any-auth/user.go
@@ -50,11 +50,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id string) {
 	u.Id = id
 	u.require(userFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)

--- a/seed/go-sdk/api-wide-base-path/internal/explicit_fields.go
+++ b/seed/go-sdk/api-wide-base-path/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/api-wide-base-path/internal/explicit_fields_test.go
+++ b/seed/go-sdk/api-wide-base-path/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/audiences/foldera/service.go
+++ b/seed/go-sdk/audiences/foldera/service.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderb "github.com/audiences/fern/folderb"
 	internal "github.com/audiences/fern/internal"
+	big "math/big"
+)
+
+var (
+	responseFieldFoo = big.NewInt(1 << 0)
 )
 
 type Response struct {
 	Foo *folderb.Foo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -27,6 +35,18 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetFoo(foo *folderb.Foo) {
+	r.Foo = foo
+	r.require(responseFieldFoo)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -41,6 +61,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	r.extraProperties = extraProperties
 	r.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Response) String() string {

--- a/seed/go-sdk/audiences/foldera/service.go
+++ b/seed/go-sdk/audiences/foldera/service.go
@@ -42,6 +42,8 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetFoo(foo *folderb.Foo) {
 	r.Foo = foo
 	r.require(responseFieldFoo)

--- a/seed/go-sdk/audiences/folderb/common.go
+++ b/seed/go-sdk/audiences/folderb/common.go
@@ -42,6 +42,8 @@ func (f *Foo) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *Foo) SetFoo(foo *folderc.FolderCFoo) {
 	f.Foo = foo
 	f.require(fooFieldFoo)

--- a/seed/go-sdk/audiences/folderb/common.go
+++ b/seed/go-sdk/audiences/folderb/common.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderc "github.com/audiences/fern/folderc"
 	internal "github.com/audiences/fern/internal"
+	big "math/big"
+)
+
+var (
+	fooFieldFoo = big.NewInt(1 << 0)
 )
 
 type Foo struct {
 	Foo *folderc.FolderCFoo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -27,6 +35,18 @@ func (f *Foo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Foo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *Foo) SetFoo(foo *folderc.FolderCFoo) {
+	f.Foo = foo
+	f.require(fooFieldFoo)
+}
+
 func (f *Foo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Foo
 	var value unmarshaler
@@ -41,6 +61,17 @@ func (f *Foo) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *Foo) MarshalJSON() ([]byte, error) {
+	type embed Foo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *Foo) String() string {

--- a/seed/go-sdk/audiences/folderc/common.go
+++ b/seed/go-sdk/audiences/folderc/common.go
@@ -42,6 +42,8 @@ func (f *FolderCFoo) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetBarProperty sets the BarProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FolderCFoo) SetBarProperty(barProperty uuid.UUID) {
 	f.BarProperty = barProperty
 	f.require(folderCFooFieldBarProperty)

--- a/seed/go-sdk/audiences/folderc/common.go
+++ b/seed/go-sdk/audiences/folderc/common.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	internal "github.com/audiences/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
+)
+
+var (
+	folderCFooFieldBarProperty = big.NewInt(1 << 0)
 )
 
 type FolderCFoo struct {
 	BarProperty uuid.UUID `json:"bar_property" url:"bar_property"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -27,6 +35,18 @@ func (f *FolderCFoo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *FolderCFoo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FolderCFoo) SetBarProperty(barProperty uuid.UUID) {
+	f.BarProperty = barProperty
+	f.require(folderCFooFieldBarProperty)
+}
+
 func (f *FolderCFoo) UnmarshalJSON(data []byte) error {
 	type unmarshaler FolderCFoo
 	var value unmarshaler
@@ -41,6 +61,17 @@ func (f *FolderCFoo) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *FolderCFoo) MarshalJSON() ([]byte, error) {
+	type embed FolderCFoo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *FolderCFoo) String() string {

--- a/seed/go-sdk/audiences/folderd/service.go
+++ b/seed/go-sdk/audiences/folderd/service.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/audiences/fern/internal"
+	big "math/big"
+)
+
+var (
+	responseFieldFoo = big.NewInt(1 << 0)
 )
 
 type Response struct {
 	Foo string `json:"foo" url:"foo"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetFoo(foo string) {
+	r.Foo = foo
+	r.require(responseFieldFoo)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	r.extraProperties = extraProperties
 	r.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Response) String() string {

--- a/seed/go-sdk/audiences/folderd/service.go
+++ b/seed/go-sdk/audiences/folderd/service.go
@@ -41,6 +41,8 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetFoo(foo string) {
 	r.Foo = foo
 	r.require(responseFieldFoo)

--- a/seed/go-sdk/audiences/foo.go
+++ b/seed/go-sdk/audiences/foo.go
@@ -6,17 +6,57 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/audiences/fern/internal"
+	big "math/big"
+)
+
+var (
+	findRequestFieldOptionalString  = big.NewInt(1 << 0)
+	findRequestFieldPublicProperty  = big.NewInt(1 << 1)
+	findRequestFieldPrivateProperty = big.NewInt(1 << 2)
 )
 
 type FindRequest struct {
 	OptionalString  OptionalString `json:"-" url:"optionalString,omitempty"`
 	PublicProperty  *string        `json:"publicProperty,omitempty" url:"-"`
 	PrivateProperty *int           `json:"privateProperty,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (f *FindRequest) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FindRequest) SetOptionalString(optionalString OptionalString) {
+	f.OptionalString = optionalString
+	f.require(findRequestFieldOptionalString)
+}
+
+func (f *FindRequest) SetPublicProperty(publicProperty *string) {
+	f.PublicProperty = publicProperty
+	f.require(findRequestFieldPublicProperty)
+}
+
+func (f *FindRequest) SetPrivateProperty(privateProperty *int) {
+	f.PrivateProperty = privateProperty
+	f.require(findRequestFieldPrivateProperty)
+}
+
+var (
+	filteredTypeFieldPublicProperty  = big.NewInt(1 << 0)
+	filteredTypeFieldPrivateProperty = big.NewInt(1 << 1)
+)
 
 type FilteredType struct {
 	PublicProperty  *string `json:"public_property,omitempty" url:"public_property,omitempty"`
 	PrivateProperty int     `json:"private_property" url:"private_property"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -40,6 +80,23 @@ func (f *FilteredType) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *FilteredType) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FilteredType) SetPublicProperty(publicProperty *string) {
+	f.PublicProperty = publicProperty
+	f.require(filteredTypeFieldPublicProperty)
+}
+
+func (f *FilteredType) SetPrivateProperty(privateProperty int) {
+	f.PrivateProperty = privateProperty
+	f.require(filteredTypeFieldPrivateProperty)
+}
+
 func (f *FilteredType) UnmarshalJSON(data []byte) error {
 	type unmarshaler FilteredType
 	var value unmarshaler
@@ -56,6 +113,17 @@ func (f *FilteredType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FilteredType) MarshalJSON() ([]byte, error) {
+	type embed FilteredType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FilteredType) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -68,8 +136,15 @@ func (f *FilteredType) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	importingTypeFieldImported = big.NewInt(1 << 0)
+)
+
 type ImportingType struct {
 	Imported Imported `json:"imported" url:"imported"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -86,6 +161,18 @@ func (i *ImportingType) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *ImportingType) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *ImportingType) SetImported(imported Imported) {
+	i.Imported = imported
+	i.require(importingTypeFieldImported)
+}
+
 func (i *ImportingType) UnmarshalJSON(data []byte) error {
 	type unmarshaler ImportingType
 	var value unmarshaler
@@ -100,6 +187,17 @@ func (i *ImportingType) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *ImportingType) MarshalJSON() ([]byte, error) {
+	type embed ImportingType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *ImportingType) String() string {

--- a/seed/go-sdk/audiences/foo.go
+++ b/seed/go-sdk/audiences/foo.go
@@ -31,16 +31,22 @@ func (f *FindRequest) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FindRequest) SetOptionalString(optionalString OptionalString) {
 	f.OptionalString = optionalString
 	f.require(findRequestFieldOptionalString)
 }
 
+// SetPublicProperty sets the PublicProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FindRequest) SetPublicProperty(publicProperty *string) {
 	f.PublicProperty = publicProperty
 	f.require(findRequestFieldPublicProperty)
 }
 
+// SetPrivateProperty sets the PrivateProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FindRequest) SetPrivateProperty(privateProperty *int) {
 	f.PrivateProperty = privateProperty
 	f.require(findRequestFieldPrivateProperty)
@@ -87,11 +93,15 @@ func (f *FilteredType) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetPublicProperty sets the PublicProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FilteredType) SetPublicProperty(publicProperty *string) {
 	f.PublicProperty = publicProperty
 	f.require(filteredTypeFieldPublicProperty)
 }
 
+// SetPrivateProperty sets the PrivateProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FilteredType) SetPrivateProperty(privateProperty int) {
 	f.PrivateProperty = privateProperty
 	f.require(filteredTypeFieldPrivateProperty)
@@ -168,6 +178,8 @@ func (i *ImportingType) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetImported sets the Imported field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *ImportingType) SetImported(imported Imported) {
 	i.Imported = imported
 	i.require(importingTypeFieldImported)

--- a/seed/go-sdk/audiences/internal/explicit_fields.go
+++ b/seed/go-sdk/audiences/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/audiences/internal/explicit_fields_test.go
+++ b/seed/go-sdk/audiences/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/auth-environment-variables/internal/explicit_fields.go
+++ b/seed/go-sdk/auth-environment-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/auth-environment-variables/internal/explicit_fields_test.go
+++ b/seed/go-sdk/auth-environment-variables/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/auth-environment-variables/service.go
+++ b/seed/go-sdk/auth-environment-variables/service.go
@@ -25,6 +25,8 @@ func (h *HeaderAuthRequest) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetXEndpointHeader sets the XEndpointHeader field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HeaderAuthRequest) SetXEndpointHeader(xEndpointHeader string) {
 	h.XEndpointHeader = xEndpointHeader
 	h.require(headerAuthRequestFieldXEndpointHeader)

--- a/seed/go-sdk/auth-environment-variables/service.go
+++ b/seed/go-sdk/auth-environment-variables/service.go
@@ -2,7 +2,30 @@
 
 package authenvironmentvariables
 
+import (
+	big "math/big"
+)
+
+var (
+	headerAuthRequestFieldXEndpointHeader = big.NewInt(1 << 0)
+)
+
 type HeaderAuthRequest struct {
 	// Specifies the endpoint key.
 	XEndpointHeader string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (h *HeaderAuthRequest) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HeaderAuthRequest) SetXEndpointHeader(xEndpointHeader string) {
+	h.XEndpointHeader = xEndpointHeader
+	h.require(headerAuthRequestFieldXEndpointHeader)
 }

--- a/seed/go-sdk/basic-auth-environment-variables/internal/explicit_fields.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/basic-auth-environment-variables/internal/explicit_fields_test.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/basic-auth-environment-variables/types.go
+++ b/seed/go-sdk/basic-auth-environment-variables/types.go
@@ -41,6 +41,8 @@ func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
 	u.Message = message
 	u.require(unauthorizedRequestErrorBodyFieldMessage)

--- a/seed/go-sdk/basic-auth-environment-variables/types.go
+++ b/seed/go-sdk/basic-auth-environment-variables/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/basic-auth-environment-variables/fern/internal"
+	big "math/big"
+)
+
+var (
+	unauthorizedRequestErrorBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type UnauthorizedRequestErrorBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]interface
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
+	u.Message = message
+	u.require(unauthorizedRequestErrorBodyFieldMessage)
+}
+
 func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler UnauthorizedRequestErrorBody
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *UnauthorizedRequestErrorBody) MarshalJSON() ([]byte, error) {
+	type embed UnauthorizedRequestErrorBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UnauthorizedRequestErrorBody) String() string {

--- a/seed/go-sdk/basic-auth/internal/explicit_fields.go
+++ b/seed/go-sdk/basic-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/basic-auth/internal/explicit_fields_test.go
+++ b/seed/go-sdk/basic-auth/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/basic-auth/types.go
+++ b/seed/go-sdk/basic-auth/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/basic-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	unauthorizedRequestErrorBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type UnauthorizedRequestErrorBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]interface
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
+	u.Message = message
+	u.require(unauthorizedRequestErrorBodyFieldMessage)
+}
+
 func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler UnauthorizedRequestErrorBody
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *UnauthorizedRequestErrorBody) MarshalJSON() ([]byte, error) {
+	type embed UnauthorizedRequestErrorBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UnauthorizedRequestErrorBody) String() string {

--- a/seed/go-sdk/basic-auth/types.go
+++ b/seed/go-sdk/basic-auth/types.go
@@ -41,6 +41,8 @@ func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
 	u.Message = message
 	u.require(unauthorizedRequestErrorBodyFieldMessage)

--- a/seed/go-sdk/bearer-token-environment-variable/internal/explicit_fields.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/bearer-token-environment-variable/internal/explicit_fields_test.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/bytes-upload/internal/explicit_fields.go
+++ b/seed/go-sdk/bytes-upload/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/bytes-upload/internal/explicit_fields_test.go
+++ b/seed/go-sdk/bytes-upload/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/circular-references-advanced/a.go
+++ b/seed/go-sdk/circular-references-advanced/a.go
@@ -41,6 +41,8 @@ func (a *A) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *A) SetS(s string) {
 	a.S = s
 	a.require(aFieldS)

--- a/seed/go-sdk/circular-references-advanced/a.go
+++ b/seed/go-sdk/circular-references-advanced/a.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references-advanced/fern/internal"
+	big "math/big"
+)
+
+var (
+	aFieldS = big.NewInt(1 << 0)
 )
 
 type A struct {
 	S string `json:"s" url:"s"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (a *A) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *A) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *A) SetS(s string) {
+	a.S = s
+	a.require(aFieldS)
+}
+
 func (a *A) UnmarshalJSON(data []byte) error {
 	type unmarshaler A
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (a *A) UnmarshalJSON(data []byte) error {
 	a.extraProperties = extraProperties
 	a.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (a *A) MarshalJSON() ([]byte, error) {
+	type embed A
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *A) String() string {

--- a/seed/go-sdk/circular-references-advanced/ast.go
+++ b/seed/go-sdk/circular-references-advanced/ast.go
@@ -41,6 +41,8 @@ func (a *Acai) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetAnimal sets the Animal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Acai) SetAnimal(animal *Animal) {
 	a.Animal = animal
 	a.require(acaiFieldAnimal)
@@ -179,6 +181,8 @@ func (b *Berry) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetAnimal sets the Animal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *Berry) SetAnimal(animal *Animal) {
 	b.Animal = animal
 	b.require(berryFieldAnimal)
@@ -255,6 +259,8 @@ func (b *BranchNode) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetChildren sets the Children field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BranchNode) SetChildren(children []*Node) {
 	b.Children = children
 	b.require(branchNodeFieldChildren)
@@ -331,6 +337,8 @@ func (c *Cat) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetFruit sets the Fruit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Cat) SetFruit(fruit *Fruit) {
 	c.Fruit = fruit
 	c.require(catFieldFruit)
@@ -542,6 +550,8 @@ func (d *Dog) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetFruit sets the Fruit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Dog) SetFruit(fruit *Fruit) {
 	d.Fruit = fruit
 	d.require(dogFieldFruit)
@@ -779,6 +789,8 @@ func (f *Fig) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetAnimal sets the Animal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *Fig) SetAnimal(animal *Animal) {
 	f.Animal = animal
 	f.require(figFieldAnimal)
@@ -1038,6 +1050,8 @@ func (n *NodesWrapper) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NodesWrapper) SetNodes(nodes [][]*Node) {
 	n.Nodes = nodes
 	n.require(nodesWrapperFieldNodes)
@@ -1124,11 +1138,15 @@ func (o *ObjectFieldValue) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectFieldValue) SetName(name FieldName) {
 	o.Name = name
 	o.require(objectFieldValueFieldName)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectFieldValue) SetValue(value *FieldValue) {
 	o.Value = value
 	o.require(objectFieldValueFieldValue)

--- a/seed/go-sdk/circular-references-advanced/ast.go
+++ b/seed/go-sdk/circular-references-advanced/ast.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references-advanced/fern/internal"
+	big "math/big"
+)
+
+var (
+	acaiFieldAnimal = big.NewInt(1 << 0)
 )
 
 type Acai struct {
 	Animal *Animal `json:"animal" url:"animal"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (a *Acai) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Acai) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Acai) SetAnimal(animal *Animal) {
+	a.Animal = animal
+	a.require(acaiFieldAnimal)
+}
+
 func (a *Acai) UnmarshalJSON(data []byte) error {
 	type unmarshaler Acai
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (a *Acai) UnmarshalJSON(data []byte) error {
 	a.extraProperties = extraProperties
 	a.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (a *Acai) MarshalJSON() ([]byte, error) {
+	type embed Acai
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *Acai) String() string {
@@ -116,8 +147,15 @@ func (a *Animal) Accept(visitor AnimalVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", a)
 }
 
+var (
+	berryFieldAnimal = big.NewInt(1 << 0)
+)
+
 type Berry struct {
 	Animal *Animal `json:"animal" url:"animal"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -132,6 +170,18 @@ func (b *Berry) GetAnimal() *Animal {
 
 func (b *Berry) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
+}
+
+func (b *Berry) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *Berry) SetAnimal(animal *Animal) {
+	b.Animal = animal
+	b.require(berryFieldAnimal)
 }
 
 func (b *Berry) UnmarshalJSON(data []byte) error {
@@ -150,6 +200,17 @@ func (b *Berry) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (b *Berry) MarshalJSON() ([]byte, error) {
+	type embed Berry
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (b *Berry) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -162,8 +223,15 @@ func (b *Berry) String() string {
 	return fmt.Sprintf("%#v", b)
 }
 
+var (
+	branchNodeFieldChildren = big.NewInt(1 << 0)
+)
+
 type BranchNode struct {
 	Children []*Node `json:"children" url:"children"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -178,6 +246,18 @@ func (b *BranchNode) GetChildren() []*Node {
 
 func (b *BranchNode) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
+}
+
+func (b *BranchNode) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BranchNode) SetChildren(children []*Node) {
+	b.Children = children
+	b.require(branchNodeFieldChildren)
 }
 
 func (b *BranchNode) UnmarshalJSON(data []byte) error {
@@ -196,6 +276,17 @@ func (b *BranchNode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (b *BranchNode) MarshalJSON() ([]byte, error) {
+	type embed BranchNode
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (b *BranchNode) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -208,8 +299,15 @@ func (b *BranchNode) String() string {
 	return fmt.Sprintf("%#v", b)
 }
 
+var (
+	catFieldFruit = big.NewInt(1 << 0)
+)
+
 type Cat struct {
 	Fruit *Fruit `json:"fruit" url:"fruit"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -226,6 +324,18 @@ func (c *Cat) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *Cat) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Cat) SetFruit(fruit *Fruit) {
+	c.Fruit = fruit
+	c.require(catFieldFruit)
+}
+
 func (c *Cat) UnmarshalJSON(data []byte) error {
 	type unmarshaler Cat
 	var value unmarshaler
@@ -240,6 +350,17 @@ func (c *Cat) UnmarshalJSON(data []byte) error {
 	c.extraProperties = extraProperties
 	c.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (c *Cat) MarshalJSON() ([]byte, error) {
+	type embed Cat
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (c *Cat) String() string {
@@ -389,8 +510,15 @@ func (c *ContainerValue) validate() error {
 	return nil
 }
 
+var (
+	dogFieldFruit = big.NewInt(1 << 0)
+)
+
 type Dog struct {
 	Fruit *Fruit `json:"fruit" url:"fruit"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -407,6 +535,18 @@ func (d *Dog) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Dog) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Dog) SetFruit(fruit *Fruit) {
+	d.Fruit = fruit
+	d.require(dogFieldFruit)
+}
+
 func (d *Dog) UnmarshalJSON(data []byte) error {
 	type unmarshaler Dog
 	var value unmarshaler
@@ -421,6 +561,17 @@ func (d *Dog) UnmarshalJSON(data []byte) error {
 	d.extraProperties = extraProperties
 	d.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (d *Dog) MarshalJSON() ([]byte, error) {
+	type embed Dog
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (d *Dog) String() string {
@@ -596,8 +747,15 @@ func (f *FieldValue) validate() error {
 	return nil
 }
 
+var (
+	figFieldAnimal = big.NewInt(1 << 0)
+)
+
 type Fig struct {
 	Animal *Animal `json:"animal" url:"animal"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -614,6 +772,18 @@ func (f *Fig) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Fig) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *Fig) SetAnimal(animal *Animal) {
+	f.Animal = animal
+	f.require(figFieldAnimal)
+}
+
 func (f *Fig) UnmarshalJSON(data []byte) error {
 	type unmarshaler Fig
 	var value unmarshaler
@@ -628,6 +798,17 @@ func (f *Fig) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *Fig) MarshalJSON() ([]byte, error) {
+	type embed Fig
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *Fig) String() string {
@@ -705,12 +886,23 @@ func (f *Fruit) Accept(visitor FruitVisitor) error {
 }
 
 type LeafNode struct {
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
 }
 
 func (l *LeafNode) GetExtraProperties() map[string]interface{} {
 	return l.extraProperties
+}
+
+func (l *LeafNode) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
 }
 
 func (l *LeafNode) UnmarshalJSON(data []byte) error {
@@ -727,6 +919,17 @@ func (l *LeafNode) UnmarshalJSON(data []byte) error {
 	l.extraProperties = extraProperties
 	l.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (l *LeafNode) MarshalJSON() ([]byte, error) {
+	type embed LeafNode
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (l *LeafNode) String() string {
@@ -803,8 +1006,15 @@ func (n *Node) Accept(visitor NodeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
+var (
+	nodesWrapperFieldNodes = big.NewInt(1 << 0)
+)
+
 type NodesWrapper struct {
 	Nodes [][]*Node `json:"nodes" url:"nodes"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -819,6 +1029,18 @@ func (n *NodesWrapper) GetNodes() [][]*Node {
 
 func (n *NodesWrapper) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
+}
+
+func (n *NodesWrapper) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NodesWrapper) SetNodes(nodes [][]*Node) {
+	n.Nodes = nodes
+	n.require(nodesWrapperFieldNodes)
 }
 
 func (n *NodesWrapper) UnmarshalJSON(data []byte) error {
@@ -837,6 +1059,17 @@ func (n *NodesWrapper) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NodesWrapper) MarshalJSON() ([]byte, error) {
+	type embed NodesWrapper
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NodesWrapper) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -850,9 +1083,17 @@ func (n *NodesWrapper) String() string {
 }
 
 // This type allows us to test a circular reference with a union type (see FieldValue).
+var (
+	objectFieldValueFieldName  = big.NewInt(1 << 0)
+	objectFieldValueFieldValue = big.NewInt(1 << 1)
+)
+
 type ObjectFieldValue struct {
 	Name  FieldName   `json:"name" url:"name"`
 	Value *FieldValue `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -876,6 +1117,23 @@ func (o *ObjectFieldValue) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *ObjectFieldValue) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *ObjectFieldValue) SetName(name FieldName) {
+	o.Name = name
+	o.require(objectFieldValueFieldName)
+}
+
+func (o *ObjectFieldValue) SetValue(value *FieldValue) {
+	o.Value = value
+	o.require(objectFieldValueFieldValue)
+}
+
 func (o *ObjectFieldValue) UnmarshalJSON(data []byte) error {
 	type unmarshaler ObjectFieldValue
 	var value unmarshaler
@@ -892,6 +1150,17 @@ func (o *ObjectFieldValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (o *ObjectFieldValue) MarshalJSON() ([]byte, error) {
+	type embed ObjectFieldValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (o *ObjectFieldValue) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {
@@ -905,12 +1174,23 @@ func (o *ObjectFieldValue) String() string {
 }
 
 type ObjectValue struct {
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
 }
 
 func (o *ObjectValue) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
+}
+
+func (o *ObjectValue) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
 }
 
 func (o *ObjectValue) UnmarshalJSON(data []byte) error {
@@ -927,6 +1207,17 @@ func (o *ObjectValue) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *ObjectValue) MarshalJSON() ([]byte, error) {
+	type embed ObjectValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectValue) String() string {

--- a/seed/go-sdk/circular-references-advanced/internal/explicit_fields.go
+++ b/seed/go-sdk/circular-references-advanced/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/circular-references-advanced/internal/explicit_fields_test.go
+++ b/seed/go-sdk/circular-references-advanced/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/circular-references-advanced/types.go
+++ b/seed/go-sdk/circular-references-advanced/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references-advanced/fern/internal"
+	big "math/big"
+)
+
+var (
+	importingAFieldA = big.NewInt(1 << 0)
 )
 
 type ImportingA struct {
 	A *A `json:"a,omitempty" url:"a,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -24,6 +32,18 @@ func (i *ImportingA) GetA() *A {
 
 func (i *ImportingA) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
+}
+
+func (i *ImportingA) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *ImportingA) SetA(a *A) {
+	i.A = a
+	i.require(importingAFieldA)
 }
 
 func (i *ImportingA) UnmarshalJSON(data []byte) error {
@@ -42,6 +62,17 @@ func (i *ImportingA) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (i *ImportingA) MarshalJSON() ([]byte, error) {
+	type embed ImportingA
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (i *ImportingA) String() string {
 	if len(i.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -54,8 +85,15 @@ func (i *ImportingA) String() string {
 	return fmt.Sprintf("%#v", i)
 }
 
+var (
+	rootTypeFieldS = big.NewInt(1 << 0)
+)
+
 type RootType struct {
 	S string `json:"s" url:"s"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -72,6 +110,18 @@ func (r *RootType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *RootType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RootType) SetS(s string) {
+	r.S = s
+	r.require(rootTypeFieldS)
+}
+
 func (r *RootType) UnmarshalJSON(data []byte) error {
 	type unmarshaler RootType
 	var value unmarshaler
@@ -86,6 +136,17 @@ func (r *RootType) UnmarshalJSON(data []byte) error {
 	r.extraProperties = extraProperties
 	r.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (r *RootType) MarshalJSON() ([]byte, error) {
+	type embed RootType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *RootType) String() string {

--- a/seed/go-sdk/circular-references-advanced/types.go
+++ b/seed/go-sdk/circular-references-advanced/types.go
@@ -41,6 +41,8 @@ func (i *ImportingA) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetA sets the A field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *ImportingA) SetA(a *A) {
 	i.A = a
 	i.require(importingAFieldA)
@@ -117,6 +119,8 @@ func (r *RootType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RootType) SetS(s string) {
 	r.S = s
 	r.require(rootTypeFieldS)

--- a/seed/go-sdk/circular-references/a.go
+++ b/seed/go-sdk/circular-references/a.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references/fern/internal"
+	big "math/big"
+)
+
+var (
+	aFieldS = big.NewInt(1 << 0)
 )
 
 type A struct {
 	S string `json:"s" url:"s"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (a *A) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *A) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *A) SetS(s string) {
+	a.S = s
+	a.require(aFieldS)
+}
+
 func (a *A) UnmarshalJSON(data []byte) error {
 	type unmarshaler A
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (a *A) UnmarshalJSON(data []byte) error {
 	a.extraProperties = extraProperties
 	a.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (a *A) MarshalJSON() ([]byte, error) {
+	type embed A
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *A) String() string {

--- a/seed/go-sdk/circular-references/a.go
+++ b/seed/go-sdk/circular-references/a.go
@@ -41,6 +41,8 @@ func (a *A) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *A) SetS(s string) {
 	a.S = s
 	a.require(aFieldS)

--- a/seed/go-sdk/circular-references/ast.go
+++ b/seed/go-sdk/circular-references/ast.go
@@ -541,6 +541,8 @@ func (t *T) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetChild sets the Child field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *T) SetChild(child *TorU) {
 	t.Child = child
 	t.require(tFieldChild)
@@ -679,6 +681,8 @@ func (u *U) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetChild sets the Child field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *U) SetChild(child *T) {
 	u.Child = child
 	u.require(uFieldChild)

--- a/seed/go-sdk/circular-references/ast.go
+++ b/seed/go-sdk/circular-references/ast.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/circular-references/fern/internal"
+	big "math/big"
 )
 
 type ContainerValue struct {
@@ -428,12 +429,23 @@ func (j *JsonLike) Accept(visitor JsonLikeVisitor) error {
 }
 
 type ObjectValue struct {
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
 }
 
 func (o *ObjectValue) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
+}
+
+func (o *ObjectValue) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
 }
 
 func (o *ObjectValue) UnmarshalJSON(data []byte) error {
@@ -450,6 +462,17 @@ func (o *ObjectValue) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *ObjectValue) MarshalJSON() ([]byte, error) {
+	type embed ObjectValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectValue) String() string {
@@ -486,8 +509,15 @@ func (p PrimitiveValue) Ptr() *PrimitiveValue {
 	return &p
 }
 
+var (
+	tFieldChild = big.NewInt(1 << 0)
+)
+
 type T struct {
 	Child *TorU `json:"child" url:"child"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -504,6 +534,18 @@ func (t *T) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *T) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *T) SetChild(child *TorU) {
+	t.Child = child
+	t.require(tFieldChild)
+}
+
 func (t *T) UnmarshalJSON(data []byte) error {
 	type unmarshaler T
 	var value unmarshaler
@@ -518,6 +560,17 @@ func (t *T) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *T) MarshalJSON() ([]byte, error) {
+	type embed T
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *T) String() string {
@@ -594,8 +647,15 @@ func (t *TorU) Accept(visitor TorUVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	uFieldChild = big.NewInt(1 << 0)
+)
+
 type U struct {
 	Child *T `json:"child" url:"child"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -612,6 +672,18 @@ func (u *U) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *U) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *U) SetChild(child *T) {
+	u.Child = child
+	u.require(uFieldChild)
+}
+
 func (u *U) UnmarshalJSON(data []byte) error {
 	type unmarshaler U
 	var value unmarshaler
@@ -626,6 +698,17 @@ func (u *U) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *U) MarshalJSON() ([]byte, error) {
+	type embed U
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *U) String() string {

--- a/seed/go-sdk/circular-references/internal/explicit_fields.go
+++ b/seed/go-sdk/circular-references/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/circular-references/internal/explicit_fields_test.go
+++ b/seed/go-sdk/circular-references/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/circular-references/types.go
+++ b/seed/go-sdk/circular-references/types.go
@@ -41,6 +41,8 @@ func (i *ImportingA) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetA sets the A field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *ImportingA) SetA(a *A) {
 	i.A = a
 	i.require(importingAFieldA)
@@ -117,6 +119,8 @@ func (r *RootType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetS sets the S field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RootType) SetS(s string) {
 	r.S = s
 	r.require(rootTypeFieldS)

--- a/seed/go-sdk/client-side-params/internal/explicit_fields.go
+++ b/seed/go-sdk/client-side-params/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/client-side-params/internal/explicit_fields_test.go
+++ b/seed/go-sdk/client-side-params/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/client-side-params/service.go
+++ b/seed/go-sdk/client-side-params/service.go
@@ -2,31 +2,140 @@
 
 package clientsideparams
 
+import (
+	big "math/big"
+)
+
+var (
+	getClientRequestFieldFields        = big.NewInt(1 << 0)
+	getClientRequestFieldIncludeFields = big.NewInt(1 << 1)
+)
+
 type GetClientRequest struct {
 	// Comma-separated list of fields to include
 	Fields *string `json:"-" url:"fields,omitempty"`
 	// Whether specified fields are included or excluded
 	IncludeFields *bool `json:"-" url:"include_fields,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetClientRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetClientRequest) SetFields(fields *string) {
+	g.Fields = fields
+	g.require(getClientRequestFieldFields)
+}
+
+func (g *GetClientRequest) SetIncludeFields(includeFields *bool) {
+	g.IncludeFields = includeFields
+	g.require(getClientRequestFieldIncludeFields)
+}
+
+var (
+	getConnectionRequestFieldFields = big.NewInt(1 << 0)
+)
 
 type GetConnectionRequest struct {
 	// Comma-separated list of fields to include
 	Fields *string `json:"-" url:"fields,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetConnectionRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetConnectionRequest) SetFields(fields *string) {
+	g.Fields = fields
+	g.require(getConnectionRequestFieldFields)
+}
+
+var (
+	getResourceRequestFieldIncludeMetadata = big.NewInt(1 << 0)
+	getResourceRequestFieldFormat          = big.NewInt(1 << 1)
+)
 
 type GetResourceRequest struct {
 	// Include metadata in response
 	IncludeMetadata bool `json:"-" url:"include_metadata"`
 	// Response format
 	Format string `json:"-" url:"format"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetResourceRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetResourceRequest) SetIncludeMetadata(includeMetadata bool) {
+	g.IncludeMetadata = includeMetadata
+	g.require(getResourceRequestFieldIncludeMetadata)
+}
+
+func (g *GetResourceRequest) SetFormat(format string) {
+	g.Format = format
+	g.require(getResourceRequestFieldFormat)
+}
+
+var (
+	getUserRequestFieldFields        = big.NewInt(1 << 0)
+	getUserRequestFieldIncludeFields = big.NewInt(1 << 1)
+)
 
 type GetUserRequest struct {
 	// Comma-separated list of fields to include or exclude
 	Fields *string `json:"-" url:"fields,omitempty"`
 	// true to include the fields specified, false to exclude them
 	IncludeFields *bool `json:"-" url:"include_fields,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetUserRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetUserRequest) SetFields(fields *string) {
+	g.Fields = fields
+	g.require(getUserRequestFieldFields)
+}
+
+func (g *GetUserRequest) SetIncludeFields(includeFields *bool) {
+	g.IncludeFields = includeFields
+	g.require(getUserRequestFieldIncludeFields)
+}
+
+var (
+	listClientsRequestFieldFields        = big.NewInt(1 << 0)
+	listClientsRequestFieldIncludeFields = big.NewInt(1 << 1)
+	listClientsRequestFieldPage          = big.NewInt(1 << 2)
+	listClientsRequestFieldPerPage       = big.NewInt(1 << 3)
+	listClientsRequestFieldIncludeTotals = big.NewInt(1 << 4)
+	listClientsRequestFieldIsGlobal      = big.NewInt(1 << 5)
+	listClientsRequestFieldIsFirstParty  = big.NewInt(1 << 6)
+	listClientsRequestFieldAppType       = big.NewInt(1 << 7)
+)
 
 type ListClientsRequest struct {
 	// Comma-separated list of fields to include
@@ -45,7 +154,63 @@ type ListClientsRequest struct {
 	IsFirstParty *bool `json:"-" url:"is_first_party,omitempty"`
 	// Filter by application type (spa, native, regular_web, non_interactive)
 	AppType []string `json:"-" url:"app_type,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListClientsRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListClientsRequest) SetFields(fields *string) {
+	l.Fields = fields
+	l.require(listClientsRequestFieldFields)
+}
+
+func (l *ListClientsRequest) SetIncludeFields(includeFields *bool) {
+	l.IncludeFields = includeFields
+	l.require(listClientsRequestFieldIncludeFields)
+}
+
+func (l *ListClientsRequest) SetPage(page *int) {
+	l.Page = page
+	l.require(listClientsRequestFieldPage)
+}
+
+func (l *ListClientsRequest) SetPerPage(perPage *int) {
+	l.PerPage = perPage
+	l.require(listClientsRequestFieldPerPage)
+}
+
+func (l *ListClientsRequest) SetIncludeTotals(includeTotals *bool) {
+	l.IncludeTotals = includeTotals
+	l.require(listClientsRequestFieldIncludeTotals)
+}
+
+func (l *ListClientsRequest) SetIsGlobal(isGlobal *bool) {
+	l.IsGlobal = isGlobal
+	l.require(listClientsRequestFieldIsGlobal)
+}
+
+func (l *ListClientsRequest) SetIsFirstParty(isFirstParty *bool) {
+	l.IsFirstParty = isFirstParty
+	l.require(listClientsRequestFieldIsFirstParty)
+}
+
+func (l *ListClientsRequest) SetAppType(appType []string) {
+	l.AppType = appType
+	l.require(listClientsRequestFieldAppType)
+}
+
+var (
+	listConnectionsRequestFieldStrategy = big.NewInt(1 << 0)
+	listConnectionsRequestFieldName     = big.NewInt(1 << 1)
+	listConnectionsRequestFieldFields   = big.NewInt(1 << 2)
+)
 
 type ListConnectionsRequest struct {
 	// Filter by strategy type (e.g., auth0, google-oauth2, samlp)
@@ -54,7 +219,42 @@ type ListConnectionsRequest struct {
 	Name *string `json:"-" url:"name,omitempty"`
 	// Comma-separated list of fields to include
 	Fields *string `json:"-" url:"fields,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListConnectionsRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListConnectionsRequest) SetStrategy(strategy *string) {
+	l.Strategy = strategy
+	l.require(listConnectionsRequestFieldStrategy)
+}
+
+func (l *ListConnectionsRequest) SetName(name *string) {
+	l.Name = name
+	l.require(listConnectionsRequestFieldName)
+}
+
+func (l *ListConnectionsRequest) SetFields(fields *string) {
+	l.Fields = fields
+	l.require(listConnectionsRequestFieldFields)
+}
+
+var (
+	listResourcesRequestFieldPage          = big.NewInt(1 << 0)
+	listResourcesRequestFieldPerPage       = big.NewInt(1 << 1)
+	listResourcesRequestFieldSort          = big.NewInt(1 << 2)
+	listResourcesRequestFieldOrder         = big.NewInt(1 << 3)
+	listResourcesRequestFieldIncludeTotals = big.NewInt(1 << 4)
+	listResourcesRequestFieldFields        = big.NewInt(1 << 5)
+	listResourcesRequestFieldSearch        = big.NewInt(1 << 6)
+)
 
 type ListResourcesRequest struct {
 	// Zero-indexed page number
@@ -71,7 +271,63 @@ type ListResourcesRequest struct {
 	Fields *string `json:"-" url:"fields,omitempty"`
 	// Search query
 	Search *string `json:"-" url:"search,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListResourcesRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListResourcesRequest) SetPage(page int) {
+	l.Page = page
+	l.require(listResourcesRequestFieldPage)
+}
+
+func (l *ListResourcesRequest) SetPerPage(perPage int) {
+	l.PerPage = perPage
+	l.require(listResourcesRequestFieldPerPage)
+}
+
+func (l *ListResourcesRequest) SetSort(sort string) {
+	l.Sort = sort
+	l.require(listResourcesRequestFieldSort)
+}
+
+func (l *ListResourcesRequest) SetOrder(order string) {
+	l.Order = order
+	l.require(listResourcesRequestFieldOrder)
+}
+
+func (l *ListResourcesRequest) SetIncludeTotals(includeTotals bool) {
+	l.IncludeTotals = includeTotals
+	l.require(listResourcesRequestFieldIncludeTotals)
+}
+
+func (l *ListResourcesRequest) SetFields(fields *string) {
+	l.Fields = fields
+	l.require(listResourcesRequestFieldFields)
+}
+
+func (l *ListResourcesRequest) SetSearch(search *string) {
+	l.Search = search
+	l.require(listResourcesRequestFieldSearch)
+}
+
+var (
+	listUsersRequestFieldPage          = big.NewInt(1 << 0)
+	listUsersRequestFieldPerPage       = big.NewInt(1 << 1)
+	listUsersRequestFieldIncludeTotals = big.NewInt(1 << 2)
+	listUsersRequestFieldSort          = big.NewInt(1 << 3)
+	listUsersRequestFieldConnection    = big.NewInt(1 << 4)
+	listUsersRequestFieldQ             = big.NewInt(1 << 5)
+	listUsersRequestFieldSearchEngine  = big.NewInt(1 << 6)
+	listUsersRequestFieldFields        = big.NewInt(1 << 7)
+)
 
 type ListUsersRequest struct {
 	// Page index of the results to return. First page is 0.
@@ -90,7 +346,64 @@ type ListUsersRequest struct {
 	SearchEngine *string `json:"-" url:"search_engine,omitempty"`
 	// Comma-separated list of fields to include or exclude
 	Fields *string `json:"-" url:"fields,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersRequest) SetPage(page *int) {
+	l.Page = page
+	l.require(listUsersRequestFieldPage)
+}
+
+func (l *ListUsersRequest) SetPerPage(perPage *int) {
+	l.PerPage = perPage
+	l.require(listUsersRequestFieldPerPage)
+}
+
+func (l *ListUsersRequest) SetIncludeTotals(includeTotals *bool) {
+	l.IncludeTotals = includeTotals
+	l.require(listUsersRequestFieldIncludeTotals)
+}
+
+func (l *ListUsersRequest) SetSort(sort *string) {
+	l.Sort = sort
+	l.require(listUsersRequestFieldSort)
+}
+
+func (l *ListUsersRequest) SetConnection(connection *string) {
+	l.Connection = connection
+	l.require(listUsersRequestFieldConnection)
+}
+
+func (l *ListUsersRequest) SetQ(q *string) {
+	l.Q = q
+	l.require(listUsersRequestFieldQ)
+}
+
+func (l *ListUsersRequest) SetSearchEngine(searchEngine *string) {
+	l.SearchEngine = searchEngine
+	l.require(listUsersRequestFieldSearchEngine)
+}
+
+func (l *ListUsersRequest) SetFields(fields *string) {
+	l.Fields = fields
+	l.require(listUsersRequestFieldFields)
+}
+
+var (
+	searchResourcesRequestFieldLimit   = big.NewInt(1 << 0)
+	searchResourcesRequestFieldOffset  = big.NewInt(1 << 1)
+	searchResourcesRequestFieldQuery   = big.NewInt(1 << 2)
+	searchResourcesRequestFieldFilters = big.NewInt(1 << 3)
+)
 
 type SearchResourcesRequest struct {
 	// Maximum results to return
@@ -100,4 +413,34 @@ type SearchResourcesRequest struct {
 	// Search query text
 	Query   *string                `json:"query,omitempty" url:"-"`
 	Filters map[string]interface{} `json:"filters,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (s *SearchResourcesRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchResourcesRequest) SetLimit(limit int) {
+	s.Limit = limit
+	s.require(searchResourcesRequestFieldLimit)
+}
+
+func (s *SearchResourcesRequest) SetOffset(offset int) {
+	s.Offset = offset
+	s.require(searchResourcesRequestFieldOffset)
+}
+
+func (s *SearchResourcesRequest) SetQuery(query *string) {
+	s.Query = query
+	s.require(searchResourcesRequestFieldQuery)
+}
+
+func (s *SearchResourcesRequest) SetFilters(filters map[string]interface{}) {
+	s.Filters = filters
+	s.require(searchResourcesRequestFieldFilters)
 }

--- a/seed/go-sdk/client-side-params/service.go
+++ b/seed/go-sdk/client-side-params/service.go
@@ -28,11 +28,15 @@ func (g *GetClientRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetFields sets the Fields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetClientRequest) SetFields(fields *string) {
 	g.Fields = fields
 	g.require(getClientRequestFieldFields)
 }
 
+// SetIncludeFields sets the IncludeFields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetClientRequest) SetIncludeFields(includeFields *bool) {
 	g.IncludeFields = includeFields
 	g.require(getClientRequestFieldIncludeFields)
@@ -57,6 +61,8 @@ func (g *GetConnectionRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetFields sets the Fields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetConnectionRequest) SetFields(fields *string) {
 	g.Fields = fields
 	g.require(getConnectionRequestFieldFields)
@@ -84,11 +90,15 @@ func (g *GetResourceRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetIncludeMetadata sets the IncludeMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetResourceRequest) SetIncludeMetadata(includeMetadata bool) {
 	g.IncludeMetadata = includeMetadata
 	g.require(getResourceRequestFieldIncludeMetadata)
 }
 
+// SetFormat sets the Format field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetResourceRequest) SetFormat(format string) {
 	g.Format = format
 	g.require(getResourceRequestFieldFormat)
@@ -116,11 +126,15 @@ func (g *GetUserRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetFields sets the Fields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUserRequest) SetFields(fields *string) {
 	g.Fields = fields
 	g.require(getUserRequestFieldFields)
 }
 
+// SetIncludeFields sets the IncludeFields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUserRequest) SetIncludeFields(includeFields *bool) {
 	g.IncludeFields = includeFields
 	g.require(getUserRequestFieldIncludeFields)
@@ -166,41 +180,57 @@ func (l *ListClientsRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetFields sets the Fields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetFields(fields *string) {
 	l.Fields = fields
 	l.require(listClientsRequestFieldFields)
 }
 
+// SetIncludeFields sets the IncludeFields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetIncludeFields(includeFields *bool) {
 	l.IncludeFields = includeFields
 	l.require(listClientsRequestFieldIncludeFields)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetPage(page *int) {
 	l.Page = page
 	l.require(listClientsRequestFieldPage)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetPerPage(perPage *int) {
 	l.PerPage = perPage
 	l.require(listClientsRequestFieldPerPage)
 }
 
+// SetIncludeTotals sets the IncludeTotals field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetIncludeTotals(includeTotals *bool) {
 	l.IncludeTotals = includeTotals
 	l.require(listClientsRequestFieldIncludeTotals)
 }
 
+// SetIsGlobal sets the IsGlobal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetIsGlobal(isGlobal *bool) {
 	l.IsGlobal = isGlobal
 	l.require(listClientsRequestFieldIsGlobal)
 }
 
+// SetIsFirstParty sets the IsFirstParty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetIsFirstParty(isFirstParty *bool) {
 	l.IsFirstParty = isFirstParty
 	l.require(listClientsRequestFieldIsFirstParty)
 }
 
+// SetAppType sets the AppType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListClientsRequest) SetAppType(appType []string) {
 	l.AppType = appType
 	l.require(listClientsRequestFieldAppType)
@@ -231,16 +261,22 @@ func (l *ListConnectionsRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetStrategy sets the Strategy field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListConnectionsRequest) SetStrategy(strategy *string) {
 	l.Strategy = strategy
 	l.require(listConnectionsRequestFieldStrategy)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListConnectionsRequest) SetName(name *string) {
 	l.Name = name
 	l.require(listConnectionsRequestFieldName)
 }
 
+// SetFields sets the Fields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListConnectionsRequest) SetFields(fields *string) {
 	l.Fields = fields
 	l.require(listConnectionsRequestFieldFields)
@@ -283,36 +319,50 @@ func (l *ListResourcesRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetPage(page int) {
 	l.Page = page
 	l.require(listResourcesRequestFieldPage)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetPerPage(perPage int) {
 	l.PerPage = perPage
 	l.require(listResourcesRequestFieldPerPage)
 }
 
+// SetSort sets the Sort field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetSort(sort string) {
 	l.Sort = sort
 	l.require(listResourcesRequestFieldSort)
 }
 
+// SetOrder sets the Order field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetOrder(order string) {
 	l.Order = order
 	l.require(listResourcesRequestFieldOrder)
 }
 
+// SetIncludeTotals sets the IncludeTotals field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetIncludeTotals(includeTotals bool) {
 	l.IncludeTotals = includeTotals
 	l.require(listResourcesRequestFieldIncludeTotals)
 }
 
+// SetFields sets the Fields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetFields(fields *string) {
 	l.Fields = fields
 	l.require(listResourcesRequestFieldFields)
 }
 
+// SetSearch sets the Search field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetSearch(search *string) {
 	l.Search = search
 	l.require(listResourcesRequestFieldSearch)
@@ -358,41 +408,57 @@ func (l *ListUsersRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetPage(page *int) {
 	l.Page = page
 	l.require(listUsersRequestFieldPage)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetPerPage(perPage *int) {
 	l.PerPage = perPage
 	l.require(listUsersRequestFieldPerPage)
 }
 
+// SetIncludeTotals sets the IncludeTotals field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetIncludeTotals(includeTotals *bool) {
 	l.IncludeTotals = includeTotals
 	l.require(listUsersRequestFieldIncludeTotals)
 }
 
+// SetSort sets the Sort field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetSort(sort *string) {
 	l.Sort = sort
 	l.require(listUsersRequestFieldSort)
 }
 
+// SetConnection sets the Connection field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetConnection(connection *string) {
 	l.Connection = connection
 	l.require(listUsersRequestFieldConnection)
 }
 
+// SetQ sets the Q field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetQ(q *string) {
 	l.Q = q
 	l.require(listUsersRequestFieldQ)
 }
 
+// SetSearchEngine sets the SearchEngine field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetSearchEngine(searchEngine *string) {
 	l.SearchEngine = searchEngine
 	l.require(listUsersRequestFieldSearchEngine)
 }
 
+// SetFields sets the Fields field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetFields(fields *string) {
 	l.Fields = fields
 	l.require(listUsersRequestFieldFields)
@@ -425,21 +491,29 @@ func (s *SearchResourcesRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResourcesRequest) SetLimit(limit int) {
 	s.Limit = limit
 	s.require(searchResourcesRequestFieldLimit)
 }
 
+// SetOffset sets the Offset field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResourcesRequest) SetOffset(offset int) {
 	s.Offset = offset
 	s.require(searchResourcesRequestFieldOffset)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResourcesRequest) SetQuery(query *string) {
 	s.Query = query
 	s.require(searchResourcesRequestFieldQuery)
 }
 
+// SetFilters sets the Filters field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResourcesRequest) SetFilters(filters map[string]interface{}) {
 	s.Filters = filters
 	s.require(searchResourcesRequestFieldFilters)

--- a/seed/go-sdk/client-side-params/types.go
+++ b/seed/go-sdk/client-side-params/types.go
@@ -334,151 +334,211 @@ func (c *Client) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetClientId(clientId string) {
 	c.ClientId = clientId
 	c.require(clientFieldClientId)
 }
 
+// SetTenant sets the Tenant field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetTenant(tenant *string) {
 	c.Tenant = tenant
 	c.require(clientFieldTenant)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetName(name string) {
 	c.Name = name
 	c.require(clientFieldName)
 }
 
+// SetDescription sets the Description field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetDescription(description *string) {
 	c.Description = description
 	c.require(clientFieldDescription)
 }
 
+// SetGlobal sets the Global field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetGlobal(global *bool) {
 	c.Global = global
 	c.require(clientFieldGlobal)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetClientSecret(clientSecret *string) {
 	c.ClientSecret = clientSecret
 	c.require(clientFieldClientSecret)
 }
 
+// SetAppType sets the AppType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetAppType(appType *string) {
 	c.AppType = appType
 	c.require(clientFieldAppType)
 }
 
+// SetLogoUri sets the LogoUri field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetLogoUri(logoUri *string) {
 	c.LogoUri = logoUri
 	c.require(clientFieldLogoUri)
 }
 
+// SetIsFirstParty sets the IsFirstParty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetIsFirstParty(isFirstParty *bool) {
 	c.IsFirstParty = isFirstParty
 	c.require(clientFieldIsFirstParty)
 }
 
+// SetOidcConformant sets the OidcConformant field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetOidcConformant(oidcConformant *bool) {
 	c.OidcConformant = oidcConformant
 	c.require(clientFieldOidcConformant)
 }
 
+// SetCallbacks sets the Callbacks field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetCallbacks(callbacks []string) {
 	c.Callbacks = callbacks
 	c.require(clientFieldCallbacks)
 }
 
+// SetAllowedOrigins sets the AllowedOrigins field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetAllowedOrigins(allowedOrigins []string) {
 	c.AllowedOrigins = allowedOrigins
 	c.require(clientFieldAllowedOrigins)
 }
 
+// SetWebOrigins sets the WebOrigins field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetWebOrigins(webOrigins []string) {
 	c.WebOrigins = webOrigins
 	c.require(clientFieldWebOrigins)
 }
 
+// SetGrantTypes sets the GrantTypes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetGrantTypes(grantTypes []string) {
 	c.GrantTypes = grantTypes
 	c.require(clientFieldGrantTypes)
 }
 
+// SetJwtConfiguration sets the JwtConfiguration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetJwtConfiguration(jwtConfiguration map[string]interface{}) {
 	c.JwtConfiguration = jwtConfiguration
 	c.require(clientFieldJwtConfiguration)
 }
 
+// SetSigningKeys sets the SigningKeys field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetSigningKeys(signingKeys []map[string]interface{}) {
 	c.SigningKeys = signingKeys
 	c.require(clientFieldSigningKeys)
 }
 
+// SetEncryptionKey sets the EncryptionKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetEncryptionKey(encryptionKey map[string]interface{}) {
 	c.EncryptionKey = encryptionKey
 	c.require(clientFieldEncryptionKey)
 }
 
+// SetSso sets the Sso field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetSso(sso *bool) {
 	c.Sso = sso
 	c.require(clientFieldSso)
 }
 
+// SetSsoDisabled sets the SsoDisabled field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetSsoDisabled(ssoDisabled *bool) {
 	c.SsoDisabled = ssoDisabled
 	c.require(clientFieldSsoDisabled)
 }
 
+// SetCrossOriginAuth sets the CrossOriginAuth field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetCrossOriginAuth(crossOriginAuth *bool) {
 	c.CrossOriginAuth = crossOriginAuth
 	c.require(clientFieldCrossOriginAuth)
 }
 
+// SetCrossOriginLoc sets the CrossOriginLoc field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetCrossOriginLoc(crossOriginLoc *string) {
 	c.CrossOriginLoc = crossOriginLoc
 	c.require(clientFieldCrossOriginLoc)
 }
 
+// SetCustomLoginPageOn sets the CustomLoginPageOn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetCustomLoginPageOn(customLoginPageOn *bool) {
 	c.CustomLoginPageOn = customLoginPageOn
 	c.require(clientFieldCustomLoginPageOn)
 }
 
+// SetCustomLoginPage sets the CustomLoginPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetCustomLoginPage(customLoginPage *string) {
 	c.CustomLoginPage = customLoginPage
 	c.require(clientFieldCustomLoginPage)
 }
 
+// SetCustomLoginPagePreview sets the CustomLoginPagePreview field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetCustomLoginPagePreview(customLoginPagePreview *string) {
 	c.CustomLoginPagePreview = customLoginPagePreview
 	c.require(clientFieldCustomLoginPagePreview)
 }
 
+// SetFormTemplate sets the FormTemplate field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetFormTemplate(formTemplate *string) {
 	c.FormTemplate = formTemplate
 	c.require(clientFieldFormTemplate)
 }
 
+// SetIsHerokuApp sets the IsHerokuApp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetIsHerokuApp(isHerokuApp *bool) {
 	c.IsHerokuApp = isHerokuApp
 	c.require(clientFieldIsHerokuApp)
 }
 
+// SetAddons sets the Addons field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetAddons(addons map[string]interface{}) {
 	c.Addons = addons
 	c.require(clientFieldAddons)
 }
 
+// SetTokenEndpointAuthMethod sets the TokenEndpointAuthMethod field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetTokenEndpointAuthMethod(tokenEndpointAuthMethod *string) {
 	c.TokenEndpointAuthMethod = tokenEndpointAuthMethod
 	c.require(clientFieldTokenEndpointAuthMethod)
 }
 
+// SetClientMetadata sets the ClientMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetClientMetadata(clientMetadata map[string]interface{}) {
 	c.ClientMetadata = clientMetadata
 	c.require(clientFieldClientMetadata)
 }
 
+// SetMobile sets the Mobile field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Client) SetMobile(mobile map[string]interface{}) {
 	c.Mobile = mobile
 	c.require(clientFieldMobile)
@@ -637,46 +697,64 @@ func (c *Connection) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetId(id string) {
 	c.Id = id
 	c.require(connectionFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetName(name string) {
 	c.Name = name
 	c.require(connectionFieldName)
 }
 
+// SetDisplayName sets the DisplayName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetDisplayName(displayName *string) {
 	c.DisplayName = displayName
 	c.require(connectionFieldDisplayName)
 }
 
+// SetStrategy sets the Strategy field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetStrategy(strategy string) {
 	c.Strategy = strategy
 	c.require(connectionFieldStrategy)
 }
 
+// SetOptions sets the Options field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetOptions(options map[string]interface{}) {
 	c.Options = options
 	c.require(connectionFieldOptions)
 }
 
+// SetEnabledClients sets the EnabledClients field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetEnabledClients(enabledClients []string) {
 	c.EnabledClients = enabledClients
 	c.require(connectionFieldEnabledClients)
 }
 
+// SetRealms sets the Realms field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetRealms(realms []string) {
 	c.Realms = realms
 	c.require(connectionFieldRealms)
 }
 
+// SetIsDomainConnection sets the IsDomainConnection field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetIsDomainConnection(isDomainConnection *bool) {
 	c.IsDomainConnection = isDomainConnection
 	c.require(connectionFieldIsDomainConnection)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Connection) SetMetadata(metadata map[string]interface{}) {
 	c.Metadata = metadata
 	c.require(connectionFieldMetadata)
@@ -825,46 +903,64 @@ func (c *CreateUserRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetEmail(email string) {
 	c.Email = email
 	c.require(createUserRequestFieldEmail)
 }
 
+// SetEmailVerified sets the EmailVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetEmailVerified(emailVerified *bool) {
 	c.EmailVerified = emailVerified
 	c.require(createUserRequestFieldEmailVerified)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetUsername(username *string) {
 	c.Username = username
 	c.require(createUserRequestFieldUsername)
 }
 
+// SetPassword sets the Password field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetPassword(password *string) {
 	c.Password = password
 	c.require(createUserRequestFieldPassword)
 }
 
+// SetPhoneNumber sets the PhoneNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetPhoneNumber(phoneNumber *string) {
 	c.PhoneNumber = phoneNumber
 	c.require(createUserRequestFieldPhoneNumber)
 }
 
+// SetPhoneVerified sets the PhoneVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetPhoneVerified(phoneVerified *bool) {
 	c.PhoneVerified = phoneVerified
 	c.require(createUserRequestFieldPhoneVerified)
 }
 
+// SetUserMetadata sets the UserMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetUserMetadata(userMetadata map[string]interface{}) {
 	c.UserMetadata = userMetadata
 	c.require(createUserRequestFieldUserMetadata)
 }
 
+// SetAppMetadata sets the AppMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetAppMetadata(appMetadata map[string]interface{}) {
 	c.AppMetadata = appMetadata
 	c.require(createUserRequestFieldAppMetadata)
 }
 
+// SetConnection sets the Connection field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetConnection(connection string) {
 	c.Connection = connection
 	c.require(createUserRequestFieldConnection)
@@ -986,31 +1082,43 @@ func (i *Identity) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetConnection sets the Connection field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identity) SetConnection(connection string) {
 	i.Connection = connection
 	i.require(identityFieldConnection)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identity) SetUserId(userId string) {
 	i.UserId = userId
 	i.require(identityFieldUserId)
 }
 
+// SetProvider sets the Provider field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identity) SetProvider(provider string) {
 	i.Provider = provider
 	i.require(identityFieldProvider)
 }
 
+// SetIsSocial sets the IsSocial field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identity) SetIsSocial(isSocial bool) {
 	i.IsSocial = isSocial
 	i.require(identityFieldIsSocial)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identity) SetAccessToken(accessToken *string) {
 	i.AccessToken = accessToken
 	i.require(identityFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identity) SetExpiresIn(expiresIn *int) {
 	i.ExpiresIn = expiresIn
 	i.require(identityFieldExpiresIn)
@@ -1129,26 +1237,36 @@ func (p *PaginatedClientResponse) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetStart sets the Start field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedClientResponse) SetStart(start int) {
 	p.Start = start
 	p.require(paginatedClientResponseFieldStart)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedClientResponse) SetLimit(limit int) {
 	p.Limit = limit
 	p.require(paginatedClientResponseFieldLimit)
 }
 
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedClientResponse) SetLength(length int) {
 	p.Length = length
 	p.require(paginatedClientResponseFieldLength)
 }
 
+// SetTotal sets the Total field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedClientResponse) SetTotal(total *int) {
 	p.Total = total
 	p.require(paginatedClientResponseFieldTotal)
 }
 
+// SetClients sets the Clients field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedClientResponse) SetClients(clients []*Client) {
 	p.Clients = clients
 	p.require(paginatedClientResponseFieldClients)
@@ -1262,26 +1380,36 @@ func (p *PaginatedUserResponse) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedUserResponse) SetUsers(users []*User) {
 	p.Users = users
 	p.require(paginatedUserResponseFieldUsers)
 }
 
+// SetStart sets the Start field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedUserResponse) SetStart(start int) {
 	p.Start = start
 	p.require(paginatedUserResponseFieldStart)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedUserResponse) SetLimit(limit int) {
 	p.Limit = limit
 	p.require(paginatedUserResponseFieldLimit)
 }
 
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedUserResponse) SetLength(length int) {
 	p.Length = length
 	p.require(paginatedUserResponseFieldLength)
 }
 
+// SetTotal sets the Total field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedUserResponse) SetTotal(total *int) {
 	p.Total = total
 	p.require(paginatedUserResponseFieldTotal)
@@ -1403,31 +1531,43 @@ func (r *Resource) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Resource) SetId(id string) {
 	r.Id = id
 	r.require(resourceFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Resource) SetName(name string) {
 	r.Name = name
 	r.require(resourceFieldName)
 }
 
+// SetDescription sets the Description field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Resource) SetDescription(description *string) {
 	r.Description = description
 	r.require(resourceFieldDescription)
 }
 
+// SetCreatedAt sets the CreatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Resource) SetCreatedAt(createdAt time.Time) {
 	r.CreatedAt = createdAt
 	r.require(resourceFieldCreatedAt)
 }
 
+// SetUpdatedAt sets the UpdatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Resource) SetUpdatedAt(updatedAt time.Time) {
 	r.UpdatedAt = updatedAt
 	r.require(resourceFieldUpdatedAt)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Resource) SetMetadata(metadata map[string]interface{}) {
 	r.Metadata = metadata
 	r.require(resourceFieldMetadata)
@@ -1534,16 +1674,22 @@ func (s *SearchResponse) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResponse) SetResults(results []*Resource) {
 	s.Results = results
 	s.require(searchResponseFieldResults)
 }
 
+// SetTotal sets the Total field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResponse) SetTotal(total *int) {
 	s.Total = total
 	s.require(searchResponseFieldTotal)
 }
 
+// SetNextOffset sets the NextOffset field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResponse) SetNextOffset(nextOffset *int) {
 	s.NextOffset = nextOffset
 	s.require(searchResponseFieldNextOffset)
@@ -1692,46 +1838,64 @@ func (u *UpdateUserRequest) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetEmail(email *string) {
 	u.Email = email
 	u.require(updateUserRequestFieldEmail)
 }
 
+// SetEmailVerified sets the EmailVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetEmailVerified(emailVerified *bool) {
 	u.EmailVerified = emailVerified
 	u.require(updateUserRequestFieldEmailVerified)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetUsername(username *string) {
 	u.Username = username
 	u.require(updateUserRequestFieldUsername)
 }
 
+// SetPhoneNumber sets the PhoneNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetPhoneNumber(phoneNumber *string) {
 	u.PhoneNumber = phoneNumber
 	u.require(updateUserRequestFieldPhoneNumber)
 }
 
+// SetPhoneVerified sets the PhoneVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetPhoneVerified(phoneVerified *bool) {
 	u.PhoneVerified = phoneVerified
 	u.require(updateUserRequestFieldPhoneVerified)
 }
 
+// SetUserMetadata sets the UserMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetUserMetadata(userMetadata map[string]interface{}) {
 	u.UserMetadata = userMetadata
 	u.require(updateUserRequestFieldUserMetadata)
 }
 
+// SetAppMetadata sets the AppMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetAppMetadata(appMetadata map[string]interface{}) {
 	u.AppMetadata = appMetadata
 	u.require(updateUserRequestFieldAppMetadata)
 }
 
+// SetPassword sets the Password field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetPassword(password *string) {
 	u.Password = password
 	u.require(updateUserRequestFieldPassword)
 }
 
+// SetBlocked sets the Blocked field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetBlocked(blocked *bool) {
 	u.Blocked = blocked
 	u.require(updateUserRequestFieldBlocked)
@@ -1989,106 +2153,148 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetUserId(userId string) {
 	u.UserId = userId
 	u.require(userFieldUserId)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetEmail(email string) {
 	u.Email = email
 	u.require(userFieldEmail)
 }
 
+// SetEmailVerified sets the EmailVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetEmailVerified(emailVerified bool) {
 	u.EmailVerified = emailVerified
 	u.require(userFieldEmailVerified)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetUsername(username *string) {
 	u.Username = username
 	u.require(userFieldUsername)
 }
 
+// SetPhoneNumber sets the PhoneNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetPhoneNumber(phoneNumber *string) {
 	u.PhoneNumber = phoneNumber
 	u.require(userFieldPhoneNumber)
 }
 
+// SetPhoneVerified sets the PhoneVerified field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetPhoneVerified(phoneVerified *bool) {
 	u.PhoneVerified = phoneVerified
 	u.require(userFieldPhoneVerified)
 }
 
+// SetCreatedAt sets the CreatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetCreatedAt(createdAt time.Time) {
 	u.CreatedAt = createdAt
 	u.require(userFieldCreatedAt)
 }
 
+// SetUpdatedAt sets the UpdatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetUpdatedAt(updatedAt time.Time) {
 	u.UpdatedAt = updatedAt
 	u.require(userFieldUpdatedAt)
 }
 
+// SetIdentities sets the Identities field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetIdentities(identities []*Identity) {
 	u.Identities = identities
 	u.require(userFieldIdentities)
 }
 
+// SetAppMetadata sets the AppMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetAppMetadata(appMetadata map[string]interface{}) {
 	u.AppMetadata = appMetadata
 	u.require(userFieldAppMetadata)
 }
 
+// SetUserMetadata sets the UserMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetUserMetadata(userMetadata map[string]interface{}) {
 	u.UserMetadata = userMetadata
 	u.require(userFieldUserMetadata)
 }
 
+// SetPicture sets the Picture field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetPicture(picture *string) {
 	u.Picture = picture
 	u.require(userFieldPicture)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name *string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetNickname sets the Nickname field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetNickname(nickname *string) {
 	u.Nickname = nickname
 	u.require(userFieldNickname)
 }
 
+// SetMultifactor sets the Multifactor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetMultifactor(multifactor []string) {
 	u.Multifactor = multifactor
 	u.require(userFieldMultifactor)
 }
 
+// SetLastIp sets the LastIp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetLastIp(lastIp *string) {
 	u.LastIp = lastIp
 	u.require(userFieldLastIp)
 }
 
+// SetLastLogin sets the LastLogin field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetLastLogin(lastLogin *time.Time) {
 	u.LastLogin = lastLogin
 	u.require(userFieldLastLogin)
 }
 
+// SetLoginsCount sets the LoginsCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetLoginsCount(loginsCount *int) {
 	u.LoginsCount = loginsCount
 	u.require(userFieldLoginsCount)
 }
 
+// SetBlocked sets the Blocked field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetBlocked(blocked *bool) {
 	u.Blocked = blocked
 	u.require(userFieldBlocked)
 }
 
+// SetGivenName sets the GivenName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetGivenName(givenName *string) {
 	u.GivenName = givenName
 	u.require(userFieldGivenName)
 }
 
+// SetFamilyName sets the FamilyName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetFamilyName(familyName *string) {
 	u.FamilyName = familyName
 	u.require(userFieldFamilyName)

--- a/seed/go-sdk/client-side-params/types.go
+++ b/seed/go-sdk/client-side-params/types.go
@@ -6,10 +6,44 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/client-side-params/fern/internal"
+	big "math/big"
 	time "time"
 )
 
 // Represents a client application
+var (
+	clientFieldClientId                = big.NewInt(1 << 0)
+	clientFieldTenant                  = big.NewInt(1 << 1)
+	clientFieldName                    = big.NewInt(1 << 2)
+	clientFieldDescription             = big.NewInt(1 << 3)
+	clientFieldGlobal                  = big.NewInt(1 << 4)
+	clientFieldClientSecret            = big.NewInt(1 << 5)
+	clientFieldAppType                 = big.NewInt(1 << 6)
+	clientFieldLogoUri                 = big.NewInt(1 << 7)
+	clientFieldIsFirstParty            = big.NewInt(1 << 8)
+	clientFieldOidcConformant          = big.NewInt(1 << 9)
+	clientFieldCallbacks               = big.NewInt(1 << 10)
+	clientFieldAllowedOrigins          = big.NewInt(1 << 11)
+	clientFieldWebOrigins              = big.NewInt(1 << 12)
+	clientFieldGrantTypes              = big.NewInt(1 << 13)
+	clientFieldJwtConfiguration        = big.NewInt(1 << 14)
+	clientFieldSigningKeys             = big.NewInt(1 << 15)
+	clientFieldEncryptionKey           = big.NewInt(1 << 16)
+	clientFieldSso                     = big.NewInt(1 << 17)
+	clientFieldSsoDisabled             = big.NewInt(1 << 18)
+	clientFieldCrossOriginAuth         = big.NewInt(1 << 19)
+	clientFieldCrossOriginLoc          = big.NewInt(1 << 20)
+	clientFieldCustomLoginPageOn       = big.NewInt(1 << 21)
+	clientFieldCustomLoginPage         = big.NewInt(1 << 22)
+	clientFieldCustomLoginPagePreview  = big.NewInt(1 << 23)
+	clientFieldFormTemplate            = big.NewInt(1 << 24)
+	clientFieldIsHerokuApp             = big.NewInt(1 << 25)
+	clientFieldAddons                  = big.NewInt(1 << 26)
+	clientFieldTokenEndpointAuthMethod = big.NewInt(1 << 27)
+	clientFieldClientMetadata          = big.NewInt(1 << 28)
+	clientFieldMobile                  = big.NewInt(1 << 29)
+)
+
 type Client struct {
 	// The unique client identifier
 	ClientId string `json:"client_id" url:"client_id"`
@@ -71,6 +105,9 @@ type Client struct {
 	ClientMetadata map[string]interface{} `json:"client_metadata,omitempty" url:"client_metadata,omitempty"`
 	// Mobile app settings
 	Mobile map[string]interface{} `json:"mobile,omitempty" url:"mobile,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -290,6 +327,163 @@ func (c *Client) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *Client) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Client) SetClientId(clientId string) {
+	c.ClientId = clientId
+	c.require(clientFieldClientId)
+}
+
+func (c *Client) SetTenant(tenant *string) {
+	c.Tenant = tenant
+	c.require(clientFieldTenant)
+}
+
+func (c *Client) SetName(name string) {
+	c.Name = name
+	c.require(clientFieldName)
+}
+
+func (c *Client) SetDescription(description *string) {
+	c.Description = description
+	c.require(clientFieldDescription)
+}
+
+func (c *Client) SetGlobal(global *bool) {
+	c.Global = global
+	c.require(clientFieldGlobal)
+}
+
+func (c *Client) SetClientSecret(clientSecret *string) {
+	c.ClientSecret = clientSecret
+	c.require(clientFieldClientSecret)
+}
+
+func (c *Client) SetAppType(appType *string) {
+	c.AppType = appType
+	c.require(clientFieldAppType)
+}
+
+func (c *Client) SetLogoUri(logoUri *string) {
+	c.LogoUri = logoUri
+	c.require(clientFieldLogoUri)
+}
+
+func (c *Client) SetIsFirstParty(isFirstParty *bool) {
+	c.IsFirstParty = isFirstParty
+	c.require(clientFieldIsFirstParty)
+}
+
+func (c *Client) SetOidcConformant(oidcConformant *bool) {
+	c.OidcConformant = oidcConformant
+	c.require(clientFieldOidcConformant)
+}
+
+func (c *Client) SetCallbacks(callbacks []string) {
+	c.Callbacks = callbacks
+	c.require(clientFieldCallbacks)
+}
+
+func (c *Client) SetAllowedOrigins(allowedOrigins []string) {
+	c.AllowedOrigins = allowedOrigins
+	c.require(clientFieldAllowedOrigins)
+}
+
+func (c *Client) SetWebOrigins(webOrigins []string) {
+	c.WebOrigins = webOrigins
+	c.require(clientFieldWebOrigins)
+}
+
+func (c *Client) SetGrantTypes(grantTypes []string) {
+	c.GrantTypes = grantTypes
+	c.require(clientFieldGrantTypes)
+}
+
+func (c *Client) SetJwtConfiguration(jwtConfiguration map[string]interface{}) {
+	c.JwtConfiguration = jwtConfiguration
+	c.require(clientFieldJwtConfiguration)
+}
+
+func (c *Client) SetSigningKeys(signingKeys []map[string]interface{}) {
+	c.SigningKeys = signingKeys
+	c.require(clientFieldSigningKeys)
+}
+
+func (c *Client) SetEncryptionKey(encryptionKey map[string]interface{}) {
+	c.EncryptionKey = encryptionKey
+	c.require(clientFieldEncryptionKey)
+}
+
+func (c *Client) SetSso(sso *bool) {
+	c.Sso = sso
+	c.require(clientFieldSso)
+}
+
+func (c *Client) SetSsoDisabled(ssoDisabled *bool) {
+	c.SsoDisabled = ssoDisabled
+	c.require(clientFieldSsoDisabled)
+}
+
+func (c *Client) SetCrossOriginAuth(crossOriginAuth *bool) {
+	c.CrossOriginAuth = crossOriginAuth
+	c.require(clientFieldCrossOriginAuth)
+}
+
+func (c *Client) SetCrossOriginLoc(crossOriginLoc *string) {
+	c.CrossOriginLoc = crossOriginLoc
+	c.require(clientFieldCrossOriginLoc)
+}
+
+func (c *Client) SetCustomLoginPageOn(customLoginPageOn *bool) {
+	c.CustomLoginPageOn = customLoginPageOn
+	c.require(clientFieldCustomLoginPageOn)
+}
+
+func (c *Client) SetCustomLoginPage(customLoginPage *string) {
+	c.CustomLoginPage = customLoginPage
+	c.require(clientFieldCustomLoginPage)
+}
+
+func (c *Client) SetCustomLoginPagePreview(customLoginPagePreview *string) {
+	c.CustomLoginPagePreview = customLoginPagePreview
+	c.require(clientFieldCustomLoginPagePreview)
+}
+
+func (c *Client) SetFormTemplate(formTemplate *string) {
+	c.FormTemplate = formTemplate
+	c.require(clientFieldFormTemplate)
+}
+
+func (c *Client) SetIsHerokuApp(isHerokuApp *bool) {
+	c.IsHerokuApp = isHerokuApp
+	c.require(clientFieldIsHerokuApp)
+}
+
+func (c *Client) SetAddons(addons map[string]interface{}) {
+	c.Addons = addons
+	c.require(clientFieldAddons)
+}
+
+func (c *Client) SetTokenEndpointAuthMethod(tokenEndpointAuthMethod *string) {
+	c.TokenEndpointAuthMethod = tokenEndpointAuthMethod
+	c.require(clientFieldTokenEndpointAuthMethod)
+}
+
+func (c *Client) SetClientMetadata(clientMetadata map[string]interface{}) {
+	c.ClientMetadata = clientMetadata
+	c.require(clientFieldClientMetadata)
+}
+
+func (c *Client) SetMobile(mobile map[string]interface{}) {
+	c.Mobile = mobile
+	c.require(clientFieldMobile)
+}
+
 func (c *Client) UnmarshalJSON(data []byte) error {
 	type unmarshaler Client
 	var value unmarshaler
@@ -306,6 +500,17 @@ func (c *Client) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Client) MarshalJSON() ([]byte, error) {
+	type embed Client
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Client) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -319,6 +524,18 @@ func (c *Client) String() string {
 }
 
 // Represents an identity provider connection
+var (
+	connectionFieldId                 = big.NewInt(1 << 0)
+	connectionFieldName               = big.NewInt(1 << 1)
+	connectionFieldDisplayName        = big.NewInt(1 << 2)
+	connectionFieldStrategy           = big.NewInt(1 << 3)
+	connectionFieldOptions            = big.NewInt(1 << 4)
+	connectionFieldEnabledClients     = big.NewInt(1 << 5)
+	connectionFieldRealms             = big.NewInt(1 << 6)
+	connectionFieldIsDomainConnection = big.NewInt(1 << 7)
+	connectionFieldMetadata           = big.NewInt(1 << 8)
+)
+
 type Connection struct {
 	// Connection identifier
 	Id string `json:"id" url:"id"`
@@ -338,6 +555,9 @@ type Connection struct {
 	IsDomainConnection *bool `json:"is_domain_connection,omitempty" url:"is_domain_connection,omitempty"`
 	// Additional metadata
 	Metadata map[string]interface{} `json:"metadata,omitempty" url:"metadata,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -410,6 +630,58 @@ func (c *Connection) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *Connection) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Connection) SetId(id string) {
+	c.Id = id
+	c.require(connectionFieldId)
+}
+
+func (c *Connection) SetName(name string) {
+	c.Name = name
+	c.require(connectionFieldName)
+}
+
+func (c *Connection) SetDisplayName(displayName *string) {
+	c.DisplayName = displayName
+	c.require(connectionFieldDisplayName)
+}
+
+func (c *Connection) SetStrategy(strategy string) {
+	c.Strategy = strategy
+	c.require(connectionFieldStrategy)
+}
+
+func (c *Connection) SetOptions(options map[string]interface{}) {
+	c.Options = options
+	c.require(connectionFieldOptions)
+}
+
+func (c *Connection) SetEnabledClients(enabledClients []string) {
+	c.EnabledClients = enabledClients
+	c.require(connectionFieldEnabledClients)
+}
+
+func (c *Connection) SetRealms(realms []string) {
+	c.Realms = realms
+	c.require(connectionFieldRealms)
+}
+
+func (c *Connection) SetIsDomainConnection(isDomainConnection *bool) {
+	c.IsDomainConnection = isDomainConnection
+	c.require(connectionFieldIsDomainConnection)
+}
+
+func (c *Connection) SetMetadata(metadata map[string]interface{}) {
+	c.Metadata = metadata
+	c.require(connectionFieldMetadata)
+}
+
 func (c *Connection) UnmarshalJSON(data []byte) error {
 	type unmarshaler Connection
 	var value unmarshaler
@@ -426,6 +698,17 @@ func (c *Connection) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Connection) MarshalJSON() ([]byte, error) {
+	type embed Connection
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Connection) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -438,6 +721,18 @@ func (c *Connection) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	createUserRequestFieldEmail         = big.NewInt(1 << 0)
+	createUserRequestFieldEmailVerified = big.NewInt(1 << 1)
+	createUserRequestFieldUsername      = big.NewInt(1 << 2)
+	createUserRequestFieldPassword      = big.NewInt(1 << 3)
+	createUserRequestFieldPhoneNumber   = big.NewInt(1 << 4)
+	createUserRequestFieldPhoneVerified = big.NewInt(1 << 5)
+	createUserRequestFieldUserMetadata  = big.NewInt(1 << 6)
+	createUserRequestFieldAppMetadata   = big.NewInt(1 << 7)
+	createUserRequestFieldConnection    = big.NewInt(1 << 8)
+)
+
 type CreateUserRequest struct {
 	Email         string                 `json:"email" url:"email"`
 	EmailVerified *bool                  `json:"email_verified,omitempty" url:"email_verified,omitempty"`
@@ -448,6 +743,9 @@ type CreateUserRequest struct {
 	UserMetadata  map[string]interface{} `json:"user_metadata,omitempty" url:"user_metadata,omitempty"`
 	AppMetadata   map[string]interface{} `json:"app_metadata,omitempty" url:"app_metadata,omitempty"`
 	Connection    string                 `json:"connection" url:"connection"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -520,6 +818,58 @@ func (c *CreateUserRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateUserRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateUserRequest) SetEmail(email string) {
+	c.Email = email
+	c.require(createUserRequestFieldEmail)
+}
+
+func (c *CreateUserRequest) SetEmailVerified(emailVerified *bool) {
+	c.EmailVerified = emailVerified
+	c.require(createUserRequestFieldEmailVerified)
+}
+
+func (c *CreateUserRequest) SetUsername(username *string) {
+	c.Username = username
+	c.require(createUserRequestFieldUsername)
+}
+
+func (c *CreateUserRequest) SetPassword(password *string) {
+	c.Password = password
+	c.require(createUserRequestFieldPassword)
+}
+
+func (c *CreateUserRequest) SetPhoneNumber(phoneNumber *string) {
+	c.PhoneNumber = phoneNumber
+	c.require(createUserRequestFieldPhoneNumber)
+}
+
+func (c *CreateUserRequest) SetPhoneVerified(phoneVerified *bool) {
+	c.PhoneVerified = phoneVerified
+	c.require(createUserRequestFieldPhoneVerified)
+}
+
+func (c *CreateUserRequest) SetUserMetadata(userMetadata map[string]interface{}) {
+	c.UserMetadata = userMetadata
+	c.require(createUserRequestFieldUserMetadata)
+}
+
+func (c *CreateUserRequest) SetAppMetadata(appMetadata map[string]interface{}) {
+	c.AppMetadata = appMetadata
+	c.require(createUserRequestFieldAppMetadata)
+}
+
+func (c *CreateUserRequest) SetConnection(connection string) {
+	c.Connection = connection
+	c.require(createUserRequestFieldConnection)
+}
+
 func (c *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateUserRequest
 	var value unmarshaler
@@ -536,6 +886,17 @@ func (c *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateUserRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateUserRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateUserRequest) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -548,6 +909,15 @@ func (c *CreateUserRequest) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	identityFieldConnection  = big.NewInt(1 << 0)
+	identityFieldUserId      = big.NewInt(1 << 1)
+	identityFieldProvider    = big.NewInt(1 << 2)
+	identityFieldIsSocial    = big.NewInt(1 << 3)
+	identityFieldAccessToken = big.NewInt(1 << 4)
+	identityFieldExpiresIn   = big.NewInt(1 << 5)
+)
+
 type Identity struct {
 	Connection  string  `json:"connection" url:"connection"`
 	UserId      string  `json:"user_id" url:"user_id"`
@@ -555,6 +925,9 @@ type Identity struct {
 	IsSocial    bool    `json:"is_social" url:"is_social"`
 	AccessToken *string `json:"access_token,omitempty" url:"access_token,omitempty"`
 	ExpiresIn   *int    `json:"expires_in,omitempty" url:"expires_in,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -606,6 +979,43 @@ func (i *Identity) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identity) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identity) SetConnection(connection string) {
+	i.Connection = connection
+	i.require(identityFieldConnection)
+}
+
+func (i *Identity) SetUserId(userId string) {
+	i.UserId = userId
+	i.require(identityFieldUserId)
+}
+
+func (i *Identity) SetProvider(provider string) {
+	i.Provider = provider
+	i.require(identityFieldProvider)
+}
+
+func (i *Identity) SetIsSocial(isSocial bool) {
+	i.IsSocial = isSocial
+	i.require(identityFieldIsSocial)
+}
+
+func (i *Identity) SetAccessToken(accessToken *string) {
+	i.AccessToken = accessToken
+	i.require(identityFieldAccessToken)
+}
+
+func (i *Identity) SetExpiresIn(expiresIn *int) {
+	i.ExpiresIn = expiresIn
+	i.require(identityFieldExpiresIn)
+}
+
 func (i *Identity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identity
 	var value unmarshaler
@@ -622,6 +1032,17 @@ func (i *Identity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (i *Identity) MarshalJSON() ([]byte, error) {
+	type embed Identity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (i *Identity) String() string {
 	if len(i.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(i.rawJSON); err == nil {
@@ -635,6 +1056,14 @@ func (i *Identity) String() string {
 }
 
 // Paginated response for clients listing
+var (
+	paginatedClientResponseFieldStart   = big.NewInt(1 << 0)
+	paginatedClientResponseFieldLimit   = big.NewInt(1 << 1)
+	paginatedClientResponseFieldLength  = big.NewInt(1 << 2)
+	paginatedClientResponseFieldTotal   = big.NewInt(1 << 3)
+	paginatedClientResponseFieldClients = big.NewInt(1 << 4)
+)
+
 type PaginatedClientResponse struct {
 	// Starting index (zero-based)
 	Start int `json:"start" url:"start"`
@@ -646,6 +1075,9 @@ type PaginatedClientResponse struct {
 	Total *int `json:"total,omitempty" url:"total,omitempty"`
 	// List of clients
 	Clients []*Client `json:"clients" url:"clients"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -690,6 +1122,38 @@ func (p *PaginatedClientResponse) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *PaginatedClientResponse) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PaginatedClientResponse) SetStart(start int) {
+	p.Start = start
+	p.require(paginatedClientResponseFieldStart)
+}
+
+func (p *PaginatedClientResponse) SetLimit(limit int) {
+	p.Limit = limit
+	p.require(paginatedClientResponseFieldLimit)
+}
+
+func (p *PaginatedClientResponse) SetLength(length int) {
+	p.Length = length
+	p.require(paginatedClientResponseFieldLength)
+}
+
+func (p *PaginatedClientResponse) SetTotal(total *int) {
+	p.Total = total
+	p.require(paginatedClientResponseFieldTotal)
+}
+
+func (p *PaginatedClientResponse) SetClients(clients []*Client) {
+	p.Clients = clients
+	p.require(paginatedClientResponseFieldClients)
+}
+
 func (p *PaginatedClientResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler PaginatedClientResponse
 	var value unmarshaler
@@ -706,6 +1170,17 @@ func (p *PaginatedClientResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PaginatedClientResponse) MarshalJSON() ([]byte, error) {
+	type embed PaginatedClientResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PaginatedClientResponse) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -719,12 +1194,23 @@ func (p *PaginatedClientResponse) String() string {
 }
 
 // Response with pagination info like Auth0
+var (
+	paginatedUserResponseFieldUsers  = big.NewInt(1 << 0)
+	paginatedUserResponseFieldStart  = big.NewInt(1 << 1)
+	paginatedUserResponseFieldLimit  = big.NewInt(1 << 2)
+	paginatedUserResponseFieldLength = big.NewInt(1 << 3)
+	paginatedUserResponseFieldTotal  = big.NewInt(1 << 4)
+)
+
 type PaginatedUserResponse struct {
 	Users  []*User `json:"users" url:"users"`
 	Start  int     `json:"start" url:"start"`
 	Limit  int     `json:"limit" url:"limit"`
 	Length int     `json:"length" url:"length"`
 	Total  *int    `json:"total,omitempty" url:"total,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -769,6 +1255,38 @@ func (p *PaginatedUserResponse) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *PaginatedUserResponse) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PaginatedUserResponse) SetUsers(users []*User) {
+	p.Users = users
+	p.require(paginatedUserResponseFieldUsers)
+}
+
+func (p *PaginatedUserResponse) SetStart(start int) {
+	p.Start = start
+	p.require(paginatedUserResponseFieldStart)
+}
+
+func (p *PaginatedUserResponse) SetLimit(limit int) {
+	p.Limit = limit
+	p.require(paginatedUserResponseFieldLimit)
+}
+
+func (p *PaginatedUserResponse) SetLength(length int) {
+	p.Length = length
+	p.require(paginatedUserResponseFieldLength)
+}
+
+func (p *PaginatedUserResponse) SetTotal(total *int) {
+	p.Total = total
+	p.require(paginatedUserResponseFieldTotal)
+}
+
 func (p *PaginatedUserResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler PaginatedUserResponse
 	var value unmarshaler
@@ -785,6 +1303,17 @@ func (p *PaginatedUserResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PaginatedUserResponse) MarshalJSON() ([]byte, error) {
+	type embed PaginatedUserResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PaginatedUserResponse) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -797,6 +1326,15 @@ func (p *PaginatedUserResponse) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	resourceFieldId          = big.NewInt(1 << 0)
+	resourceFieldName        = big.NewInt(1 << 1)
+	resourceFieldDescription = big.NewInt(1 << 2)
+	resourceFieldCreatedAt   = big.NewInt(1 << 3)
+	resourceFieldUpdatedAt   = big.NewInt(1 << 4)
+	resourceFieldMetadata    = big.NewInt(1 << 5)
+)
+
 type Resource struct {
 	Id          string                 `json:"id" url:"id"`
 	Name        string                 `json:"name" url:"name"`
@@ -804,6 +1342,9 @@ type Resource struct {
 	CreatedAt   time.Time              `json:"created_at" url:"created_at"`
 	UpdatedAt   time.Time              `json:"updated_at" url:"updated_at"`
 	Metadata    map[string]interface{} `json:"metadata,omitempty" url:"metadata,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -855,6 +1396,43 @@ func (r *Resource) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Resource) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Resource) SetId(id string) {
+	r.Id = id
+	r.require(resourceFieldId)
+}
+
+func (r *Resource) SetName(name string) {
+	r.Name = name
+	r.require(resourceFieldName)
+}
+
+func (r *Resource) SetDescription(description *string) {
+	r.Description = description
+	r.require(resourceFieldDescription)
+}
+
+func (r *Resource) SetCreatedAt(createdAt time.Time) {
+	r.CreatedAt = createdAt
+	r.require(resourceFieldCreatedAt)
+}
+
+func (r *Resource) SetUpdatedAt(updatedAt time.Time) {
+	r.UpdatedAt = updatedAt
+	r.require(resourceFieldUpdatedAt)
+}
+
+func (r *Resource) SetMetadata(metadata map[string]interface{}) {
+	r.Metadata = metadata
+	r.require(resourceFieldMetadata)
+}
+
 func (r *Resource) UnmarshalJSON(data []byte) error {
 	type embed Resource
 	var unmarshaler = struct {
@@ -890,7 +1468,8 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 		CreatedAt: internal.NewDateTime(r.CreatedAt),
 		UpdatedAt: internal.NewDateTime(r.UpdatedAt),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Resource) String() string {
@@ -905,10 +1484,19 @@ func (r *Resource) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	searchResponseFieldResults    = big.NewInt(1 << 0)
+	searchResponseFieldTotal      = big.NewInt(1 << 1)
+	searchResponseFieldNextOffset = big.NewInt(1 << 2)
+)
+
 type SearchResponse struct {
 	Results    []*Resource `json:"results" url:"results"`
 	Total      *int        `json:"total,omitempty" url:"total,omitempty"`
 	NextOffset *int        `json:"next_offset,omitempty" url:"next_offset,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -939,6 +1527,28 @@ func (s *SearchResponse) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SearchResponse) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchResponse) SetResults(results []*Resource) {
+	s.Results = results
+	s.require(searchResponseFieldResults)
+}
+
+func (s *SearchResponse) SetTotal(total *int) {
+	s.Total = total
+	s.require(searchResponseFieldTotal)
+}
+
+func (s *SearchResponse) SetNextOffset(nextOffset *int) {
+	s.NextOffset = nextOffset
+	s.require(searchResponseFieldNextOffset)
+}
+
 func (s *SearchResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler SearchResponse
 	var value unmarshaler
@@ -955,6 +1565,17 @@ func (s *SearchResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SearchResponse) MarshalJSON() ([]byte, error) {
+	type embed SearchResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SearchResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -967,6 +1588,18 @@ func (s *SearchResponse) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	updateUserRequestFieldEmail         = big.NewInt(1 << 0)
+	updateUserRequestFieldEmailVerified = big.NewInt(1 << 1)
+	updateUserRequestFieldUsername      = big.NewInt(1 << 2)
+	updateUserRequestFieldPhoneNumber   = big.NewInt(1 << 3)
+	updateUserRequestFieldPhoneVerified = big.NewInt(1 << 4)
+	updateUserRequestFieldUserMetadata  = big.NewInt(1 << 5)
+	updateUserRequestFieldAppMetadata   = big.NewInt(1 << 6)
+	updateUserRequestFieldPassword      = big.NewInt(1 << 7)
+	updateUserRequestFieldBlocked       = big.NewInt(1 << 8)
+)
+
 type UpdateUserRequest struct {
 	Email         *string                `json:"email,omitempty" url:"email,omitempty"`
 	EmailVerified *bool                  `json:"email_verified,omitempty" url:"email_verified,omitempty"`
@@ -977,6 +1610,9 @@ type UpdateUserRequest struct {
 	AppMetadata   map[string]interface{} `json:"app_metadata,omitempty" url:"app_metadata,omitempty"`
 	Password      *string                `json:"password,omitempty" url:"password,omitempty"`
 	Blocked       *bool                  `json:"blocked,omitempty" url:"blocked,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1049,6 +1685,58 @@ func (u *UpdateUserRequest) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UpdateUserRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UpdateUserRequest) SetEmail(email *string) {
+	u.Email = email
+	u.require(updateUserRequestFieldEmail)
+}
+
+func (u *UpdateUserRequest) SetEmailVerified(emailVerified *bool) {
+	u.EmailVerified = emailVerified
+	u.require(updateUserRequestFieldEmailVerified)
+}
+
+func (u *UpdateUserRequest) SetUsername(username *string) {
+	u.Username = username
+	u.require(updateUserRequestFieldUsername)
+}
+
+func (u *UpdateUserRequest) SetPhoneNumber(phoneNumber *string) {
+	u.PhoneNumber = phoneNumber
+	u.require(updateUserRequestFieldPhoneNumber)
+}
+
+func (u *UpdateUserRequest) SetPhoneVerified(phoneVerified *bool) {
+	u.PhoneVerified = phoneVerified
+	u.require(updateUserRequestFieldPhoneVerified)
+}
+
+func (u *UpdateUserRequest) SetUserMetadata(userMetadata map[string]interface{}) {
+	u.UserMetadata = userMetadata
+	u.require(updateUserRequestFieldUserMetadata)
+}
+
+func (u *UpdateUserRequest) SetAppMetadata(appMetadata map[string]interface{}) {
+	u.AppMetadata = appMetadata
+	u.require(updateUserRequestFieldAppMetadata)
+}
+
+func (u *UpdateUserRequest) SetPassword(password *string) {
+	u.Password = password
+	u.require(updateUserRequestFieldPassword)
+}
+
+func (u *UpdateUserRequest) SetBlocked(blocked *bool) {
+	u.Blocked = blocked
+	u.require(updateUserRequestFieldBlocked)
+}
+
 func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler UpdateUserRequest
 	var value unmarshaler
@@ -1065,6 +1753,17 @@ func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UpdateUserRequest) MarshalJSON() ([]byte, error) {
+	type embed UpdateUserRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UpdateUserRequest) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -1078,6 +1777,30 @@ func (u *UpdateUserRequest) String() string {
 }
 
 // User object similar to Auth0 users
+var (
+	userFieldUserId        = big.NewInt(1 << 0)
+	userFieldEmail         = big.NewInt(1 << 1)
+	userFieldEmailVerified = big.NewInt(1 << 2)
+	userFieldUsername      = big.NewInt(1 << 3)
+	userFieldPhoneNumber   = big.NewInt(1 << 4)
+	userFieldPhoneVerified = big.NewInt(1 << 5)
+	userFieldCreatedAt     = big.NewInt(1 << 6)
+	userFieldUpdatedAt     = big.NewInt(1 << 7)
+	userFieldIdentities    = big.NewInt(1 << 8)
+	userFieldAppMetadata   = big.NewInt(1 << 9)
+	userFieldUserMetadata  = big.NewInt(1 << 10)
+	userFieldPicture       = big.NewInt(1 << 11)
+	userFieldName          = big.NewInt(1 << 12)
+	userFieldNickname      = big.NewInt(1 << 13)
+	userFieldMultifactor   = big.NewInt(1 << 14)
+	userFieldLastIp        = big.NewInt(1 << 15)
+	userFieldLastLogin     = big.NewInt(1 << 16)
+	userFieldLoginsCount   = big.NewInt(1 << 17)
+	userFieldBlocked       = big.NewInt(1 << 18)
+	userFieldGivenName     = big.NewInt(1 << 19)
+	userFieldFamilyName    = big.NewInt(1 << 20)
+)
+
 type User struct {
 	UserId        string                 `json:"user_id" url:"user_id"`
 	Email         string                 `json:"email" url:"email"`
@@ -1100,6 +1823,9 @@ type User struct {
 	Blocked       *bool                  `json:"blocked,omitempty" url:"blocked,omitempty"`
 	GivenName     *string                `json:"given_name,omitempty" url:"given_name,omitempty"`
 	FamilyName    *string                `json:"family_name,omitempty" url:"family_name,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1256,6 +1982,118 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetUserId(userId string) {
+	u.UserId = userId
+	u.require(userFieldUserId)
+}
+
+func (u *User) SetEmail(email string) {
+	u.Email = email
+	u.require(userFieldEmail)
+}
+
+func (u *User) SetEmailVerified(emailVerified bool) {
+	u.EmailVerified = emailVerified
+	u.require(userFieldEmailVerified)
+}
+
+func (u *User) SetUsername(username *string) {
+	u.Username = username
+	u.require(userFieldUsername)
+}
+
+func (u *User) SetPhoneNumber(phoneNumber *string) {
+	u.PhoneNumber = phoneNumber
+	u.require(userFieldPhoneNumber)
+}
+
+func (u *User) SetPhoneVerified(phoneVerified *bool) {
+	u.PhoneVerified = phoneVerified
+	u.require(userFieldPhoneVerified)
+}
+
+func (u *User) SetCreatedAt(createdAt time.Time) {
+	u.CreatedAt = createdAt
+	u.require(userFieldCreatedAt)
+}
+
+func (u *User) SetUpdatedAt(updatedAt time.Time) {
+	u.UpdatedAt = updatedAt
+	u.require(userFieldUpdatedAt)
+}
+
+func (u *User) SetIdentities(identities []*Identity) {
+	u.Identities = identities
+	u.require(userFieldIdentities)
+}
+
+func (u *User) SetAppMetadata(appMetadata map[string]interface{}) {
+	u.AppMetadata = appMetadata
+	u.require(userFieldAppMetadata)
+}
+
+func (u *User) SetUserMetadata(userMetadata map[string]interface{}) {
+	u.UserMetadata = userMetadata
+	u.require(userFieldUserMetadata)
+}
+
+func (u *User) SetPicture(picture *string) {
+	u.Picture = picture
+	u.require(userFieldPicture)
+}
+
+func (u *User) SetName(name *string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetNickname(nickname *string) {
+	u.Nickname = nickname
+	u.require(userFieldNickname)
+}
+
+func (u *User) SetMultifactor(multifactor []string) {
+	u.Multifactor = multifactor
+	u.require(userFieldMultifactor)
+}
+
+func (u *User) SetLastIp(lastIp *string) {
+	u.LastIp = lastIp
+	u.require(userFieldLastIp)
+}
+
+func (u *User) SetLastLogin(lastLogin *time.Time) {
+	u.LastLogin = lastLogin
+	u.require(userFieldLastLogin)
+}
+
+func (u *User) SetLoginsCount(loginsCount *int) {
+	u.LoginsCount = loginsCount
+	u.require(userFieldLoginsCount)
+}
+
+func (u *User) SetBlocked(blocked *bool) {
+	u.Blocked = blocked
+	u.require(userFieldBlocked)
+}
+
+func (u *User) SetGivenName(givenName *string) {
+	u.GivenName = givenName
+	u.require(userFieldGivenName)
+}
+
+func (u *User) SetFamilyName(familyName *string) {
+	u.FamilyName = familyName
+	u.require(userFieldFamilyName)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type embed User
 	var unmarshaler = struct {
@@ -1295,7 +2133,8 @@ func (u *User) MarshalJSON() ([]byte, error) {
 		UpdatedAt: internal.NewDateTime(u.UpdatedAt),
 		LastLogin: internal.NewOptionalDateTime(u.LastLogin),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/content-type/internal/explicit_fields.go
+++ b/seed/go-sdk/content-type/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/content-type/internal/explicit_fields_test.go
+++ b/seed/go-sdk/content-type/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/content-type/service.go
+++ b/seed/go-sdk/content-type/service.go
@@ -2,11 +2,54 @@
 
 package contenttypes
 
+import (
+	big "math/big"
+)
+
+var (
+	namedMixedPatchRequestFieldAppId        = big.NewInt(1 << 0)
+	namedMixedPatchRequestFieldInstructions = big.NewInt(1 << 1)
+	namedMixedPatchRequestFieldActive       = big.NewInt(1 << 2)
+)
+
 type NamedMixedPatchRequest struct {
 	AppId        *string `json:"appId,omitempty" url:"-"`
 	Instructions *string `json:"instructions,omitempty" url:"-"`
 	Active       *bool   `json:"active,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (n *NamedMixedPatchRequest) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NamedMixedPatchRequest) SetAppId(appId *string) {
+	n.AppId = appId
+	n.require(namedMixedPatchRequestFieldAppId)
+}
+
+func (n *NamedMixedPatchRequest) SetInstructions(instructions *string) {
+	n.Instructions = instructions
+	n.require(namedMixedPatchRequestFieldInstructions)
+}
+
+func (n *NamedMixedPatchRequest) SetActive(active *bool) {
+	n.Active = active
+	n.require(namedMixedPatchRequestFieldActive)
+}
+
+var (
+	optionalMergePatchRequestFieldRequiredField   = big.NewInt(1 << 0)
+	optionalMergePatchRequestFieldOptionalString  = big.NewInt(1 << 1)
+	optionalMergePatchRequestFieldOptionalInteger = big.NewInt(1 << 2)
+	optionalMergePatchRequestFieldOptionalBoolean = big.NewInt(1 << 3)
+	optionalMergePatchRequestFieldNullableString  = big.NewInt(1 << 4)
+)
 
 type OptionalMergePatchRequest struct {
 	RequiredField   string  `json:"requiredField" url:"-"`
@@ -14,12 +57,85 @@ type OptionalMergePatchRequest struct {
 	OptionalInteger *int    `json:"optionalInteger,omitempty" url:"-"`
 	OptionalBoolean *bool   `json:"optionalBoolean,omitempty" url:"-"`
 	NullableString  *string `json:"nullableString,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (o *OptionalMergePatchRequest) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *OptionalMergePatchRequest) SetRequiredField(requiredField string) {
+	o.RequiredField = requiredField
+	o.require(optionalMergePatchRequestFieldRequiredField)
+}
+
+func (o *OptionalMergePatchRequest) SetOptionalString(optionalString *string) {
+	o.OptionalString = optionalString
+	o.require(optionalMergePatchRequestFieldOptionalString)
+}
+
+func (o *OptionalMergePatchRequest) SetOptionalInteger(optionalInteger *int) {
+	o.OptionalInteger = optionalInteger
+	o.require(optionalMergePatchRequestFieldOptionalInteger)
+}
+
+func (o *OptionalMergePatchRequest) SetOptionalBoolean(optionalBoolean *bool) {
+	o.OptionalBoolean = optionalBoolean
+	o.require(optionalMergePatchRequestFieldOptionalBoolean)
+}
+
+func (o *OptionalMergePatchRequest) SetNullableString(nullableString *string) {
+	o.NullableString = nullableString
+	o.require(optionalMergePatchRequestFieldNullableString)
+}
+
+var (
+	patchProxyRequestFieldApplication = big.NewInt(1 << 0)
+	patchProxyRequestFieldRequireAuth = big.NewInt(1 << 1)
+)
 
 type PatchProxyRequest struct {
 	Application *string `json:"application,omitempty" url:"-"`
 	RequireAuth *bool   `json:"require_auth,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (p *PatchProxyRequest) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PatchProxyRequest) SetApplication(application *string) {
+	p.Application = application
+	p.require(patchProxyRequestFieldApplication)
+}
+
+func (p *PatchProxyRequest) SetRequireAuth(requireAuth *bool) {
+	p.RequireAuth = requireAuth
+	p.require(patchProxyRequestFieldRequireAuth)
+}
+
+var (
+	patchComplexRequestFieldName            = big.NewInt(1 << 0)
+	patchComplexRequestFieldAge             = big.NewInt(1 << 1)
+	patchComplexRequestFieldActive          = big.NewInt(1 << 2)
+	patchComplexRequestFieldMetadata        = big.NewInt(1 << 3)
+	patchComplexRequestFieldTags            = big.NewInt(1 << 4)
+	patchComplexRequestFieldEmail           = big.NewInt(1 << 5)
+	patchComplexRequestFieldNickname        = big.NewInt(1 << 6)
+	patchComplexRequestFieldBio             = big.NewInt(1 << 7)
+	patchComplexRequestFieldProfileImageUrl = big.NewInt(1 << 8)
+	patchComplexRequestFieldSettings        = big.NewInt(1 << 9)
+)
 
 type PatchComplexRequest struct {
 	Name            *string                `json:"name,omitempty" url:"-"`
@@ -32,9 +148,94 @@ type PatchComplexRequest struct {
 	Bio             *string                `json:"bio,omitempty" url:"-"`
 	ProfileImageUrl *string                `json:"profileImageUrl,omitempty" url:"-"`
 	Settings        map[string]interface{} `json:"settings,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (p *PatchComplexRequest) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PatchComplexRequest) SetName(name *string) {
+	p.Name = name
+	p.require(patchComplexRequestFieldName)
+}
+
+func (p *PatchComplexRequest) SetAge(age *int) {
+	p.Age = age
+	p.require(patchComplexRequestFieldAge)
+}
+
+func (p *PatchComplexRequest) SetActive(active *bool) {
+	p.Active = active
+	p.require(patchComplexRequestFieldActive)
+}
+
+func (p *PatchComplexRequest) SetMetadata(metadata map[string]interface{}) {
+	p.Metadata = metadata
+	p.require(patchComplexRequestFieldMetadata)
+}
+
+func (p *PatchComplexRequest) SetTags(tags []string) {
+	p.Tags = tags
+	p.require(patchComplexRequestFieldTags)
+}
+
+func (p *PatchComplexRequest) SetEmail(email *string) {
+	p.Email = email
+	p.require(patchComplexRequestFieldEmail)
+}
+
+func (p *PatchComplexRequest) SetNickname(nickname *string) {
+	p.Nickname = nickname
+	p.require(patchComplexRequestFieldNickname)
+}
+
+func (p *PatchComplexRequest) SetBio(bio *string) {
+	p.Bio = bio
+	p.require(patchComplexRequestFieldBio)
+}
+
+func (p *PatchComplexRequest) SetProfileImageUrl(profileImageUrl *string) {
+	p.ProfileImageUrl = profileImageUrl
+	p.require(patchComplexRequestFieldProfileImageUrl)
+}
+
+func (p *PatchComplexRequest) SetSettings(settings map[string]interface{}) {
+	p.Settings = settings
+	p.require(patchComplexRequestFieldSettings)
+}
+
+var (
+	regularPatchRequestFieldField1 = big.NewInt(1 << 0)
+	regularPatchRequestFieldField2 = big.NewInt(1 << 1)
+)
 
 type RegularPatchRequest struct {
 	Field1 *string `json:"field1,omitempty" url:"-"`
 	Field2 *int    `json:"field2,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (r *RegularPatchRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RegularPatchRequest) SetField1(field1 *string) {
+	r.Field1 = field1
+	r.require(regularPatchRequestFieldField1)
+}
+
+func (r *RegularPatchRequest) SetField2(field2 *int) {
+	r.Field2 = field2
+	r.require(regularPatchRequestFieldField2)
 }

--- a/seed/go-sdk/content-type/service.go
+++ b/seed/go-sdk/content-type/service.go
@@ -28,16 +28,22 @@ func (n *NamedMixedPatchRequest) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetAppId sets the AppId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NamedMixedPatchRequest) SetAppId(appId *string) {
 	n.AppId = appId
 	n.require(namedMixedPatchRequestFieldAppId)
 }
 
+// SetInstructions sets the Instructions field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NamedMixedPatchRequest) SetInstructions(instructions *string) {
 	n.Instructions = instructions
 	n.require(namedMixedPatchRequestFieldInstructions)
 }
 
+// SetActive sets the Active field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NamedMixedPatchRequest) SetActive(active *bool) {
 	n.Active = active
 	n.require(namedMixedPatchRequestFieldActive)
@@ -69,26 +75,36 @@ func (o *OptionalMergePatchRequest) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetRequiredField sets the RequiredField field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *OptionalMergePatchRequest) SetRequiredField(requiredField string) {
 	o.RequiredField = requiredField
 	o.require(optionalMergePatchRequestFieldRequiredField)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *OptionalMergePatchRequest) SetOptionalString(optionalString *string) {
 	o.OptionalString = optionalString
 	o.require(optionalMergePatchRequestFieldOptionalString)
 }
 
+// SetOptionalInteger sets the OptionalInteger field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *OptionalMergePatchRequest) SetOptionalInteger(optionalInteger *int) {
 	o.OptionalInteger = optionalInteger
 	o.require(optionalMergePatchRequestFieldOptionalInteger)
 }
 
+// SetOptionalBoolean sets the OptionalBoolean field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *OptionalMergePatchRequest) SetOptionalBoolean(optionalBoolean *bool) {
 	o.OptionalBoolean = optionalBoolean
 	o.require(optionalMergePatchRequestFieldOptionalBoolean)
 }
 
+// SetNullableString sets the NullableString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *OptionalMergePatchRequest) SetNullableString(nullableString *string) {
 	o.NullableString = nullableString
 	o.require(optionalMergePatchRequestFieldNullableString)
@@ -114,11 +130,15 @@ func (p *PatchProxyRequest) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetApplication sets the Application field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchProxyRequest) SetApplication(application *string) {
 	p.Application = application
 	p.require(patchProxyRequestFieldApplication)
 }
 
+// SetRequireAuth sets the RequireAuth field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchProxyRequest) SetRequireAuth(requireAuth *bool) {
 	p.RequireAuth = requireAuth
 	p.require(patchProxyRequestFieldRequireAuth)
@@ -160,51 +180,71 @@ func (p *PatchComplexRequest) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetName(name *string) {
 	p.Name = name
 	p.require(patchComplexRequestFieldName)
 }
 
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetAge(age *int) {
 	p.Age = age
 	p.require(patchComplexRequestFieldAge)
 }
 
+// SetActive sets the Active field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetActive(active *bool) {
 	p.Active = active
 	p.require(patchComplexRequestFieldActive)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetMetadata(metadata map[string]interface{}) {
 	p.Metadata = metadata
 	p.require(patchComplexRequestFieldMetadata)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetTags(tags []string) {
 	p.Tags = tags
 	p.require(patchComplexRequestFieldTags)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetEmail(email *string) {
 	p.Email = email
 	p.require(patchComplexRequestFieldEmail)
 }
 
+// SetNickname sets the Nickname field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetNickname(nickname *string) {
 	p.Nickname = nickname
 	p.require(patchComplexRequestFieldNickname)
 }
 
+// SetBio sets the Bio field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetBio(bio *string) {
 	p.Bio = bio
 	p.require(patchComplexRequestFieldBio)
 }
 
+// SetProfileImageUrl sets the ProfileImageUrl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetProfileImageUrl(profileImageUrl *string) {
 	p.ProfileImageUrl = profileImageUrl
 	p.require(patchComplexRequestFieldProfileImageUrl)
 }
 
+// SetSettings sets the Settings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PatchComplexRequest) SetSettings(settings map[string]interface{}) {
 	p.Settings = settings
 	p.require(patchComplexRequestFieldSettings)
@@ -230,11 +270,15 @@ func (r *RegularPatchRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetField1 sets the Field1 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RegularPatchRequest) SetField1(field1 *string) {
 	r.Field1 = field1
 	r.require(regularPatchRequestFieldField1)
 }
 
+// SetField2 sets the Field2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RegularPatchRequest) SetField2(field2 *int) {
 	r.Field2 = field2
 	r.require(regularPatchRequestFieldField2)

--- a/seed/go-sdk/cross-package-type-names/foldera/service.go
+++ b/seed/go-sdk/cross-package-type-names/foldera/service.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderb "github.com/cross-package-type-names/fern/folderb"
 	internal "github.com/cross-package-type-names/fern/internal"
+	big "math/big"
+)
+
+var (
+	responseFieldFoo = big.NewInt(1 << 0)
 )
 
 type Response struct {
 	Foo *folderb.Foo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -27,6 +35,18 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetFoo(foo *folderb.Foo) {
+	r.Foo = foo
+	r.require(responseFieldFoo)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -41,6 +61,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	r.extraProperties = extraProperties
 	r.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Response) String() string {

--- a/seed/go-sdk/cross-package-type-names/foldera/service.go
+++ b/seed/go-sdk/cross-package-type-names/foldera/service.go
@@ -42,6 +42,8 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetFoo(foo *folderb.Foo) {
 	r.Foo = foo
 	r.require(responseFieldFoo)

--- a/seed/go-sdk/cross-package-type-names/folderb/common.go
+++ b/seed/go-sdk/cross-package-type-names/folderb/common.go
@@ -42,6 +42,8 @@ func (f *Foo) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *Foo) SetFoo(foo *folderc.Foo) {
 	f.Foo = foo
 	f.require(fooFieldFoo)

--- a/seed/go-sdk/cross-package-type-names/folderc/common.go
+++ b/seed/go-sdk/cross-package-type-names/folderc/common.go
@@ -42,6 +42,8 @@ func (f *Foo) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetBarProperty sets the BarProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *Foo) SetBarProperty(barProperty uuid.UUID) {
 	f.BarProperty = barProperty
 	f.require(fooFieldBarProperty)

--- a/seed/go-sdk/cross-package-type-names/folderc/common.go
+++ b/seed/go-sdk/cross-package-type-names/folderc/common.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	internal "github.com/cross-package-type-names/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
+)
+
+var (
+	fooFieldBarProperty = big.NewInt(1 << 0)
 )
 
 type Foo struct {
 	BarProperty uuid.UUID `json:"bar_property" url:"bar_property"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -27,6 +35,18 @@ func (f *Foo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *Foo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *Foo) SetBarProperty(barProperty uuid.UUID) {
+	f.BarProperty = barProperty
+	f.require(fooFieldBarProperty)
+}
+
 func (f *Foo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Foo
 	var value unmarshaler
@@ -41,6 +61,17 @@ func (f *Foo) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *Foo) MarshalJSON() ([]byte, error) {
+	type embed Foo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *Foo) String() string {

--- a/seed/go-sdk/cross-package-type-names/folderd/service.go
+++ b/seed/go-sdk/cross-package-type-names/folderd/service.go
@@ -7,10 +7,18 @@ import (
 	fmt "fmt"
 	folderb "github.com/cross-package-type-names/fern/folderb"
 	internal "github.com/cross-package-type-names/fern/internal"
+	big "math/big"
+)
+
+var (
+	responseFieldFoo = big.NewInt(1 << 0)
 )
 
 type Response struct {
 	Foo *folderb.Foo `json:"foo,omitempty" url:"foo,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -27,6 +35,18 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetFoo(foo *folderb.Foo) {
+	r.Foo = foo
+	r.require(responseFieldFoo)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -41,6 +61,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	r.extraProperties = extraProperties
 	r.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (r *Response) String() string {

--- a/seed/go-sdk/cross-package-type-names/folderd/service.go
+++ b/seed/go-sdk/cross-package-type-names/folderd/service.go
@@ -42,6 +42,8 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetFoo(foo *folderb.Foo) {
 	r.Foo = foo
 	r.require(responseFieldFoo)

--- a/seed/go-sdk/cross-package-type-names/foo.go
+++ b/seed/go-sdk/cross-package-type-names/foo.go
@@ -31,16 +31,22 @@ func (f *FindRequest) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FindRequest) SetOptionalString(optionalString OptionalString) {
 	f.OptionalString = optionalString
 	f.require(findRequestFieldOptionalString)
 }
 
+// SetPublicProperty sets the PublicProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FindRequest) SetPublicProperty(publicProperty *string) {
 	f.PublicProperty = publicProperty
 	f.require(findRequestFieldPublicProperty)
 }
 
+// SetPrivateProperty sets the PrivateProperty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FindRequest) SetPrivateProperty(privateProperty *int) {
 	f.PrivateProperty = privateProperty
 	f.require(findRequestFieldPrivateProperty)
@@ -78,6 +84,8 @@ func (i *ImportingType) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetImported sets the Imported field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *ImportingType) SetImported(imported Imported) {
 	i.Imported = imported
 	i.require(importingTypeFieldImported)

--- a/seed/go-sdk/cross-package-type-names/internal/explicit_fields.go
+++ b/seed/go-sdk/cross-package-type-names/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/cross-package-type-names/internal/explicit_fields_test.go
+++ b/seed/go-sdk/cross-package-type-names/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/custom-auth/internal/explicit_fields.go
+++ b/seed/go-sdk/custom-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/custom-auth/internal/explicit_fields_test.go
+++ b/seed/go-sdk/custom-auth/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/custom-auth/types.go
+++ b/seed/go-sdk/custom-auth/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/custom-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	unauthorizedRequestErrorBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type UnauthorizedRequestErrorBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (u *UnauthorizedRequestErrorBody) GetExtraProperties() map[string]interface
 	return u.extraProperties
 }
 
+func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
+	u.Message = message
+	u.require(unauthorizedRequestErrorBodyFieldMessage)
+}
+
 func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler UnauthorizedRequestErrorBody
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (u *UnauthorizedRequestErrorBody) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *UnauthorizedRequestErrorBody) MarshalJSON() ([]byte, error) {
+	type embed UnauthorizedRequestErrorBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UnauthorizedRequestErrorBody) String() string {

--- a/seed/go-sdk/custom-auth/types.go
+++ b/seed/go-sdk/custom-auth/types.go
@@ -41,6 +41,8 @@ func (u *UnauthorizedRequestErrorBody) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UnauthorizedRequestErrorBody) SetMessage(message string) {
 	u.Message = message
 	u.require(unauthorizedRequestErrorBodyFieldMessage)

--- a/seed/go-sdk/empty-clients/internal/explicit_fields.go
+++ b/seed/go-sdk/empty-clients/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/empty-clients/internal/explicit_fields_test.go
+++ b/seed/go-sdk/empty-clients/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/empty-clients/level1/level2/types.go
+++ b/seed/go-sdk/empty-clients/level1/level2/types.go
@@ -82,26 +82,36 @@ func (a *Address) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetLine1 sets the Line1 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetLine1(line1 string) {
 	a.Line1 = line1
 	a.require(addressFieldLine1)
 }
 
+// SetLine2 sets the Line2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetLine2(line2 *string) {
 	a.Line2 = line2
 	a.require(addressFieldLine2)
 }
 
+// SetCity sets the City field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetCity(city string) {
 	a.City = city
 	a.require(addressFieldCity)
 }
 
+// SetState sets the State field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetState(state string) {
 	a.State = state
 	a.require(addressFieldState)
 }
 
+// SetZip sets the Zip field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetZip(zip string) {
 	a.Zip = zip
 	a.require(addressFieldZip)
@@ -198,11 +208,15 @@ func (p *Person) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Person) SetName(name string) {
 	p.Name = name
 	p.require(personFieldName)
 }
 
+// SetAddress sets the Address field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Person) SetAddress(address *Address) {
 	p.Address = address
 	p.require(personFieldAddress)

--- a/seed/go-sdk/empty-clients/level1/level2/types.go
+++ b/seed/go-sdk/empty-clients/level1/level2/types.go
@@ -6,15 +6,27 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/empty-clients/fern/internal"
+	big "math/big"
+)
+
+var (
+	addressFieldLine1 = big.NewInt(1 << 0)
+	addressFieldLine2 = big.NewInt(1 << 1)
+	addressFieldCity  = big.NewInt(1 << 2)
+	addressFieldState = big.NewInt(1 << 3)
+	addressFieldZip   = big.NewInt(1 << 4)
 )
 
 type Address struct {
-	Line1   string  `json:"line1" url:"line1"`
-	Line2   *string `json:"line2,omitempty" url:"line2,omitempty"`
-	City    string  `json:"city" url:"city"`
-	State   string  `json:"state" url:"state"`
-	Zip     string  `json:"zip" url:"zip"`
-	country string
+	Line1 string  `json:"line1" url:"line1"`
+	Line2 *string `json:"line2,omitempty" url:"line2,omitempty"`
+	City  string  `json:"city" url:"city"`
+	State string  `json:"state" url:"state"`
+	Zip   string  `json:"zip" url:"zip"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	country        string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -63,6 +75,38 @@ func (a *Address) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Address) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Address) SetLine1(line1 string) {
+	a.Line1 = line1
+	a.require(addressFieldLine1)
+}
+
+func (a *Address) SetLine2(line2 *string) {
+	a.Line2 = line2
+	a.require(addressFieldLine2)
+}
+
+func (a *Address) SetCity(city string) {
+	a.City = city
+	a.require(addressFieldCity)
+}
+
+func (a *Address) SetState(state string) {
+	a.State = state
+	a.require(addressFieldState)
+}
+
+func (a *Address) SetZip(zip string) {
+	a.Zip = zip
+	a.require(addressFieldZip)
+}
+
 func (a *Address) UnmarshalJSON(data []byte) error {
 	type embed Address
 	var unmarshaler = struct {
@@ -97,7 +141,8 @@ func (a *Address) MarshalJSON() ([]byte, error) {
 		embed:   embed(*a),
 		Country: "USA",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *Address) String() string {
@@ -112,9 +157,17 @@ func (a *Address) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	personFieldName    = big.NewInt(1 << 0)
+	personFieldAddress = big.NewInt(1 << 1)
+)
+
 type Person struct {
 	Name    string   `json:"name" url:"name"`
 	Address *Address `json:"address" url:"address"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -138,6 +191,23 @@ func (p *Person) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Person) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *Person) SetName(name string) {
+	p.Name = name
+	p.require(personFieldName)
+}
+
+func (p *Person) SetAddress(address *Address) {
+	p.Address = address
+	p.require(personFieldAddress)
+}
+
 func (p *Person) UnmarshalJSON(data []byte) error {
 	type unmarshaler Person
 	var value unmarshaler
@@ -152,6 +222,17 @@ func (p *Person) UnmarshalJSON(data []byte) error {
 	p.extraProperties = extraProperties
 	p.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (p *Person) MarshalJSON() ([]byte, error) {
+	type embed Person
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *Person) String() string {

--- a/seed/go-sdk/empty-clients/level1/types.go
+++ b/seed/go-sdk/empty-clients/level1/types.go
@@ -82,26 +82,36 @@ func (a *Address) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetLine1 sets the Line1 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetLine1(line1 string) {
 	a.Line1 = line1
 	a.require(addressFieldLine1)
 }
 
+// SetLine2 sets the Line2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetLine2(line2 *string) {
 	a.Line2 = line2
 	a.require(addressFieldLine2)
 }
 
+// SetCity sets the City field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetCity(city string) {
 	a.City = city
 	a.require(addressFieldCity)
 }
 
+// SetState sets the State field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetState(state string) {
 	a.State = state
 	a.require(addressFieldState)
 }
 
+// SetZip sets the Zip field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetZip(zip string) {
 	a.Zip = zip
 	a.require(addressFieldZip)
@@ -198,11 +208,15 @@ func (p *Person) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Person) SetName(name string) {
 	p.Name = name
 	p.require(personFieldName)
 }
 
+// SetAddress sets the Address field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Person) SetAddress(address *Address) {
 	p.Address = address
 	p.require(personFieldAddress)

--- a/seed/go-sdk/empty-clients/level1/types.go
+++ b/seed/go-sdk/empty-clients/level1/types.go
@@ -6,15 +6,27 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/empty-clients/fern/internal"
+	big "math/big"
+)
+
+var (
+	addressFieldLine1 = big.NewInt(1 << 0)
+	addressFieldLine2 = big.NewInt(1 << 1)
+	addressFieldCity  = big.NewInt(1 << 2)
+	addressFieldState = big.NewInt(1 << 3)
+	addressFieldZip   = big.NewInt(1 << 4)
 )
 
 type Address struct {
-	Line1   string  `json:"line1" url:"line1"`
-	Line2   *string `json:"line2,omitempty" url:"line2,omitempty"`
-	City    string  `json:"city" url:"city"`
-	State   string  `json:"state" url:"state"`
-	Zip     string  `json:"zip" url:"zip"`
-	country string
+	Line1 string  `json:"line1" url:"line1"`
+	Line2 *string `json:"line2,omitempty" url:"line2,omitempty"`
+	City  string  `json:"city" url:"city"`
+	State string  `json:"state" url:"state"`
+	Zip   string  `json:"zip" url:"zip"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	country        string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -63,6 +75,38 @@ func (a *Address) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Address) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Address) SetLine1(line1 string) {
+	a.Line1 = line1
+	a.require(addressFieldLine1)
+}
+
+func (a *Address) SetLine2(line2 *string) {
+	a.Line2 = line2
+	a.require(addressFieldLine2)
+}
+
+func (a *Address) SetCity(city string) {
+	a.City = city
+	a.require(addressFieldCity)
+}
+
+func (a *Address) SetState(state string) {
+	a.State = state
+	a.require(addressFieldState)
+}
+
+func (a *Address) SetZip(zip string) {
+	a.Zip = zip
+	a.require(addressFieldZip)
+}
+
 func (a *Address) UnmarshalJSON(data []byte) error {
 	type embed Address
 	var unmarshaler = struct {
@@ -97,7 +141,8 @@ func (a *Address) MarshalJSON() ([]byte, error) {
 		embed:   embed(*a),
 		Country: "USA",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *Address) String() string {
@@ -112,9 +157,17 @@ func (a *Address) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	personFieldName    = big.NewInt(1 << 0)
+	personFieldAddress = big.NewInt(1 << 1)
+)
+
 type Person struct {
 	Name    string   `json:"name" url:"name"`
 	Address *Address `json:"address" url:"address"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -138,6 +191,23 @@ func (p *Person) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Person) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *Person) SetName(name string) {
+	p.Name = name
+	p.require(personFieldName)
+}
+
+func (p *Person) SetAddress(address *Address) {
+	p.Address = address
+	p.require(personFieldAddress)
+}
+
 func (p *Person) UnmarshalJSON(data []byte) error {
 	type unmarshaler Person
 	var value unmarshaler
@@ -152,6 +222,17 @@ func (p *Person) UnmarshalJSON(data []byte) error {
 	p.extraProperties = extraProperties
 	p.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (p *Person) MarshalJSON() ([]byte, error) {
+	type embed Person
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *Person) String() string {

--- a/seed/go-sdk/enum/headers.go
+++ b/seed/go-sdk/enum/headers.go
@@ -30,21 +30,29 @@ func (s *SendEnumAsHeaderRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetOperand sets the Operand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsHeaderRequest) SetOperand(operand Operand) {
 	s.Operand = operand
 	s.require(sendEnumAsHeaderRequestFieldOperand)
 }
 
+// SetMaybeOperand sets the MaybeOperand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsHeaderRequest) SetMaybeOperand(maybeOperand *Operand) {
 	s.MaybeOperand = maybeOperand
 	s.require(sendEnumAsHeaderRequestFieldMaybeOperand)
 }
 
+// SetOperandOrColor sets the OperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsHeaderRequest) SetOperandOrColor(operandOrColor *ColorOrOperand) {
 	s.OperandOrColor = operandOrColor
 	s.require(sendEnumAsHeaderRequestFieldOperandOrColor)
 }
 
+// SetMaybeOperandOrColor sets the MaybeOperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsHeaderRequest) SetMaybeOperandOrColor(maybeOperandOrColor *ColorOrOperand) {
 	s.MaybeOperandOrColor = maybeOperandOrColor
 	s.require(sendEnumAsHeaderRequestFieldMaybeOperandOrColor)

--- a/seed/go-sdk/enum/headers.go
+++ b/seed/go-sdk/enum/headers.go
@@ -2,9 +2,50 @@
 
 package enum
 
+import (
+	big "math/big"
+)
+
+var (
+	sendEnumAsHeaderRequestFieldOperand             = big.NewInt(1 << 0)
+	sendEnumAsHeaderRequestFieldMaybeOperand        = big.NewInt(1 << 1)
+	sendEnumAsHeaderRequestFieldOperandOrColor      = big.NewInt(1 << 2)
+	sendEnumAsHeaderRequestFieldMaybeOperandOrColor = big.NewInt(1 << 3)
+)
+
 type SendEnumAsHeaderRequest struct {
 	Operand             Operand         `json:"-" url:"-"`
 	MaybeOperand        *Operand        `json:"-" url:"-"`
 	OperandOrColor      *ColorOrOperand `json:"-" url:"-"`
 	MaybeOperandOrColor *ColorOrOperand `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (s *SendEnumAsHeaderRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEnumAsHeaderRequest) SetOperand(operand Operand) {
+	s.Operand = operand
+	s.require(sendEnumAsHeaderRequestFieldOperand)
+}
+
+func (s *SendEnumAsHeaderRequest) SetMaybeOperand(maybeOperand *Operand) {
+	s.MaybeOperand = maybeOperand
+	s.require(sendEnumAsHeaderRequestFieldMaybeOperand)
+}
+
+func (s *SendEnumAsHeaderRequest) SetOperandOrColor(operandOrColor *ColorOrOperand) {
+	s.OperandOrColor = operandOrColor
+	s.require(sendEnumAsHeaderRequestFieldOperandOrColor)
+}
+
+func (s *SendEnumAsHeaderRequest) SetMaybeOperandOrColor(maybeOperandOrColor *ColorOrOperand) {
+	s.MaybeOperandOrColor = maybeOperandOrColor
+	s.require(sendEnumAsHeaderRequestFieldMaybeOperandOrColor)
 }

--- a/seed/go-sdk/enum/inlined_request.go
+++ b/seed/go-sdk/enum/inlined_request.go
@@ -2,9 +2,50 @@
 
 package enum
 
+import (
+	big "math/big"
+)
+
+var (
+	sendEnumInlinedRequestFieldOperand             = big.NewInt(1 << 0)
+	sendEnumInlinedRequestFieldMaybeOperand        = big.NewInt(1 << 1)
+	sendEnumInlinedRequestFieldOperandOrColor      = big.NewInt(1 << 2)
+	sendEnumInlinedRequestFieldMaybeOperandOrColor = big.NewInt(1 << 3)
+)
+
 type SendEnumInlinedRequest struct {
 	Operand             Operand         `json:"operand" url:"-"`
 	MaybeOperand        *Operand        `json:"maybeOperand,omitempty" url:"-"`
 	OperandOrColor      *ColorOrOperand `json:"operandOrColor,omitempty" url:"-"`
 	MaybeOperandOrColor *ColorOrOperand `json:"maybeOperandOrColor,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (s *SendEnumInlinedRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEnumInlinedRequest) SetOperand(operand Operand) {
+	s.Operand = operand
+	s.require(sendEnumInlinedRequestFieldOperand)
+}
+
+func (s *SendEnumInlinedRequest) SetMaybeOperand(maybeOperand *Operand) {
+	s.MaybeOperand = maybeOperand
+	s.require(sendEnumInlinedRequestFieldMaybeOperand)
+}
+
+func (s *SendEnumInlinedRequest) SetOperandOrColor(operandOrColor *ColorOrOperand) {
+	s.OperandOrColor = operandOrColor
+	s.require(sendEnumInlinedRequestFieldOperandOrColor)
+}
+
+func (s *SendEnumInlinedRequest) SetMaybeOperandOrColor(maybeOperandOrColor *ColorOrOperand) {
+	s.MaybeOperandOrColor = maybeOperandOrColor
+	s.require(sendEnumInlinedRequestFieldMaybeOperandOrColor)
 }

--- a/seed/go-sdk/enum/inlined_request.go
+++ b/seed/go-sdk/enum/inlined_request.go
@@ -30,21 +30,29 @@ func (s *SendEnumInlinedRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetOperand sets the Operand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumInlinedRequest) SetOperand(operand Operand) {
 	s.Operand = operand
 	s.require(sendEnumInlinedRequestFieldOperand)
 }
 
+// SetMaybeOperand sets the MaybeOperand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumInlinedRequest) SetMaybeOperand(maybeOperand *Operand) {
 	s.MaybeOperand = maybeOperand
 	s.require(sendEnumInlinedRequestFieldMaybeOperand)
 }
 
+// SetOperandOrColor sets the OperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumInlinedRequest) SetOperandOrColor(operandOrColor *ColorOrOperand) {
 	s.OperandOrColor = operandOrColor
 	s.require(sendEnumInlinedRequestFieldOperandOrColor)
 }
 
+// SetMaybeOperandOrColor sets the MaybeOperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumInlinedRequest) SetMaybeOperandOrColor(maybeOperandOrColor *ColorOrOperand) {
 	s.MaybeOperandOrColor = maybeOperandOrColor
 	s.require(sendEnumInlinedRequestFieldMaybeOperandOrColor)

--- a/seed/go-sdk/enum/internal/explicit_fields.go
+++ b/seed/go-sdk/enum/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/enum/internal/explicit_fields_test.go
+++ b/seed/go-sdk/enum/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/enum/query_param.go
+++ b/seed/go-sdk/enum/query_param.go
@@ -30,21 +30,29 @@ func (s *SendEnumAsQueryParamRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetOperand sets the Operand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsQueryParamRequest) SetOperand(operand Operand) {
 	s.Operand = operand
 	s.require(sendEnumAsQueryParamRequestFieldOperand)
 }
 
+// SetMaybeOperand sets the MaybeOperand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsQueryParamRequest) SetMaybeOperand(maybeOperand *Operand) {
 	s.MaybeOperand = maybeOperand
 	s.require(sendEnumAsQueryParamRequestFieldMaybeOperand)
 }
 
+// SetOperandOrColor sets the OperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsQueryParamRequest) SetOperandOrColor(operandOrColor *ColorOrOperand) {
 	s.OperandOrColor = operandOrColor
 	s.require(sendEnumAsQueryParamRequestFieldOperandOrColor)
 }
 
+// SetMaybeOperandOrColor sets the MaybeOperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumAsQueryParamRequest) SetMaybeOperandOrColor(maybeOperandOrColor *ColorOrOperand) {
 	s.MaybeOperandOrColor = maybeOperandOrColor
 	s.require(sendEnumAsQueryParamRequestFieldMaybeOperandOrColor)
@@ -74,21 +82,29 @@ func (s *SendEnumListAsQueryParamRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetOperand sets the Operand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumListAsQueryParamRequest) SetOperand(operand []Operand) {
 	s.Operand = operand
 	s.require(sendEnumListAsQueryParamRequestFieldOperand)
 }
 
+// SetMaybeOperand sets the MaybeOperand field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumListAsQueryParamRequest) SetMaybeOperand(maybeOperand []*Operand) {
 	s.MaybeOperand = maybeOperand
 	s.require(sendEnumListAsQueryParamRequestFieldMaybeOperand)
 }
 
+// SetOperandOrColor sets the OperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumListAsQueryParamRequest) SetOperandOrColor(operandOrColor []*ColorOrOperand) {
 	s.OperandOrColor = operandOrColor
 	s.require(sendEnumListAsQueryParamRequestFieldOperandOrColor)
 }
 
+// SetMaybeOperandOrColor sets the MaybeOperandOrColor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEnumListAsQueryParamRequest) SetMaybeOperandOrColor(maybeOperandOrColor []*ColorOrOperand) {
 	s.MaybeOperandOrColor = maybeOperandOrColor
 	s.require(sendEnumListAsQueryParamRequestFieldMaybeOperandOrColor)

--- a/seed/go-sdk/enum/query_param.go
+++ b/seed/go-sdk/enum/query_param.go
@@ -2,16 +2,94 @@
 
 package enum
 
+import (
+	big "math/big"
+)
+
+var (
+	sendEnumAsQueryParamRequestFieldOperand             = big.NewInt(1 << 0)
+	sendEnumAsQueryParamRequestFieldMaybeOperand        = big.NewInt(1 << 1)
+	sendEnumAsQueryParamRequestFieldOperandOrColor      = big.NewInt(1 << 2)
+	sendEnumAsQueryParamRequestFieldMaybeOperandOrColor = big.NewInt(1 << 3)
+)
+
 type SendEnumAsQueryParamRequest struct {
 	Operand             Operand         `json:"-" url:"operand"`
 	MaybeOperand        *Operand        `json:"-" url:"maybeOperand,omitempty"`
 	OperandOrColor      *ColorOrOperand `json:"-" url:"operandOrColor"`
 	MaybeOperandOrColor *ColorOrOperand `json:"-" url:"maybeOperandOrColor,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *SendEnumAsQueryParamRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEnumAsQueryParamRequest) SetOperand(operand Operand) {
+	s.Operand = operand
+	s.require(sendEnumAsQueryParamRequestFieldOperand)
+}
+
+func (s *SendEnumAsQueryParamRequest) SetMaybeOperand(maybeOperand *Operand) {
+	s.MaybeOperand = maybeOperand
+	s.require(sendEnumAsQueryParamRequestFieldMaybeOperand)
+}
+
+func (s *SendEnumAsQueryParamRequest) SetOperandOrColor(operandOrColor *ColorOrOperand) {
+	s.OperandOrColor = operandOrColor
+	s.require(sendEnumAsQueryParamRequestFieldOperandOrColor)
+}
+
+func (s *SendEnumAsQueryParamRequest) SetMaybeOperandOrColor(maybeOperandOrColor *ColorOrOperand) {
+	s.MaybeOperandOrColor = maybeOperandOrColor
+	s.require(sendEnumAsQueryParamRequestFieldMaybeOperandOrColor)
+}
+
+var (
+	sendEnumListAsQueryParamRequestFieldOperand             = big.NewInt(1 << 0)
+	sendEnumListAsQueryParamRequestFieldMaybeOperand        = big.NewInt(1 << 1)
+	sendEnumListAsQueryParamRequestFieldOperandOrColor      = big.NewInt(1 << 2)
+	sendEnumListAsQueryParamRequestFieldMaybeOperandOrColor = big.NewInt(1 << 3)
+)
 
 type SendEnumListAsQueryParamRequest struct {
 	Operand             []Operand         `json:"-" url:"operand"`
 	MaybeOperand        []*Operand        `json:"-" url:"maybeOperand,omitempty"`
 	OperandOrColor      []*ColorOrOperand `json:"-" url:"operandOrColor"`
 	MaybeOperandOrColor []*ColorOrOperand `json:"-" url:"maybeOperandOrColor,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (s *SendEnumListAsQueryParamRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEnumListAsQueryParamRequest) SetOperand(operand []Operand) {
+	s.Operand = operand
+	s.require(sendEnumListAsQueryParamRequestFieldOperand)
+}
+
+func (s *SendEnumListAsQueryParamRequest) SetMaybeOperand(maybeOperand []*Operand) {
+	s.MaybeOperand = maybeOperand
+	s.require(sendEnumListAsQueryParamRequestFieldMaybeOperand)
+}
+
+func (s *SendEnumListAsQueryParamRequest) SetOperandOrColor(operandOrColor []*ColorOrOperand) {
+	s.OperandOrColor = operandOrColor
+	s.require(sendEnumListAsQueryParamRequestFieldOperandOrColor)
+}
+
+func (s *SendEnumListAsQueryParamRequest) SetMaybeOperandOrColor(maybeOperandOrColor []*ColorOrOperand) {
+	s.MaybeOperandOrColor = maybeOperandOrColor
+	s.require(sendEnumListAsQueryParamRequestFieldMaybeOperandOrColor)
 }

--- a/seed/go-sdk/error-property/internal/explicit_fields.go
+++ b/seed/go-sdk/error-property/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/error-property/internal/explicit_fields_test.go
+++ b/seed/go-sdk/error-property/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/error-property/types.go
+++ b/seed/go-sdk/error-property/types.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/error-property/fern/internal"
+	big "math/big"
+)
+
+var (
+	propertyBasedErrorTestBodyFieldMessage = big.NewInt(1 << 0)
 )
 
 type PropertyBasedErrorTestBody struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (p *PropertyBasedErrorTestBody) GetExtraProperties() map[string]interface{}
 	return p.extraProperties
 }
 
+func (p *PropertyBasedErrorTestBody) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PropertyBasedErrorTestBody) SetMessage(message string) {
+	p.Message = message
+	p.require(propertyBasedErrorTestBodyFieldMessage)
+}
+
 func (p *PropertyBasedErrorTestBody) UnmarshalJSON(data []byte) error {
 	type unmarshaler PropertyBasedErrorTestBody
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (p *PropertyBasedErrorTestBody) UnmarshalJSON(data []byte) error {
 	p.extraProperties = extraProperties
 	p.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (p *PropertyBasedErrorTestBody) MarshalJSON() ([]byte, error) {
+	type embed PropertyBasedErrorTestBody
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *PropertyBasedErrorTestBody) String() string {

--- a/seed/go-sdk/error-property/types.go
+++ b/seed/go-sdk/error-property/types.go
@@ -41,6 +41,8 @@ func (p *PropertyBasedErrorTestBody) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PropertyBasedErrorTestBody) SetMessage(message string) {
 	p.Message = message
 	p.require(propertyBasedErrorTestBodyFieldMessage)

--- a/seed/go-sdk/errors/commons.go
+++ b/seed/go-sdk/errors/commons.go
@@ -50,11 +50,15 @@ func (e *ErrorBody) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ErrorBody) SetMessage(message string) {
 	e.Message = message
 	e.require(errorBodyFieldMessage)
 }
 
+// SetCode sets the Code field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ErrorBody) SetCode(code int) {
 	e.Code = code
 	e.require(errorBodyFieldCode)

--- a/seed/go-sdk/errors/internal/explicit_fields.go
+++ b/seed/go-sdk/errors/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/errors/internal/explicit_fields_test.go
+++ b/seed/go-sdk/errors/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/errors/simple.go
+++ b/seed/go-sdk/errors/simple.go
@@ -41,6 +41,8 @@ func (f *FooRequest) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetBar sets the Bar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooRequest) SetBar(bar string) {
 	f.Bar = bar
 	f.require(fooRequestFieldBar)
@@ -117,6 +119,8 @@ func (f *FooResponse) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetBar sets the Bar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooResponse) SetBar(bar string) {
 	f.Bar = bar
 	f.require(fooResponseFieldBar)

--- a/seed/go-sdk/errors/simple.go
+++ b/seed/go-sdk/errors/simple.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/errors/fern/internal"
+	big "math/big"
+)
+
+var (
+	fooRequestFieldBar = big.NewInt(1 << 0)
 )
 
 type FooRequest struct {
 	Bar string `json:"bar" url:"bar"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -24,6 +32,18 @@ func (f *FooRequest) GetBar() string {
 
 func (f *FooRequest) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FooRequest) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FooRequest) SetBar(bar string) {
+	f.Bar = bar
+	f.require(fooRequestFieldBar)
 }
 
 func (f *FooRequest) UnmarshalJSON(data []byte) error {
@@ -42,6 +62,17 @@ func (f *FooRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FooRequest) MarshalJSON() ([]byte, error) {
+	type embed FooRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FooRequest) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -54,8 +85,15 @@ func (f *FooRequest) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	fooResponseFieldBar = big.NewInt(1 << 0)
+)
+
 type FooResponse struct {
 	Bar string `json:"bar" url:"bar"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -72,6 +110,18 @@ func (f *FooResponse) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *FooResponse) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FooResponse) SetBar(bar string) {
+	f.Bar = bar
+	f.require(fooResponseFieldBar)
+}
+
 func (f *FooResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler FooResponse
 	var value unmarshaler
@@ -86,6 +136,17 @@ func (f *FooResponse) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *FooResponse) MarshalJSON() ([]byte, error) {
+	type embed FooResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *FooResponse) String() string {

--- a/seed/go-sdk/examples/always-send-required-properties/commons/types.go
+++ b/seed/go-sdk/examples/always-send-required-properties/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/always-send-required-properties/commons/types.go
+++ b/seed/go-sdk/examples/always-send-required-properties/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/always-send-required-properties/file/service.go
+++ b/seed/go-sdk/examples/always-send-required-properties/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/always-send-required-properties/file/service.go
+++ b/seed/go-sdk/examples/always-send-required-properties/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/always-send-required-properties/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/always-send-required-properties/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/always-send-required-properties/service.go
+++ b/seed/go-sdk/examples/always-send-required-properties/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/always-send-required-properties/service.go
+++ b/seed/go-sdk/examples/always-send-required-properties/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/always-send-required-properties/types.go
+++ b/seed/go-sdk/examples/always-send-required-properties/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/always-send-required-properties/types.go
+++ b/seed/go-sdk/examples/always-send-required-properties/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/commons/types.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/commons/types.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/file/service.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/file/service.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/service.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/service.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/types.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/types.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/client-name/commons/types.go
+++ b/seed/go-sdk/examples/client-name/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/client-name/commons/types.go
+++ b/seed/go-sdk/examples/client-name/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/client-name/file/service.go
+++ b/seed/go-sdk/examples/client-name/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/client-name/file/service.go
+++ b/seed/go-sdk/examples/client-name/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/client-name/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/client-name/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/client-name/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/client-name/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/client-name/service.go
+++ b/seed/go-sdk/examples/client-name/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/client-name/service.go
+++ b/seed/go-sdk/examples/client-name/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/client-name/types.go
+++ b/seed/go-sdk/examples/client-name/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/client-name/types.go
+++ b/seed/go-sdk/examples/client-name/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/exported-client-name/commons/types.go
+++ b/seed/go-sdk/examples/exported-client-name/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/exported-client-name/commons/types.go
+++ b/seed/go-sdk/examples/exported-client-name/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/exported-client-name/file/service.go
+++ b/seed/go-sdk/examples/exported-client-name/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/exported-client-name/file/service.go
+++ b/seed/go-sdk/examples/exported-client-name/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/exported-client-name/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/exported-client-name/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/exported-client-name/service.go
+++ b/seed/go-sdk/examples/exported-client-name/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/exported-client-name/service.go
+++ b/seed/go-sdk/examples/exported-client-name/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/exported-client-name/types.go
+++ b/seed/go-sdk/examples/exported-client-name/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/exported-client-name/types.go
+++ b/seed/go-sdk/examples/exported-client-name/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/getters-pass-by-value/commons/types.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/getters-pass-by-value/commons/types.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/getters-pass-by-value/file/service.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/getters-pass-by-value/file/service.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/getters-pass-by-value/service.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/getters-pass-by-value/service.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/getters-pass-by-value/types.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/getters-pass-by-value/types.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/no-custom-config/commons/types.go
+++ b/seed/go-sdk/examples/no-custom-config/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/no-custom-config/commons/types.go
+++ b/seed/go-sdk/examples/no-custom-config/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/no-custom-config/file/service.go
+++ b/seed/go-sdk/examples/no-custom-config/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/no-custom-config/file/service.go
+++ b/seed/go-sdk/examples/no-custom-config/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/no-custom-config/service.go
+++ b/seed/go-sdk/examples/no-custom-config/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/no-custom-config/service.go
+++ b/seed/go-sdk/examples/no-custom-config/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/no-custom-config/types.go
+++ b/seed/go-sdk/examples/no-custom-config/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/no-custom-config/types.go
+++ b/seed/go-sdk/examples/no-custom-config/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/package-path/pleaseinhere/commons/types.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/package-path/pleaseinhere/commons/types.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/pleaseinhere/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/package-path/pleaseinhere/file/service.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/package-path/pleaseinhere/file/service.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/package-path/pleaseinhere/service.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/package-path/pleaseinhere/service.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/package-path/pleaseinhere/types.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/package-path/pleaseinhere/types.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/pleaseinhere/commons"
 	internal "github.com/examples/fern/pleaseinhere/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/readme-config/commons/types.go
+++ b/seed/go-sdk/examples/readme-config/commons/types.go
@@ -320,16 +320,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/readme-config/commons/types.go
+++ b/seed/go-sdk/examples/readme-config/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -269,10 +270,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -303,6 +313,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -317,6 +349,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/readme-config/file/service.go
+++ b/seed/go-sdk/examples/readme-config/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/readme-config/file/service.go
+++ b/seed/go-sdk/examples/readme-config/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/readme-config/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/readme-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/readme-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/readme-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/readme-config/service.go
+++ b/seed/go-sdk/examples/readme-config/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/readme-config/service.go
+++ b/seed/go-sdk/examples/readme-config/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/readme-config/types.go
+++ b/seed/go-sdk/examples/readme-config/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type" url:"type"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -182,9 +225,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +259,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -224,6 +292,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -236,9 +315,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -262,6 +349,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -278,6 +382,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -289,6 +404,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -304,6 +435,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -404,6 +538,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -418,6 +624,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -515,8 +732,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -531,6 +755,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -549,6 +785,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -561,10 +808,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -595,6 +851,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -611,6 +889,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -623,9 +912,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type" url:"type"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -649,6 +946,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -663,6 +977,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -801,10 +1126,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -835,6 +1169,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -851,6 +1207,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -862,6 +1229,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -875,7 +1255,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast" url:"cast"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -959,6 +1342,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -993,7 +1433,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1008,9 +1449,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1034,6 +1483,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1048,6 +1514,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1225,9 +1702,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1251,6 +1736,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1265,6 +1767,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1306,10 +1819,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1338,6 +1860,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1375,7 +1919,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1390,6 +1935,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1401,7 +1958,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata" url:"metadata"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1478,6 +2038,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1512,7 +2124,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1529,10 +2142,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1563,6 +2185,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1579,6 +2223,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1591,8 +2246,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1607,6 +2269,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1625,6 +2299,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1637,8 +2322,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request" url:"request"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1653,6 +2345,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1671,6 +2375,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1683,9 +2398,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response" url:"response"`
 	Identifiers []*Identifier `json:"identifiers" url:"identifiers"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1709,6 +2432,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1725,6 +2465,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1737,8 +2488,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type" url:"type"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1753,6 +2511,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1771,6 +2541,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1783,9 +2564,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1809,6 +2598,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1823,6 +2629,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -1972,8 +2789,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1990,6 +2814,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2004,6 +2840,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/examples/readme-config/types.go
+++ b/seed/go-sdk/examples/readme-config/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -266,11 +272,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -356,11 +366,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -545,66 +559,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -764,6 +804,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -858,16 +900,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -953,11 +1001,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1176,16 +1228,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1349,51 +1407,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1490,11 +1568,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1743,11 +1825,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1869,16 +1955,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2045,46 +2137,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2192,16 +2302,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2278,6 +2394,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2354,6 +2472,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2439,11 +2559,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2520,6 +2644,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2605,11 +2731,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2821,6 +2951,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/v0/commons/types.go
+++ b/seed/go-sdk/examples/v0/commons/types.go
@@ -340,16 +340,22 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)
 }
 
+// SetJsonString sets the JsonString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetJsonString(jsonString *string) {
 	m.JsonString = jsonString
 	m.require(metadataFieldJsonString)

--- a/seed/go-sdk/examples/v0/commons/types.go
+++ b/seed/go-sdk/examples/v0/commons/types.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/examples/fern/internal"
+	big "math/big"
 )
 
 type Data struct {
@@ -289,10 +290,19 @@ func (e *EventInfo) validate() error {
 	return nil
 }
 
+var (
+	metadataFieldId         = big.NewInt(1 << 0)
+	metadataFieldData       = big.NewInt(1 << 1)
+	metadataFieldJsonString = big.NewInt(1 << 2)
+)
+
 type Metadata struct {
 	Id         string            `json:"id" url:"id"`
 	Data       map[string]string `json:"data,omitempty" url:"data,omitempty"`
 	JsonString *string           `json:"jsonString,omitempty" url:"jsonString,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -323,6 +333,28 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
+func (m *Metadata) SetJsonString(jsonString *string) {
+	m.JsonString = jsonString
+	m.require(metadataFieldJsonString)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -337,6 +369,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/examples/v0/file/service.go
+++ b/seed/go-sdk/examples/v0/file/service.go
@@ -2,8 +2,31 @@
 
 package file
 
+import (
+	big "math/big"
+)
+
+var (
+	getFileRequestFieldXFileApiVersion = big.NewInt(1 << 0)
+)
+
 type GetFileRequest struct {
 	XFileApiVersion string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetFileRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
+	g.XFileApiVersion = xFileApiVersion
+	g.require(getFileRequestFieldXFileApiVersion)
 }
 
 type Filename = string

--- a/seed/go-sdk/examples/v0/file/service.go
+++ b/seed/go-sdk/examples/v0/file/service.go
@@ -24,6 +24,8 @@ func (g *GetFileRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXFileApiVersion sets the XFileApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetFileRequest) SetXFileApiVersion(xFileApiVersion string) {
 	g.XFileApiVersion = xFileApiVersion
 	g.require(getFileRequestFieldXFileApiVersion)

--- a/seed/go-sdk/examples/v0/internal/explicit_fields.go
+++ b/seed/go-sdk/examples/v0/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/examples/v0/internal/explicit_fields_test.go
+++ b/seed/go-sdk/examples/v0/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/examples/v0/service.go
+++ b/seed/go-sdk/examples/v0/service.go
@@ -28,16 +28,22 @@ func (g *GetMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiVersion sets the XApiVersion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
 	g.XApiVersion = xApiVersion
 	g.require(getMetadataRequestFieldXApiVersion)
 }
 
+// SetShallow sets the Shallow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetShallow(shallow *bool) {
 	g.Shallow = shallow
 	g.require(getMetadataRequestFieldShallow)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetMetadataRequest) SetTag(tag []*string) {
 	g.Tag = tag
 	g.require(getMetadataRequestFieldTag)

--- a/seed/go-sdk/examples/v0/service.go
+++ b/seed/go-sdk/examples/v0/service.go
@@ -2,8 +2,43 @@
 
 package examples
 
+import (
+	big "math/big"
+)
+
+var (
+	getMetadataRequestFieldXApiVersion = big.NewInt(1 << 0)
+	getMetadataRequestFieldShallow     = big.NewInt(1 << 1)
+	getMetadataRequestFieldTag         = big.NewInt(1 << 2)
+)
+
 type GetMetadataRequest struct {
 	XApiVersion string    `json:"-" url:"-"`
 	Shallow     *bool     `json:"-" url:"shallow,omitempty"`
 	Tag         []*string `json:"-" url:"tag,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetMetadataRequest) SetXApiVersion(xApiVersion string) {
+	g.XApiVersion = xApiVersion
+	g.require(getMetadataRequestFieldXApiVersion)
+}
+
+func (g *GetMetadataRequest) SetShallow(shallow *bool) {
+	g.Shallow = shallow
+	g.require(getMetadataRequestFieldShallow)
+}
+
+func (g *GetMetadataRequest) SetTag(tag []*string) {
+	g.Tag = tag
+	g.require(getMetadataRequestFieldTag)
 }

--- a/seed/go-sdk/examples/v0/types.go
+++ b/seed/go-sdk/examples/v0/types.go
@@ -109,16 +109,22 @@ func (i *Identifier) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetType(type_ *Type) {
 	i.Type = type_
 	i.require(identifierFieldType)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetValue(value string) {
 	i.Value = value
 	i.require(identifierFieldValue)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Identifier) SetLabel(label string) {
 	i.Label = label
 	i.require(identifierFieldLabel)
@@ -274,11 +280,15 @@ func (a *Actor) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetName(name string) {
 	a.Name = name
 	a.require(actorFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actor) SetId(id string) {
 	a.Id = id
 	a.require(actorFieldId)
@@ -364,11 +374,15 @@ func (a *Actress) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetName(name string) {
 	a.Name = name
 	a.require(actressFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Actress) SetId(id string) {
 	a.Id = id
 	a.require(actressFieldId)
@@ -553,66 +567,92 @@ func (b *BigEntity) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetCastMember sets the CastMember field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCastMember(castMember *CastMember) {
 	b.CastMember = castMember
 	b.require(bigEntityFieldCastMember)
 }
 
+// SetExtendedMovie sets the ExtendedMovie field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
 	b.ExtendedMovie = extendedMovie
 	b.require(bigEntityFieldExtendedMovie)
 }
 
+// SetEntity sets the Entity field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEntity(entity *Entity) {
 	b.Entity = entity
 	b.require(bigEntityFieldEntity)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMetadata(metadata *Metadata) {
 	b.Metadata = metadata
 	b.require(bigEntityFieldMetadata)
 }
 
+// SetCommonMetadata sets the CommonMetadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
 	b.CommonMetadata = commonMetadata
 	b.require(bigEntityFieldCommonMetadata)
 }
 
+// SetEventInfo sets the EventInfo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
 	b.EventInfo = eventInfo
 	b.require(bigEntityFieldEventInfo)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetData(data *commons.Data) {
 	b.Data = data
 	b.require(bigEntityFieldData)
 }
 
+// SetMigration sets the Migration field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMigration(migration *Migration) {
 	b.Migration = migration
 	b.require(bigEntityFieldMigration)
 }
 
+// SetException sets the Exception field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetException(exception *Exception) {
 	b.Exception = exception
 	b.require(bigEntityFieldException)
 }
 
+// SetTest sets the Test field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetTest(test *Test) {
 	b.Test = test
 	b.require(bigEntityFieldTest)
 }
 
+// SetNode sets the Node field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetNode(node *Node) {
 	b.Node = node
 	b.require(bigEntityFieldNode)
 }
 
+// SetDirectory sets the Directory field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetDirectory(directory *Directory) {
 	b.Directory = directory
 	b.require(bigEntityFieldDirectory)
 }
 
+// SetMoment sets the Moment field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BigEntity) SetMoment(moment *Moment) {
 	b.Moment = moment
 	b.require(bigEntityFieldMoment)
@@ -784,6 +824,8 @@ func (c *CronJob) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetExpression sets the Expression field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CronJob) SetExpression(expression string) {
 	c.Expression = expression
 	c.require(cronJobFieldExpression)
@@ -878,16 +920,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)
@@ -973,11 +1021,15 @@ func (e *Entity) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetType(type_ *Type) {
 	e.Type = type_
 	e.require(entityFieldType)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Entity) SetName(name string) {
 	e.Name = name
 	e.require(entityFieldName)
@@ -1206,16 +1258,22 @@ func (e *ExceptionInfo) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetExceptionType sets the ExceptionType field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
 	e.ExceptionType = exceptionType
 	e.require(exceptionInfoFieldExceptionType)
 }
 
+// SetExceptionMessage sets the ExceptionMessage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
 	e.ExceptionMessage = exceptionMessage
 	e.require(exceptionInfoFieldExceptionMessage)
 }
 
+// SetExceptionStacktrace sets the ExceptionStacktrace field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
 	e.ExceptionStacktrace = exceptionStacktrace
 	e.require(exceptionInfoFieldExceptionStacktrace)
@@ -1379,51 +1437,71 @@ func (e *ExtendedMovie) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetId(id MovieId) {
 	e.Id = id
 	e.require(extendedMovieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
 	e.Prequel = prequel
 	e.require(extendedMovieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTitle(title string) {
 	e.Title = title
 	e.require(extendedMovieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetFrom(from string) {
 	e.From = from
 	e.require(extendedMovieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRating(rating float64) {
 	e.Rating = rating
 	e.require(extendedMovieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetTag(tag commons.Tag) {
 	e.Tag = tag
 	e.require(extendedMovieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetBook(book *string) {
 	e.Book = book
 	e.require(extendedMovieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
 	e.Metadata = metadata
 	e.require(extendedMovieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetRevenue(revenue int64) {
 	e.Revenue = revenue
 	e.require(extendedMovieFieldRevenue)
 }
 
+// SetCast sets the Cast field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExtendedMovie) SetCast(cast []string) {
 	e.Cast = cast
 	e.require(extendedMovieFieldCast)
@@ -1520,11 +1598,15 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
@@ -1783,11 +1865,15 @@ func (m *Migration) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetName(name string) {
 	m.Name = name
 	m.require(migrationFieldName)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Migration) SetStatus(status MigrationStatus) {
 	m.Status = status
 	m.require(migrationFieldStatus)
@@ -1909,16 +1995,22 @@ func (m *Moment) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetId(id uuid.UUID) {
 	m.Id = id
 	m.require(momentFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDate(date time.Time) {
 	m.Date = date
 	m.require(momentFieldDate)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Moment) SetDatetime(datetime time.Time) {
 	m.Datetime = datetime
 	m.require(momentFieldDatetime)
@@ -2085,46 +2177,64 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetPrequel sets the Prequel field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetPrequel(prequel *MovieId) {
 	m.Prequel = prequel
 	m.require(movieFieldPrequel)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetFrom sets the From field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetFrom(from string) {
 	m.From = from
 	m.require(movieFieldFrom)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)
 }
 
+// SetTag sets the Tag field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTag(tag commons.Tag) {
 	m.Tag = tag
 	m.require(movieFieldTag)
 }
 
+// SetBook sets the Book field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetBook(book *string) {
 	m.Book = book
 	m.require(movieFieldBook)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetMetadata(metadata map[string]interface{}) {
 	m.Metadata = metadata
 	m.require(movieFieldMetadata)
 }
 
+// SetRevenue sets the Revenue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRevenue(revenue int64) {
 	m.Revenue = revenue
 	m.require(movieFieldRevenue)
@@ -2232,16 +2342,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetName(name string) {
 	n.Name = name
 	n.require(nodeFieldName)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetNodes(nodes []*Node) {
 	n.Nodes = nodes
 	n.require(nodeFieldNodes)
 }
 
+// SetTrees sets the Trees field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetTrees(trees []*Tree) {
 	n.Trees = trees
 	n.require(nodeFieldTrees)
@@ -2318,6 +2434,8 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetTtl sets the Ttl field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetTtl(ttl int) {
 	r.Ttl = ttl
 	r.require(refreshTokenRequestFieldTtl)
@@ -2394,6 +2512,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetRequest sets the Request field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetRequest(request interface{}) {
 	r.Request = request
 	r.require(requestFieldRequest)
@@ -2479,11 +2599,15 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetResponse sets the Response field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetResponse(response interface{}) {
 	r.Response = response
 	r.require(responseFieldResponse)
 }
 
+// SetIdentifiers sets the Identifiers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetIdentifiers(identifiers []*Identifier) {
 	r.Identifiers = identifiers
 	r.require(responseFieldIdentifiers)
@@ -2560,6 +2684,8 @@ func (r *ResponseType) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetType sets the Type field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ResponseType) SetType(type_ *Type) {
 	r.Type = type_
 	r.require(responseTypeFieldType)
@@ -2645,11 +2771,15 @@ func (s *StuntDouble) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetName(name string) {
 	s.Name = name
 	s.require(stuntDoubleFieldName)
 }
 
+// SetActorOrActressId sets the ActorOrActressId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
 	s.ActorOrActressId = actorOrActressId
 	s.require(stuntDoubleFieldActorOrActressId)
@@ -2871,6 +3001,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/examples/v0/types.go
+++ b/seed/go-sdk/examples/v0/types.go
@@ -8,6 +8,7 @@ import (
 	commons "github.com/examples/fern/commons"
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
 )
 
@@ -58,10 +59,19 @@ func (c ComplexType) Ptr() *ComplexType {
 	return &c
 }
 
+var (
+	identifierFieldType  = big.NewInt(1 << 0)
+	identifierFieldValue = big.NewInt(1 << 1)
+	identifierFieldLabel = big.NewInt(1 << 2)
+)
+
 type Identifier struct {
 	Type  *Type  `json:"type,omitempty" url:"type,omitempty"`
 	Value string `json:"value" url:"value"`
 	Label string `json:"label" url:"label"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -92,6 +102,28 @@ func (i *Identifier) GetExtraProperties() map[string]interface{} {
 	return i.extraProperties
 }
 
+func (i *Identifier) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
+}
+
+func (i *Identifier) SetType(type_ *Type) {
+	i.Type = type_
+	i.require(identifierFieldType)
+}
+
+func (i *Identifier) SetValue(value string) {
+	i.Value = value
+	i.require(identifierFieldValue)
+}
+
+func (i *Identifier) SetLabel(label string) {
+	i.Label = label
+	i.require(identifierFieldLabel)
+}
+
 func (i *Identifier) UnmarshalJSON(data []byte) error {
 	type unmarshaler Identifier
 	var value unmarshaler
@@ -106,6 +138,17 @@ func (i *Identifier) UnmarshalJSON(data []byte) error {
 	i.extraProperties = extraProperties
 	i.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (i *Identifier) MarshalJSON() ([]byte, error) {
+	type embed Identifier
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*i),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, i.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (i *Identifier) String() string {
@@ -190,9 +233,17 @@ func (t *Type) Accept(visitor TypeVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", t)
 }
 
+var (
+	actorFieldName = big.NewInt(1 << 0)
+	actorFieldId   = big.NewInt(1 << 1)
+)
+
 type Actor struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -216,6 +267,23 @@ func (a *Actor) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actor) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actor) SetName(name string) {
+	a.Name = name
+	a.require(actorFieldName)
+}
+
+func (a *Actor) SetId(id string) {
+	a.Id = id
+	a.require(actorFieldId)
+}
+
 func (a *Actor) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actor
 	var value unmarshaler
@@ -232,6 +300,17 @@ func (a *Actor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actor) MarshalJSON() ([]byte, error) {
+	type embed Actor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actor) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -244,9 +323,17 @@ func (a *Actor) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	actressFieldName = big.NewInt(1 << 0)
+	actressFieldId   = big.NewInt(1 << 1)
+)
+
 type Actress struct {
 	Name string `json:"name" url:"name"`
 	Id   string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -270,6 +357,23 @@ func (a *Actress) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Actress) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Actress) SetName(name string) {
+	a.Name = name
+	a.require(actressFieldName)
+}
+
+func (a *Actress) SetId(id string) {
+	a.Id = id
+	a.require(actressFieldId)
+}
+
 func (a *Actress) UnmarshalJSON(data []byte) error {
 	type unmarshaler Actress
 	var value unmarshaler
@@ -286,6 +390,17 @@ func (a *Actress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Actress) MarshalJSON() ([]byte, error) {
+	type embed Actress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Actress) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -297,6 +412,22 @@ func (a *Actress) String() string {
 	}
 	return fmt.Sprintf("%#v", a)
 }
+
+var (
+	bigEntityFieldCastMember     = big.NewInt(1 << 0)
+	bigEntityFieldExtendedMovie  = big.NewInt(1 << 1)
+	bigEntityFieldEntity         = big.NewInt(1 << 2)
+	bigEntityFieldMetadata       = big.NewInt(1 << 3)
+	bigEntityFieldCommonMetadata = big.NewInt(1 << 4)
+	bigEntityFieldEventInfo      = big.NewInt(1 << 5)
+	bigEntityFieldData           = big.NewInt(1 << 6)
+	bigEntityFieldMigration      = big.NewInt(1 << 7)
+	bigEntityFieldException      = big.NewInt(1 << 8)
+	bigEntityFieldTest           = big.NewInt(1 << 9)
+	bigEntityFieldNode           = big.NewInt(1 << 10)
+	bigEntityFieldDirectory      = big.NewInt(1 << 11)
+	bigEntityFieldMoment         = big.NewInt(1 << 12)
+)
 
 type BigEntity struct {
 	CastMember     *CastMember        `json:"castMember,omitempty" url:"castMember,omitempty"`
@@ -312,6 +443,9 @@ type BigEntity struct {
 	Node           *Node              `json:"node,omitempty" url:"node,omitempty"`
 	Directory      *Directory         `json:"directory,omitempty" url:"directory,omitempty"`
 	Moment         *Moment            `json:"moment,omitempty" url:"moment,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -412,6 +546,78 @@ func (b *BigEntity) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BigEntity) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BigEntity) SetCastMember(castMember *CastMember) {
+	b.CastMember = castMember
+	b.require(bigEntityFieldCastMember)
+}
+
+func (b *BigEntity) SetExtendedMovie(extendedMovie *ExtendedMovie) {
+	b.ExtendedMovie = extendedMovie
+	b.require(bigEntityFieldExtendedMovie)
+}
+
+func (b *BigEntity) SetEntity(entity *Entity) {
+	b.Entity = entity
+	b.require(bigEntityFieldEntity)
+}
+
+func (b *BigEntity) SetMetadata(metadata *Metadata) {
+	b.Metadata = metadata
+	b.require(bigEntityFieldMetadata)
+}
+
+func (b *BigEntity) SetCommonMetadata(commonMetadata *commons.Metadata) {
+	b.CommonMetadata = commonMetadata
+	b.require(bigEntityFieldCommonMetadata)
+}
+
+func (b *BigEntity) SetEventInfo(eventInfo *commons.EventInfo) {
+	b.EventInfo = eventInfo
+	b.require(bigEntityFieldEventInfo)
+}
+
+func (b *BigEntity) SetData(data *commons.Data) {
+	b.Data = data
+	b.require(bigEntityFieldData)
+}
+
+func (b *BigEntity) SetMigration(migration *Migration) {
+	b.Migration = migration
+	b.require(bigEntityFieldMigration)
+}
+
+func (b *BigEntity) SetException(exception *Exception) {
+	b.Exception = exception
+	b.require(bigEntityFieldException)
+}
+
+func (b *BigEntity) SetTest(test *Test) {
+	b.Test = test
+	b.require(bigEntityFieldTest)
+}
+
+func (b *BigEntity) SetNode(node *Node) {
+	b.Node = node
+	b.require(bigEntityFieldNode)
+}
+
+func (b *BigEntity) SetDirectory(directory *Directory) {
+	b.Directory = directory
+	b.require(bigEntityFieldDirectory)
+}
+
+func (b *BigEntity) SetMoment(moment *Moment) {
+	b.Moment = moment
+	b.require(bigEntityFieldMoment)
+}
+
 func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	type unmarshaler BigEntity
 	var value unmarshaler
@@ -426,6 +632,17 @@ func (b *BigEntity) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BigEntity) MarshalJSON() ([]byte, error) {
+	type embed BigEntity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BigEntity) String() string {
@@ -535,8 +752,15 @@ func (c *CastMember) Accept(visitor CastMemberVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", c)
 }
 
+var (
+	cronJobFieldExpression = big.NewInt(1 << 0)
+)
+
 type CronJob struct {
 	Expression string `json:"expression" url:"expression"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -551,6 +775,18 @@ func (c *CronJob) GetExpression() string {
 
 func (c *CronJob) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CronJob) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CronJob) SetExpression(expression string) {
+	c.Expression = expression
+	c.require(cronJobFieldExpression)
 }
 
 func (c *CronJob) UnmarshalJSON(data []byte) error {
@@ -569,6 +805,17 @@ func (c *CronJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CronJob) MarshalJSON() ([]byte, error) {
+	type embed CronJob
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CronJob) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -581,10 +828,19 @@ func (c *CronJob) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
+)
+
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*File      `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -615,6 +871,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -631,6 +909,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Directory) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -643,9 +932,17 @@ func (d *Directory) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	entityFieldType = big.NewInt(1 << 0)
+	entityFieldName = big.NewInt(1 << 1)
+)
+
 type Entity struct {
 	Type *Type  `json:"type,omitempty" url:"type,omitempty"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -669,6 +966,23 @@ func (e *Entity) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Entity) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Entity) SetType(type_ *Type) {
+	e.Type = type_
+	e.require(entityFieldType)
+}
+
+func (e *Entity) SetName(name string) {
+	e.Name = name
+	e.require(entityFieldName)
+}
+
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	type unmarshaler Entity
 	var value unmarshaler
@@ -683,6 +997,17 @@ func (e *Entity) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Entity) MarshalJSON() ([]byte, error) {
+	type embed Entity
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Entity) String() string {
@@ -831,10 +1156,19 @@ func (e *Exception) validate() error {
 	return nil
 }
 
+var (
+	exceptionInfoFieldExceptionType       = big.NewInt(1 << 0)
+	exceptionInfoFieldExceptionMessage    = big.NewInt(1 << 1)
+	exceptionInfoFieldExceptionStacktrace = big.NewInt(1 << 2)
+)
+
 type ExceptionInfo struct {
 	ExceptionType       string `json:"exceptionType" url:"exceptionType"`
 	ExceptionMessage    string `json:"exceptionMessage" url:"exceptionMessage"`
 	ExceptionStacktrace string `json:"exceptionStacktrace" url:"exceptionStacktrace"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -865,6 +1199,28 @@ func (e *ExceptionInfo) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExceptionInfo) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExceptionInfo) SetExceptionType(exceptionType string) {
+	e.ExceptionType = exceptionType
+	e.require(exceptionInfoFieldExceptionType)
+}
+
+func (e *ExceptionInfo) SetExceptionMessage(exceptionMessage string) {
+	e.ExceptionMessage = exceptionMessage
+	e.require(exceptionInfoFieldExceptionMessage)
+}
+
+func (e *ExceptionInfo) SetExceptionStacktrace(exceptionStacktrace string) {
+	e.ExceptionStacktrace = exceptionStacktrace
+	e.require(exceptionInfoFieldExceptionStacktrace)
+}
+
 func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler ExceptionInfo
 	var value unmarshaler
@@ -881,6 +1237,17 @@ func (e *ExceptionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *ExceptionInfo) MarshalJSON() ([]byte, error) {
+	type embed ExceptionInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (e *ExceptionInfo) String() string {
 	if len(e.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(e.rawJSON); err == nil {
@@ -892,6 +1259,19 @@ func (e *ExceptionInfo) String() string {
 	}
 	return fmt.Sprintf("%#v", e)
 }
+
+var (
+	extendedMovieFieldId       = big.NewInt(1 << 0)
+	extendedMovieFieldPrequel  = big.NewInt(1 << 1)
+	extendedMovieFieldTitle    = big.NewInt(1 << 2)
+	extendedMovieFieldFrom     = big.NewInt(1 << 3)
+	extendedMovieFieldRating   = big.NewInt(1 << 4)
+	extendedMovieFieldTag      = big.NewInt(1 << 5)
+	extendedMovieFieldBook     = big.NewInt(1 << 6)
+	extendedMovieFieldMetadata = big.NewInt(1 << 7)
+	extendedMovieFieldRevenue  = big.NewInt(1 << 8)
+	extendedMovieFieldCast     = big.NewInt(1 << 9)
+)
 
 type ExtendedMovie struct {
 	Id      MovieId  `json:"id" url:"id"`
@@ -905,7 +1285,10 @@ type ExtendedMovie struct {
 	Metadata map[string]interface{} `json:"metadata,omitempty" url:"metadata,omitempty"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
 	Cast     []string               `json:"cast,omitempty" url:"cast,omitempty"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -989,6 +1372,63 @@ func (e *ExtendedMovie) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *ExtendedMovie) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *ExtendedMovie) SetId(id MovieId) {
+	e.Id = id
+	e.require(extendedMovieFieldId)
+}
+
+func (e *ExtendedMovie) SetPrequel(prequel *MovieId) {
+	e.Prequel = prequel
+	e.require(extendedMovieFieldPrequel)
+}
+
+func (e *ExtendedMovie) SetTitle(title string) {
+	e.Title = title
+	e.require(extendedMovieFieldTitle)
+}
+
+func (e *ExtendedMovie) SetFrom(from string) {
+	e.From = from
+	e.require(extendedMovieFieldFrom)
+}
+
+func (e *ExtendedMovie) SetRating(rating float64) {
+	e.Rating = rating
+	e.require(extendedMovieFieldRating)
+}
+
+func (e *ExtendedMovie) SetTag(tag commons.Tag) {
+	e.Tag = tag
+	e.require(extendedMovieFieldTag)
+}
+
+func (e *ExtendedMovie) SetBook(book *string) {
+	e.Book = book
+	e.require(extendedMovieFieldBook)
+}
+
+func (e *ExtendedMovie) SetMetadata(metadata map[string]interface{}) {
+	e.Metadata = metadata
+	e.require(extendedMovieFieldMetadata)
+}
+
+func (e *ExtendedMovie) SetRevenue(revenue int64) {
+	e.Revenue = revenue
+	e.require(extendedMovieFieldRevenue)
+}
+
+func (e *ExtendedMovie) SetCast(cast []string) {
+	e.Cast = cast
+	e.require(extendedMovieFieldCast)
+}
+
 func (e *ExtendedMovie) UnmarshalJSON(data []byte) error {
 	type embed ExtendedMovie
 	var unmarshaler = struct {
@@ -1023,7 +1463,8 @@ func (e *ExtendedMovie) MarshalJSON() ([]byte, error) {
 		embed: embed(*e),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *ExtendedMovie) String() string {
@@ -1038,9 +1479,17 @@ func (e *ExtendedMovie) String() string {
 	return fmt.Sprintf("%#v", e)
 }
 
+var (
+	fileFieldName     = big.NewInt(1 << 0)
+	fileFieldContents = big.NewInt(1 << 1)
+)
+
 type File struct {
 	Name     string `json:"name" url:"name"`
 	Contents string `json:"contents" url:"contents"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1064,6 +1513,23 @@ func (f *File) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *File) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *File) SetName(name string) {
+	f.Name = name
+	f.require(fileFieldName)
+}
+
+func (f *File) SetContents(contents string) {
+	f.Contents = contents
+	f.require(fileFieldContents)
+}
+
 func (f *File) UnmarshalJSON(data []byte) error {
 	type unmarshaler File
 	var value unmarshaler
@@ -1078,6 +1544,17 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *File) MarshalJSON() ([]byte, error) {
+	type embed File
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *File) String() string {
@@ -1265,9 +1742,17 @@ func (m *Metadata) validate() error {
 	return nil
 }
 
+var (
+	migrationFieldName   = big.NewInt(1 << 0)
+	migrationFieldStatus = big.NewInt(1 << 1)
+)
+
 type Migration struct {
 	Name   string          `json:"name" url:"name"`
 	Status MigrationStatus `json:"status" url:"status"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1291,6 +1776,23 @@ func (m *Migration) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Migration) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Migration) SetName(name string) {
+	m.Name = name
+	m.require(migrationFieldName)
+}
+
+func (m *Migration) SetStatus(status MigrationStatus) {
+	m.Status = status
+	m.require(migrationFieldStatus)
+}
+
 func (m *Migration) UnmarshalJSON(data []byte) error {
 	type unmarshaler Migration
 	var value unmarshaler
@@ -1305,6 +1807,17 @@ func (m *Migration) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Migration) MarshalJSON() ([]byte, error) {
+	type embed Migration
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Migration) String() string {
@@ -1346,10 +1859,19 @@ func (m MigrationStatus) Ptr() *MigrationStatus {
 	return &m
 }
 
+var (
+	momentFieldId       = big.NewInt(1 << 0)
+	momentFieldDate     = big.NewInt(1 << 1)
+	momentFieldDatetime = big.NewInt(1 << 2)
+)
+
 type Moment struct {
 	Id       uuid.UUID `json:"id" url:"id"`
 	Date     time.Time `json:"date" url:"date" format:"date"`
 	Datetime time.Time `json:"datetime" url:"datetime"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1378,6 +1900,28 @@ func (m *Moment) GetDatetime() time.Time {
 
 func (m *Moment) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *Moment) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Moment) SetId(id uuid.UUID) {
+	m.Id = id
+	m.require(momentFieldId)
+}
+
+func (m *Moment) SetDate(date time.Time) {
+	m.Date = date
+	m.require(momentFieldDate)
+}
+
+func (m *Moment) SetDatetime(datetime time.Time) {
+	m.Datetime = datetime
+	m.require(momentFieldDatetime)
 }
 
 func (m *Moment) UnmarshalJSON(data []byte) error {
@@ -1415,7 +1959,8 @@ func (m *Moment) MarshalJSON() ([]byte, error) {
 		Date:     internal.NewDate(m.Date),
 		Datetime: internal.NewDateTime(m.Datetime),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Moment) String() string {
@@ -1430,6 +1975,18 @@ func (m *Moment) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	movieFieldId       = big.NewInt(1 << 0)
+	movieFieldPrequel  = big.NewInt(1 << 1)
+	movieFieldTitle    = big.NewInt(1 << 2)
+	movieFieldFrom     = big.NewInt(1 << 3)
+	movieFieldRating   = big.NewInt(1 << 4)
+	movieFieldTag      = big.NewInt(1 << 5)
+	movieFieldBook     = big.NewInt(1 << 6)
+	movieFieldMetadata = big.NewInt(1 << 7)
+	movieFieldRevenue  = big.NewInt(1 << 8)
+)
+
 type Movie struct {
 	Id      MovieId  `json:"id" url:"id"`
 	Prequel *MovieId `json:"prequel,omitempty" url:"prequel,omitempty"`
@@ -1441,7 +1998,10 @@ type Movie struct {
 	Book     *string                `json:"book,omitempty" url:"book,omitempty"`
 	Metadata map[string]interface{} `json:"metadata,omitempty" url:"metadata,omitempty"`
 	Revenue  int64                  `json:"revenue" url:"revenue"`
-	type_    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1518,6 +2078,58 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetPrequel(prequel *MovieId) {
+	m.Prequel = prequel
+	m.require(movieFieldPrequel)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetFrom(from string) {
+	m.From = from
+	m.require(movieFieldFrom)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
+func (m *Movie) SetTag(tag commons.Tag) {
+	m.Tag = tag
+	m.require(movieFieldTag)
+}
+
+func (m *Movie) SetBook(book *string) {
+	m.Book = book
+	m.require(movieFieldBook)
+}
+
+func (m *Movie) SetMetadata(metadata map[string]interface{}) {
+	m.Metadata = metadata
+	m.require(movieFieldMetadata)
+}
+
+func (m *Movie) SetRevenue(revenue int64) {
+	m.Revenue = revenue
+	m.require(movieFieldRevenue)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type embed Movie
 	var unmarshaler = struct {
@@ -1552,7 +2164,8 @@ func (m *Movie) MarshalJSON() ([]byte, error) {
 		embed: embed(*m),
 		Type:  "movie",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {
@@ -1569,10 +2182,19 @@ func (m *Movie) String() string {
 
 type MovieId = string
 
+var (
+	nodeFieldName  = big.NewInt(1 << 0)
+	nodeFieldNodes = big.NewInt(1 << 1)
+	nodeFieldTrees = big.NewInt(1 << 2)
+)
+
 type Node struct {
 	Name  string  `json:"name" url:"name"`
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
 	Trees []*Tree `json:"trees,omitempty" url:"trees,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1603,6 +2225,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetName(name string) {
+	n.Name = name
+	n.require(nodeFieldName)
+}
+
+func (n *Node) SetNodes(nodes []*Node) {
+	n.Nodes = nodes
+	n.require(nodeFieldNodes)
+}
+
+func (n *Node) SetTrees(trees []*Tree) {
+	n.Trees = trees
+	n.require(nodeFieldTrees)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -1619,6 +2263,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1631,8 +2286,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	refreshTokenRequestFieldTtl = big.NewInt(1 << 0)
+)
+
 type RefreshTokenRequest struct {
 	Ttl int `json:"ttl" url:"ttl"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1647,6 +2309,18 @@ func (r *RefreshTokenRequest) GetTtl() int {
 
 func (r *RefreshTokenRequest) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetTtl(ttl int) {
+	r.Ttl = ttl
+	r.require(refreshTokenRequestFieldTtl)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -1665,6 +2339,17 @@ func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
+	type embed RefreshTokenRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RefreshTokenRequest) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1677,8 +2362,15 @@ func (r *RefreshTokenRequest) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	requestFieldRequest = big.NewInt(1 << 0)
+)
+
 type Request struct {
 	Request interface{} `json:"request,omitempty" url:"request,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1693,6 +2385,18 @@ func (r *Request) GetRequest() interface{} {
 
 func (r *Request) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *Request) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Request) SetRequest(request interface{}) {
+	r.Request = request
+	r.require(requestFieldRequest)
 }
 
 func (r *Request) UnmarshalJSON(data []byte) error {
@@ -1711,6 +2415,17 @@ func (r *Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Request) MarshalJSON() ([]byte, error) {
+	type embed Request
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Request) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1723,9 +2438,17 @@ func (r *Request) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseFieldResponse    = big.NewInt(1 << 0)
+	responseFieldIdentifiers = big.NewInt(1 << 1)
+)
+
 type Response struct {
 	Response    interface{}   `json:"response,omitempty" url:"response,omitempty"`
 	Identifiers []*Identifier `json:"identifiers,omitempty" url:"identifiers,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1749,6 +2472,23 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetResponse(response interface{}) {
+	r.Response = response
+	r.require(responseFieldResponse)
+}
+
+func (r *Response) SetIdentifiers(identifiers []*Identifier) {
+	r.Identifiers = identifiers
+	r.require(responseFieldIdentifiers)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -1765,6 +2505,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1777,8 +2528,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	responseTypeFieldType = big.NewInt(1 << 0)
+)
+
 type ResponseType struct {
 	Type *Type `json:"type,omitempty" url:"type,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1793,6 +2551,18 @@ func (r *ResponseType) GetType() *Type {
 
 func (r *ResponseType) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ResponseType) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ResponseType) SetType(type_ *Type) {
+	r.Type = type_
+	r.require(responseTypeFieldType)
 }
 
 func (r *ResponseType) UnmarshalJSON(data []byte) error {
@@ -1811,6 +2581,17 @@ func (r *ResponseType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ResponseType) MarshalJSON() ([]byte, error) {
+	type embed ResponseType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ResponseType) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1823,9 +2604,17 @@ func (r *ResponseType) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	stuntDoubleFieldName             = big.NewInt(1 << 0)
+	stuntDoubleFieldActorOrActressId = big.NewInt(1 << 1)
+)
+
 type StuntDouble struct {
 	Name             string `json:"name" url:"name"`
 	ActorOrActressId string `json:"actorOrActressId" url:"actorOrActressId"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1849,6 +2638,23 @@ func (s *StuntDouble) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StuntDouble) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StuntDouble) SetName(name string) {
+	s.Name = name
+	s.require(stuntDoubleFieldName)
+}
+
+func (s *StuntDouble) SetActorOrActressId(actorOrActressId string) {
+	s.ActorOrActressId = actorOrActressId
+	s.require(stuntDoubleFieldActorOrActressId)
+}
+
 func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	type unmarshaler StuntDouble
 	var value unmarshaler
@@ -1863,6 +2669,17 @@ func (s *StuntDouble) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StuntDouble) MarshalJSON() ([]byte, error) {
+	type embed StuntDouble
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StuntDouble) String() string {
@@ -2022,8 +2839,15 @@ func (t *Test) validate() error {
 	return nil
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2040,6 +2864,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -2054,6 +2890,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/exhaustive/endpoints/params.go
+++ b/seed/go-sdk/exhaustive/endpoints/params.go
@@ -4,34 +4,167 @@ package endpoints
 
 import (
 	json "encoding/json"
+	big "math/big"
+)
+
+var (
+	getWithMultipleQueryFieldQuery  = big.NewInt(1 << 0)
+	getWithMultipleQueryFieldNumber = big.NewInt(1 << 1)
 )
 
 type GetWithMultipleQuery struct {
 	Query  []string `json:"-" url:"query"`
 	Number []int    `json:"-" url:"number"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetWithMultipleQuery) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetWithMultipleQuery) SetQuery(query []string) {
+	g.Query = query
+	g.require(getWithMultipleQueryFieldQuery)
+}
+
+func (g *GetWithMultipleQuery) SetNumber(number []int) {
+	g.Number = number
+	g.require(getWithMultipleQueryFieldNumber)
+}
+
+var (
+	getWithInlinePathFieldParam = big.NewInt(1 << 0)
+)
 
 type GetWithInlinePath struct {
 	Param string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetWithInlinePath) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetWithInlinePath) SetParam(param string) {
+	g.Param = param
+	g.require(getWithInlinePathFieldParam)
+}
+
+var (
+	getWithInlinePathAndQueryFieldParam = big.NewInt(1 << 0)
+	getWithInlinePathAndQueryFieldQuery = big.NewInt(1 << 1)
+)
 
 type GetWithInlinePathAndQuery struct {
 	Param string `json:"-" url:"-"`
 	Query string `json:"-" url:"query"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetWithInlinePathAndQuery) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetWithInlinePathAndQuery) SetParam(param string) {
+	g.Param = param
+	g.require(getWithInlinePathAndQueryFieldParam)
+}
+
+func (g *GetWithInlinePathAndQuery) SetQuery(query string) {
+	g.Query = query
+	g.require(getWithInlinePathAndQueryFieldQuery)
+}
+
+var (
+	getWithPathAndQueryFieldQuery = big.NewInt(1 << 0)
+)
 
 type GetWithPathAndQuery struct {
 	Query string `json:"-" url:"query"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetWithPathAndQuery) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetWithPathAndQuery) SetQuery(query string) {
+	g.Query = query
+	g.require(getWithPathAndQueryFieldQuery)
+}
+
+var (
+	getWithQueryFieldQuery  = big.NewInt(1 << 0)
+	getWithQueryFieldNumber = big.NewInt(1 << 1)
+)
 
 type GetWithQuery struct {
 	Query  string `json:"-" url:"query"`
 	Number int    `json:"-" url:"number"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetWithQuery) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetWithQuery) SetQuery(query string) {
+	g.Query = query
+	g.require(getWithQueryFieldQuery)
+}
+
+func (g *GetWithQuery) SetNumber(number int) {
+	g.Number = number
+	g.require(getWithQueryFieldNumber)
+}
+
+var (
+	modifyResourceAtInlinedPathFieldParam = big.NewInt(1 << 0)
+)
 
 type ModifyResourceAtInlinedPath struct {
 	Param string `json:"-" url:"-"`
 	Body  string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (m *ModifyResourceAtInlinedPath) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *ModifyResourceAtInlinedPath) SetParam(param string) {
+	m.Param = param
+	m.require(modifyResourceAtInlinedPathFieldParam)
 }
 
 func (m *ModifyResourceAtInlinedPath) UnmarshalJSON(data []byte) error {

--- a/seed/go-sdk/exhaustive/endpoints/params.go
+++ b/seed/go-sdk/exhaustive/endpoints/params.go
@@ -27,11 +27,15 @@ func (g *GetWithMultipleQuery) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithMultipleQuery) SetQuery(query []string) {
 	g.Query = query
 	g.require(getWithMultipleQueryFieldQuery)
 }
 
+// SetNumber sets the Number field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithMultipleQuery) SetNumber(number []int) {
 	g.Number = number
 	g.require(getWithMultipleQueryFieldNumber)
@@ -55,6 +59,8 @@ func (g *GetWithInlinePath) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetParam sets the Param field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithInlinePath) SetParam(param string) {
 	g.Param = param
 	g.require(getWithInlinePathFieldParam)
@@ -80,11 +86,15 @@ func (g *GetWithInlinePathAndQuery) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetParam sets the Param field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithInlinePathAndQuery) SetParam(param string) {
 	g.Param = param
 	g.require(getWithInlinePathAndQueryFieldParam)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithInlinePathAndQuery) SetQuery(query string) {
 	g.Query = query
 	g.require(getWithInlinePathAndQueryFieldQuery)
@@ -108,6 +118,8 @@ func (g *GetWithPathAndQuery) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithPathAndQuery) SetQuery(query string) {
 	g.Query = query
 	g.require(getWithPathAndQueryFieldQuery)
@@ -133,11 +145,15 @@ func (g *GetWithQuery) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithQuery) SetQuery(query string) {
 	g.Query = query
 	g.require(getWithQueryFieldQuery)
 }
 
+// SetNumber sets the Number field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetWithQuery) SetNumber(number int) {
 	g.Number = number
 	g.require(getWithQueryFieldNumber)
@@ -162,6 +178,8 @@ func (m *ModifyResourceAtInlinedPath) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetParam sets the Param field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *ModifyResourceAtInlinedPath) SetParam(param string) {
 	m.Param = param
 	m.require(modifyResourceAtInlinedPathFieldParam)

--- a/seed/go-sdk/exhaustive/endpoints/put.go
+++ b/seed/go-sdk/exhaustive/endpoints/put.go
@@ -27,6 +27,8 @@ func (p *PutRequest) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PutRequest) SetId(id string) {
 	p.Id = id
 	p.require(putRequestFieldId)
@@ -91,21 +93,29 @@ func (e *Error) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetCategory sets the Category field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Error) SetCategory(category ErrorCategory) {
 	e.Category = category
 	e.require(errorFieldCategory)
 }
 
+// SetCode sets the Code field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Error) SetCode(code ErrorCode) {
 	e.Code = code
 	e.require(errorFieldCode)
 }
 
+// SetDetail sets the Detail field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Error) SetDetail(detail *string) {
 	e.Detail = detail
 	e.require(errorFieldDetail)
 }
 
+// SetField sets the Field field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Error) SetField(field *string) {
 	e.Field = field
 	e.require(errorFieldField)
@@ -256,6 +266,8 @@ func (p *PutResponse) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetErrors sets the Errors field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PutResponse) SetErrors(errors []*Error) {
 	p.Errors = errors
 	p.require(putResponseFieldErrors)

--- a/seed/go-sdk/exhaustive/endpoints/put.go
+++ b/seed/go-sdk/exhaustive/endpoints/put.go
@@ -6,17 +6,47 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
+	big "math/big"
+)
+
+var (
+	putRequestFieldId = big.NewInt(1 << 0)
 )
 
 type PutRequest struct {
 	Id string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (p *PutRequest) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PutRequest) SetId(id string) {
+	p.Id = id
+	p.require(putRequestFieldId)
+}
+
+var (
+	errorFieldCategory = big.NewInt(1 << 0)
+	errorFieldCode     = big.NewInt(1 << 1)
+	errorFieldDetail   = big.NewInt(1 << 2)
+	errorFieldField    = big.NewInt(1 << 3)
+)
 
 type Error struct {
 	Category ErrorCategory `json:"category" url:"category"`
 	Code     ErrorCode     `json:"code" url:"code"`
 	Detail   *string       `json:"detail,omitempty" url:"detail,omitempty"`
 	Field    *string       `json:"field,omitempty" url:"field,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -54,6 +84,33 @@ func (e *Error) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Error) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Error) SetCategory(category ErrorCategory) {
+	e.Category = category
+	e.require(errorFieldCategory)
+}
+
+func (e *Error) SetCode(code ErrorCode) {
+	e.Code = code
+	e.require(errorFieldCode)
+}
+
+func (e *Error) SetDetail(detail *string) {
+	e.Detail = detail
+	e.require(errorFieldDetail)
+}
+
+func (e *Error) SetField(field *string) {
+	e.Field = field
+	e.require(errorFieldField)
+}
+
 func (e *Error) UnmarshalJSON(data []byte) error {
 	type unmarshaler Error
 	var value unmarshaler
@@ -68,6 +125,17 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Error) MarshalJSON() ([]byte, error) {
+	type embed Error
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Error) String() string {
@@ -156,8 +224,15 @@ func (e ErrorCode) Ptr() *ErrorCode {
 	return &e
 }
 
+var (
+	putResponseFieldErrors = big.NewInt(1 << 0)
+)
+
 type PutResponse struct {
 	Errors []*Error `json:"errors,omitempty" url:"errors,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -174,6 +249,18 @@ func (p *PutResponse) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *PutResponse) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PutResponse) SetErrors(errors []*Error) {
+	p.Errors = errors
+	p.require(putResponseFieldErrors)
+}
+
 func (p *PutResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler PutResponse
 	var value unmarshaler
@@ -188,6 +275,17 @@ func (p *PutResponse) UnmarshalJSON(data []byte) error {
 	p.extraProperties = extraProperties
 	p.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (p *PutResponse) MarshalJSON() ([]byte, error) {
+	type embed PutResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *PutResponse) String() string {

--- a/seed/go-sdk/exhaustive/general_errors.go
+++ b/seed/go-sdk/exhaustive/general_errors.go
@@ -41,6 +41,8 @@ func (b *BadObjectRequestInfo) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BadObjectRequestInfo) SetMessage(message string) {
 	b.Message = message
 	b.require(badObjectRequestInfoFieldMessage)

--- a/seed/go-sdk/exhaustive/general_errors.go
+++ b/seed/go-sdk/exhaustive/general_errors.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
+	big "math/big"
+)
+
+var (
+	badObjectRequestInfoFieldMessage = big.NewInt(1 << 0)
 )
 
 type BadObjectRequestInfo struct {
 	Message string `json:"message" url:"message"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (b *BadObjectRequestInfo) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BadObjectRequestInfo) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BadObjectRequestInfo) SetMessage(message string) {
+	b.Message = message
+	b.require(badObjectRequestInfoFieldMessage)
+}
+
 func (b *BadObjectRequestInfo) UnmarshalJSON(data []byte) error {
 	type unmarshaler BadObjectRequestInfo
 	var value unmarshaler
@@ -40,6 +60,17 @@ func (b *BadObjectRequestInfo) UnmarshalJSON(data []byte) error {
 	b.extraProperties = extraProperties
 	b.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (b *BadObjectRequestInfo) MarshalJSON() ([]byte, error) {
+	type embed BadObjectRequestInfo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (b *BadObjectRequestInfo) String() string {

--- a/seed/go-sdk/exhaustive/inlined_requests.go
+++ b/seed/go-sdk/exhaustive/inlined_requests.go
@@ -29,16 +29,22 @@ func (p *PostWithObjectBody) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PostWithObjectBody) SetString(string_ string) {
 	p.String = string_
 	p.require(postWithObjectBodyFieldString)
 }
 
+// SetInteger sets the Integer field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PostWithObjectBody) SetInteger(integer int) {
 	p.Integer = integer
 	p.require(postWithObjectBodyFieldInteger)
 }
 
+// SetNestedObject sets the NestedObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PostWithObjectBody) SetNestedObject(nestedObject *types.ObjectWithOptionalField) {
 	p.NestedObject = nestedObject
 	p.require(postWithObjectBodyFieldNestedObject)

--- a/seed/go-sdk/exhaustive/inlined_requests.go
+++ b/seed/go-sdk/exhaustive/inlined_requests.go
@@ -4,10 +4,42 @@ package exhaustive
 
 import (
 	types "github.com/exhaustive/fern/types"
+	big "math/big"
+)
+
+var (
+	postWithObjectBodyFieldString       = big.NewInt(1 << 0)
+	postWithObjectBodyFieldInteger      = big.NewInt(1 << 1)
+	postWithObjectBodyFieldNestedObject = big.NewInt(1 << 2)
 )
 
 type PostWithObjectBody struct {
 	String       string                         `json:"string" url:"-"`
 	Integer      int                            `json:"integer" url:"-"`
 	NestedObject *types.ObjectWithOptionalField `json:"NestedObject,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (p *PostWithObjectBody) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PostWithObjectBody) SetString(string_ string) {
+	p.String = string_
+	p.require(postWithObjectBodyFieldString)
+}
+
+func (p *PostWithObjectBody) SetInteger(integer int) {
+	p.Integer = integer
+	p.require(postWithObjectBodyFieldInteger)
+}
+
+func (p *PostWithObjectBody) SetNestedObject(nestedObject *types.ObjectWithOptionalField) {
+	p.NestedObject = nestedObject
+	p.require(postWithObjectBodyFieldNestedObject)
 }

--- a/seed/go-sdk/exhaustive/internal/explicit_fields.go
+++ b/seed/go-sdk/exhaustive/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/exhaustive/internal/explicit_fields_test.go
+++ b/seed/go-sdk/exhaustive/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/exhaustive/req_with_headers.go
+++ b/seed/go-sdk/exhaustive/req_with_headers.go
@@ -28,11 +28,15 @@ func (r *ReqWithHeaders) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetXTestServiceHeader sets the XTestServiceHeader field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReqWithHeaders) SetXTestServiceHeader(xTestServiceHeader string) {
 	r.XTestServiceHeader = xTestServiceHeader
 	r.require(reqWithHeadersFieldXTestServiceHeader)
 }
 
+// SetXTestEndpointHeader sets the XTestEndpointHeader field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReqWithHeaders) SetXTestEndpointHeader(xTestEndpointHeader string) {
 	r.XTestEndpointHeader = xTestEndpointHeader
 	r.require(reqWithHeadersFieldXTestEndpointHeader)

--- a/seed/go-sdk/exhaustive/req_with_headers.go
+++ b/seed/go-sdk/exhaustive/req_with_headers.go
@@ -4,12 +4,38 @@ package exhaustive
 
 import (
 	json "encoding/json"
+	big "math/big"
+)
+
+var (
+	reqWithHeadersFieldXTestServiceHeader  = big.NewInt(1 << 0)
+	reqWithHeadersFieldXTestEndpointHeader = big.NewInt(1 << 1)
 )
 
 type ReqWithHeaders struct {
 	XTestServiceHeader  string `json:"-" url:"-"`
 	XTestEndpointHeader string `json:"-" url:"-"`
 	Body                string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (r *ReqWithHeaders) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReqWithHeaders) SetXTestServiceHeader(xTestServiceHeader string) {
+	r.XTestServiceHeader = xTestServiceHeader
+	r.require(reqWithHeadersFieldXTestServiceHeader)
+}
+
+func (r *ReqWithHeaders) SetXTestEndpointHeader(xTestEndpointHeader string) {
+	r.XTestEndpointHeader = xTestEndpointHeader
+	r.require(reqWithHeadersFieldXTestEndpointHeader)
 }
 
 func (r *ReqWithHeaders) UnmarshalJSON(data []byte) error {

--- a/seed/go-sdk/exhaustive/types/docs.go
+++ b/seed/go-sdk/exhaustive/types/docs.go
@@ -96,6 +96,8 @@ func (o *ObjectWithDocs) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithDocs) SetString(string_ string) {
 	o.String = string_
 	o.require(objectWithDocsFieldString)

--- a/seed/go-sdk/exhaustive/types/docs.go
+++ b/seed/go-sdk/exhaustive/types/docs.go
@@ -6,6 +6,11 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
+	big "math/big"
+)
+
+var (
+	objectWithDocsFieldString = big.NewInt(1 << 0)
 )
 
 type ObjectWithDocs struct {
@@ -66,6 +71,9 @@ type ObjectWithDocs struct {
 	// - &: HTML entities
 	String string `json:"string" url:"string"`
 
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
 }
@@ -79,6 +87,18 @@ func (o *ObjectWithDocs) GetString() string {
 
 func (o *ObjectWithDocs) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
+}
+
+func (o *ObjectWithDocs) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *ObjectWithDocs) SetString(string_ string) {
+	o.String = string_
+	o.require(objectWithDocsFieldString)
 }
 
 func (o *ObjectWithDocs) UnmarshalJSON(data []byte) error {
@@ -95,6 +115,17 @@ func (o *ObjectWithDocs) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *ObjectWithDocs) MarshalJSON() ([]byte, error) {
+	type embed ObjectWithDocs
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectWithDocs) String() string {

--- a/seed/go-sdk/exhaustive/types/object.go
+++ b/seed/go-sdk/exhaustive/types/object.go
@@ -43,6 +43,8 @@ func (d *DoubleOptional) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetOptionalAlias sets the OptionalAlias field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DoubleOptional) SetOptionalAlias(optionalAlias *OptionalAlias) {
 	d.OptionalAlias = optionalAlias
 	d.require(doubleOptionalFieldOptionalAlias)
@@ -128,11 +130,15 @@ func (n *NestedObjectWithOptionalField) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedObjectWithOptionalField) SetString(string_ *string) {
 	n.String = string_
 	n.require(nestedObjectWithOptionalFieldFieldString)
 }
 
+// SetNestedObject sets the NestedObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedObjectWithOptionalField) SetNestedObject(nestedObject *ObjectWithOptionalField) {
 	n.NestedObject = nestedObject
 	n.require(nestedObjectWithOptionalFieldFieldNestedObject)
@@ -218,11 +224,15 @@ func (n *NestedObjectWithRequiredField) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedObjectWithRequiredField) SetString(string_ string) {
 	n.String = string_
 	n.require(nestedObjectWithRequiredFieldFieldString)
 }
 
+// SetNestedObject sets the NestedObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedObjectWithRequiredField) SetNestedObject(nestedObject *ObjectWithOptionalField) {
 	n.NestedObject = nestedObject
 	n.require(nestedObjectWithRequiredFieldFieldNestedObject)
@@ -299,6 +309,8 @@ func (o *ObjectWithMapOfMap) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetMap sets the Map field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithMapOfMap) SetMap(map_ map[string]map[string]string) {
 	o.Map = map_
 	o.require(objectWithMapOfMapFieldMap)
@@ -484,66 +496,92 @@ func (o *ObjectWithOptionalField) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetString(string_ *string) {
 	o.String = string_
 	o.require(objectWithOptionalFieldFieldString)
 }
 
+// SetInteger sets the Integer field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetInteger(integer *int) {
 	o.Integer = integer
 	o.require(objectWithOptionalFieldFieldInteger)
 }
 
+// SetLong sets the Long field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetLong(long *int64) {
 	o.Long = long
 	o.require(objectWithOptionalFieldFieldLong)
 }
 
+// SetDouble sets the Double field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetDouble(double *float64) {
 	o.Double = double
 	o.require(objectWithOptionalFieldFieldDouble)
 }
 
+// SetBool sets the Bool field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetBool(bool_ *bool) {
 	o.Bool = bool_
 	o.require(objectWithOptionalFieldFieldBool)
 }
 
+// SetDatetime sets the Datetime field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetDatetime(datetime *time.Time) {
 	o.Datetime = datetime
 	o.require(objectWithOptionalFieldFieldDatetime)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetDate(date *time.Time) {
 	o.Date = date
 	o.require(objectWithOptionalFieldFieldDate)
 }
 
+// SetUuid sets the Uuid field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetUuid(uuid *uuid.UUID) {
 	o.Uuid = uuid
 	o.require(objectWithOptionalFieldFieldUuid)
 }
 
+// SetBase64 sets the Base64 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetBase64(base64 *[]byte) {
 	o.Base64 = base64
 	o.require(objectWithOptionalFieldFieldBase64)
 }
 
+// SetList sets the List field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetList(list []string) {
 	o.List = list
 	o.require(objectWithOptionalFieldFieldList)
 }
 
+// SetSet sets the Set field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetSet(set []string) {
 	o.Set = set
 	o.require(objectWithOptionalFieldFieldSet)
 }
 
+// SetMap sets the Map field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetMap(map_ map[int]string) {
 	o.Map = map_
 	o.require(objectWithOptionalFieldFieldMap)
 }
 
+// SetBigint sets the Bigint field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithOptionalField) SetBigint(bigint *string) {
 	o.Bigint = bigint
 	o.require(objectWithOptionalFieldFieldBigint)
@@ -632,6 +670,8 @@ func (o *ObjectWithRequiredField) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetString sets the String field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *ObjectWithRequiredField) SetString(string_ string) {
 	o.String = string_
 	o.require(objectWithRequiredFieldFieldString)

--- a/seed/go-sdk/exhaustive/types/object.go
+++ b/seed/go-sdk/exhaustive/types/object.go
@@ -7,11 +7,19 @@ import (
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
 	uuid "github.com/google/uuid"
+	big "math/big"
 	time "time"
+)
+
+var (
+	doubleOptionalFieldOptionalAlias = big.NewInt(1 << 0)
 )
 
 type DoubleOptional struct {
 	OptionalAlias *OptionalAlias `json:"optionalAlias,omitempty" url:"optionalAlias,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (d *DoubleOptional) GetOptionalAlias() *OptionalAlias {
 
 func (d *DoubleOptional) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DoubleOptional) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DoubleOptional) SetOptionalAlias(optionalAlias *OptionalAlias) {
+	d.OptionalAlias = optionalAlias
+	d.require(doubleOptionalFieldOptionalAlias)
 }
 
 func (d *DoubleOptional) UnmarshalJSON(data []byte) error {
@@ -44,6 +64,17 @@ func (d *DoubleOptional) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DoubleOptional) MarshalJSON() ([]byte, error) {
+	type embed DoubleOptional
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DoubleOptional) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -56,9 +87,17 @@ func (d *DoubleOptional) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	nestedObjectWithOptionalFieldFieldString       = big.NewInt(1 << 0)
+	nestedObjectWithOptionalFieldFieldNestedObject = big.NewInt(1 << 1)
+)
+
 type NestedObjectWithOptionalField struct {
 	String       *string                  `json:"string,omitempty" url:"string,omitempty"`
 	NestedObject *ObjectWithOptionalField `json:"NestedObject,omitempty" url:"NestedObject,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -82,6 +121,23 @@ func (n *NestedObjectWithOptionalField) GetExtraProperties() map[string]interfac
 	return n.extraProperties
 }
 
+func (n *NestedObjectWithOptionalField) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NestedObjectWithOptionalField) SetString(string_ *string) {
+	n.String = string_
+	n.require(nestedObjectWithOptionalFieldFieldString)
+}
+
+func (n *NestedObjectWithOptionalField) SetNestedObject(nestedObject *ObjectWithOptionalField) {
+	n.NestedObject = nestedObject
+	n.require(nestedObjectWithOptionalFieldFieldNestedObject)
+}
+
 func (n *NestedObjectWithOptionalField) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedObjectWithOptionalField
 	var value unmarshaler
@@ -98,6 +154,17 @@ func (n *NestedObjectWithOptionalField) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedObjectWithOptionalField) MarshalJSON() ([]byte, error) {
+	type embed NestedObjectWithOptionalField
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedObjectWithOptionalField) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -110,9 +177,17 @@ func (n *NestedObjectWithOptionalField) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	nestedObjectWithRequiredFieldFieldString       = big.NewInt(1 << 0)
+	nestedObjectWithRequiredFieldFieldNestedObject = big.NewInt(1 << 1)
+)
+
 type NestedObjectWithRequiredField struct {
 	String       string                   `json:"string" url:"string"`
 	NestedObject *ObjectWithOptionalField `json:"NestedObject" url:"NestedObject"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -136,6 +211,23 @@ func (n *NestedObjectWithRequiredField) GetExtraProperties() map[string]interfac
 	return n.extraProperties
 }
 
+func (n *NestedObjectWithRequiredField) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NestedObjectWithRequiredField) SetString(string_ string) {
+	n.String = string_
+	n.require(nestedObjectWithRequiredFieldFieldString)
+}
+
+func (n *NestedObjectWithRequiredField) SetNestedObject(nestedObject *ObjectWithOptionalField) {
+	n.NestedObject = nestedObject
+	n.require(nestedObjectWithRequiredFieldFieldNestedObject)
+}
+
 func (n *NestedObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedObjectWithRequiredField
 	var value unmarshaler
@@ -152,6 +244,17 @@ func (n *NestedObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedObjectWithRequiredField) MarshalJSON() ([]byte, error) {
+	type embed NestedObjectWithRequiredField
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedObjectWithRequiredField) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -164,8 +267,15 @@ func (n *NestedObjectWithRequiredField) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	objectWithMapOfMapFieldMap = big.NewInt(1 << 0)
+)
+
 type ObjectWithMapOfMap struct {
 	Map map[string]map[string]string `json:"map" url:"map"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -180,6 +290,18 @@ func (o *ObjectWithMapOfMap) GetMap() map[string]map[string]string {
 
 func (o *ObjectWithMapOfMap) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
+}
+
+func (o *ObjectWithMapOfMap) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *ObjectWithMapOfMap) SetMap(map_ map[string]map[string]string) {
+	o.Map = map_
+	o.require(objectWithMapOfMapFieldMap)
 }
 
 func (o *ObjectWithMapOfMap) UnmarshalJSON(data []byte) error {
@@ -198,6 +320,17 @@ func (o *ObjectWithMapOfMap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (o *ObjectWithMapOfMap) MarshalJSON() ([]byte, error) {
+	type embed ObjectWithMapOfMap
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (o *ObjectWithMapOfMap) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {
@@ -209,6 +342,22 @@ func (o *ObjectWithMapOfMap) String() string {
 	}
 	return fmt.Sprintf("%#v", o)
 }
+
+var (
+	objectWithOptionalFieldFieldString   = big.NewInt(1 << 0)
+	objectWithOptionalFieldFieldInteger  = big.NewInt(1 << 1)
+	objectWithOptionalFieldFieldLong     = big.NewInt(1 << 2)
+	objectWithOptionalFieldFieldDouble   = big.NewInt(1 << 3)
+	objectWithOptionalFieldFieldBool     = big.NewInt(1 << 4)
+	objectWithOptionalFieldFieldDatetime = big.NewInt(1 << 5)
+	objectWithOptionalFieldFieldDate     = big.NewInt(1 << 6)
+	objectWithOptionalFieldFieldUuid     = big.NewInt(1 << 7)
+	objectWithOptionalFieldFieldBase64   = big.NewInt(1 << 8)
+	objectWithOptionalFieldFieldList     = big.NewInt(1 << 9)
+	objectWithOptionalFieldFieldSet      = big.NewInt(1 << 10)
+	objectWithOptionalFieldFieldMap      = big.NewInt(1 << 11)
+	objectWithOptionalFieldFieldBigint   = big.NewInt(1 << 12)
+)
 
 type ObjectWithOptionalField struct {
 	// This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered.
@@ -225,6 +374,9 @@ type ObjectWithOptionalField struct {
 	Set      []string       `json:"set,omitempty" url:"set,omitempty"`
 	Map      map[int]string `json:"map,omitempty" url:"map,omitempty"`
 	Bigint   *string        `json:"bigint,omitempty" url:"bigint,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -325,6 +477,78 @@ func (o *ObjectWithOptionalField) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *ObjectWithOptionalField) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *ObjectWithOptionalField) SetString(string_ *string) {
+	o.String = string_
+	o.require(objectWithOptionalFieldFieldString)
+}
+
+func (o *ObjectWithOptionalField) SetInteger(integer *int) {
+	o.Integer = integer
+	o.require(objectWithOptionalFieldFieldInteger)
+}
+
+func (o *ObjectWithOptionalField) SetLong(long *int64) {
+	o.Long = long
+	o.require(objectWithOptionalFieldFieldLong)
+}
+
+func (o *ObjectWithOptionalField) SetDouble(double *float64) {
+	o.Double = double
+	o.require(objectWithOptionalFieldFieldDouble)
+}
+
+func (o *ObjectWithOptionalField) SetBool(bool_ *bool) {
+	o.Bool = bool_
+	o.require(objectWithOptionalFieldFieldBool)
+}
+
+func (o *ObjectWithOptionalField) SetDatetime(datetime *time.Time) {
+	o.Datetime = datetime
+	o.require(objectWithOptionalFieldFieldDatetime)
+}
+
+func (o *ObjectWithOptionalField) SetDate(date *time.Time) {
+	o.Date = date
+	o.require(objectWithOptionalFieldFieldDate)
+}
+
+func (o *ObjectWithOptionalField) SetUuid(uuid *uuid.UUID) {
+	o.Uuid = uuid
+	o.require(objectWithOptionalFieldFieldUuid)
+}
+
+func (o *ObjectWithOptionalField) SetBase64(base64 *[]byte) {
+	o.Base64 = base64
+	o.require(objectWithOptionalFieldFieldBase64)
+}
+
+func (o *ObjectWithOptionalField) SetList(list []string) {
+	o.List = list
+	o.require(objectWithOptionalFieldFieldList)
+}
+
+func (o *ObjectWithOptionalField) SetSet(set []string) {
+	o.Set = set
+	o.require(objectWithOptionalFieldFieldSet)
+}
+
+func (o *ObjectWithOptionalField) SetMap(map_ map[int]string) {
+	o.Map = map_
+	o.require(objectWithOptionalFieldFieldMap)
+}
+
+func (o *ObjectWithOptionalField) SetBigint(bigint *string) {
+	o.Bigint = bigint
+	o.require(objectWithOptionalFieldFieldBigint)
+}
+
 func (o *ObjectWithOptionalField) UnmarshalJSON(data []byte) error {
 	type embed ObjectWithOptionalField
 	var unmarshaler = struct {
@@ -360,7 +584,8 @@ func (o *ObjectWithOptionalField) MarshalJSON() ([]byte, error) {
 		Datetime: internal.NewOptionalDateTime(o.Datetime),
 		Date:     internal.NewOptionalDate(o.Date),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectWithOptionalField) String() string {
@@ -375,8 +600,15 @@ func (o *ObjectWithOptionalField) String() string {
 	return fmt.Sprintf("%#v", o)
 }
 
+var (
+	objectWithRequiredFieldFieldString = big.NewInt(1 << 0)
+)
+
 type ObjectWithRequiredField struct {
 	String string `json:"string" url:"string"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -393,6 +625,18 @@ func (o *ObjectWithRequiredField) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *ObjectWithRequiredField) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *ObjectWithRequiredField) SetString(string_ string) {
+	o.String = string_
+	o.require(objectWithRequiredFieldFieldString)
+}
+
 func (o *ObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	type unmarshaler ObjectWithRequiredField
 	var value unmarshaler
@@ -407,6 +651,17 @@ func (o *ObjectWithRequiredField) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *ObjectWithRequiredField) MarshalJSON() ([]byte, error) {
+	type embed ObjectWithRequiredField
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *ObjectWithRequiredField) String() string {

--- a/seed/go-sdk/exhaustive/types/union.go
+++ b/seed/go-sdk/exhaustive/types/union.go
@@ -167,11 +167,15 @@ func (c *Cat) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Cat) SetName(name string) {
 	c.Name = name
 	c.require(catFieldName)
 }
 
+// SetLikesToMeow sets the LikesToMeow field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Cat) SetLikesToMeow(likesToMeow bool) {
 	c.LikesToMeow = likesToMeow
 	c.require(catFieldLikesToMeow)
@@ -257,11 +261,15 @@ func (d *Dog) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Dog) SetName(name string) {
 	d.Name = name
 	d.require(dogFieldName)
 }
 
+// SetLikesToWoof sets the LikesToWoof field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Dog) SetLikesToWoof(likesToWoof bool) {
 	d.LikesToWoof = likesToWoof
 	d.require(dogFieldLikesToWoof)

--- a/seed/go-sdk/exhaustive/types/union.go
+++ b/seed/go-sdk/exhaustive/types/union.go
@@ -6,6 +6,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
+	big "math/big"
 )
 
 type Animal struct {
@@ -125,9 +126,17 @@ func (a *Animal) validate() error {
 	return nil
 }
 
+var (
+	catFieldName        = big.NewInt(1 << 0)
+	catFieldLikesToMeow = big.NewInt(1 << 1)
+)
+
 type Cat struct {
 	Name        string `json:"name" url:"name"`
 	LikesToMeow bool   `json:"likesToMeow" url:"likesToMeow"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -151,6 +160,23 @@ func (c *Cat) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *Cat) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Cat) SetName(name string) {
+	c.Name = name
+	c.require(catFieldName)
+}
+
+func (c *Cat) SetLikesToMeow(likesToMeow bool) {
+	c.LikesToMeow = likesToMeow
+	c.require(catFieldLikesToMeow)
+}
+
 func (c *Cat) UnmarshalJSON(data []byte) error {
 	type unmarshaler Cat
 	var value unmarshaler
@@ -167,6 +193,17 @@ func (c *Cat) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Cat) MarshalJSON() ([]byte, error) {
+	type embed Cat
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Cat) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -179,9 +216,17 @@ func (c *Cat) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	dogFieldName        = big.NewInt(1 << 0)
+	dogFieldLikesToWoof = big.NewInt(1 << 1)
+)
+
 type Dog struct {
 	Name        string `json:"name" url:"name"`
 	LikesToWoof bool   `json:"likesToWoof" url:"likesToWoof"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -205,6 +250,23 @@ func (d *Dog) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Dog) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Dog) SetName(name string) {
+	d.Name = name
+	d.require(dogFieldName)
+}
+
+func (d *Dog) SetLikesToWoof(likesToWoof bool) {
+	d.LikesToWoof = likesToWoof
+	d.require(dogFieldLikesToWoof)
+}
+
 func (d *Dog) UnmarshalJSON(data []byte) error {
 	type unmarshaler Dog
 	var value unmarshaler
@@ -219,6 +281,17 @@ func (d *Dog) UnmarshalJSON(data []byte) error {
 	d.extraProperties = extraProperties
 	d.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (d *Dog) MarshalJSON() ([]byte, error) {
+	type embed Dog
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (d *Dog) String() string {

--- a/seed/go-sdk/extends/internal/explicit_fields.go
+++ b/seed/go-sdk/extends/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/extends/internal/explicit_fields_test.go
+++ b/seed/go-sdk/extends/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/extends/types.go
+++ b/seed/go-sdk/extends/types.go
@@ -29,6 +29,8 @@ func (i *Inlined) require(field *big.Int) {
 	i.explicitFields.Or(i.explicitFields, field)
 }
 
+// SetUnique sets the Unique field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (i *Inlined) SetUnique(unique string) {
 	i.Unique = unique
 	i.require(inlinedFieldUnique)
@@ -66,6 +68,8 @@ func (d *Docs) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Docs) SetDocs(docs string) {
 	d.Docs = docs
 	d.require(docsFieldDocs)
@@ -151,11 +155,15 @@ func (e *ExampleType) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExampleType) SetDocs(docs string) {
 	e.Docs = docs
 	e.require(exampleTypeFieldDocs)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *ExampleType) SetName(name string) {
 	e.Name = name
 	e.require(exampleTypeFieldName)
@@ -241,11 +249,15 @@ func (j *Json) require(field *big.Int) {
 	j.explicitFields.Or(j.explicitFields, field)
 }
 
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *Json) SetDocs(docs string) {
 	j.Docs = docs
 	j.require(jsonFieldDocs)
 }
 
+// SetRaw sets the Raw field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *Json) SetRaw(raw string) {
 	j.Raw = raw
 	j.require(jsonFieldRaw)
@@ -340,16 +352,22 @@ func (n *NestedType) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedType) SetDocs(docs string) {
 	n.Docs = docs
 	n.require(nestedTypeFieldDocs)
 }
 
+// SetRaw sets the Raw field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedType) SetRaw(raw string) {
 	n.Raw = raw
 	n.require(nestedTypeFieldRaw)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedType) SetName(name string) {
 	n.Name = name
 	n.require(nestedTypeFieldName)

--- a/seed/go-sdk/extra-properties/internal/explicit_fields.go
+++ b/seed/go-sdk/extra-properties/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/extra-properties/internal/explicit_fields_test.go
+++ b/seed/go-sdk/extra-properties/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/extra-properties/types.go
+++ b/seed/go-sdk/extra-properties/types.go
@@ -6,10 +6,14 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/extra-properties/fern/internal"
+	big "math/big"
 )
 
 type Failure struct {
-	status string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	status         string
 
 	ExtraProperties map[string]interface{} `json:"-" url:"-"`
 
@@ -22,6 +26,13 @@ func (f *Failure) Status() string {
 
 func (f *Failure) GetExtraProperties() map[string]interface{} {
 	return f.ExtraProperties
+}
+
+func (f *Failure) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
 }
 
 func (f *Failure) UnmarshalJSON(data []byte) error {
@@ -58,7 +69,8 @@ func (f *Failure) MarshalJSON() ([]byte, error) {
 		embed:  embed(*f),
 		Status: "failure",
 	}
-	return internal.MarshalJSONWithExtraProperties(marshaler, f.ExtraProperties)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return internal.MarshalJSONWithExtraProperties(explicitMarshaler, f.ExtraProperties)
 }
 
 func (f *Failure) String() string {

--- a/seed/go-sdk/extra-properties/user.go
+++ b/seed/go-sdk/extra-properties/user.go
@@ -6,6 +6,11 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/extra-properties/fern/internal"
+	big "math/big"
+)
+
+var (
+	createUserRequestFieldName = big.NewInt(1 << 0)
 )
 
 type CreateUserRequest struct {
@@ -14,6 +19,9 @@ type CreateUserRequest struct {
 	version string
 
 	ExtraProperties map[string]interface{} `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (c *CreateUserRequest) Type() string {
@@ -22,6 +30,18 @@ func (c *CreateUserRequest) Type() string {
 
 func (c *CreateUserRequest) Version() string {
 	return c.version
+}
+
+func (c *CreateUserRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateUserRequest) SetName(name string) {
+	c.Name = name
+	c.require(createUserRequestFieldName)
 }
 
 func (c *CreateUserRequest) UnmarshalJSON(data []byte) error {
@@ -53,11 +73,19 @@ func (c *CreateUserRequest) MarshalJSON() ([]byte, error) {
 		Type:    "CreateUserRequest",
 		Version: "v1",
 	}
-	return internal.MarshalJSONWithExtraProperties(marshaler, c.ExtraProperties)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return internal.MarshalJSONWithExtraProperties(explicitMarshaler, c.ExtraProperties)
 }
+
+var (
+	userFieldName = big.NewInt(1 << 0)
+)
 
 type User struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	ExtraProperties map[string]interface{} `json:"-" url:"-"`
 
@@ -73,6 +101,18 @@ func (u *User) GetName() string {
 
 func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.ExtraProperties
+}
+
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
 }
 
 func (u *User) UnmarshalJSON(data []byte) error {
@@ -102,7 +142,8 @@ func (u *User) MarshalJSON() ([]byte, error) {
 	}{
 		embed: embed(*u),
 	}
-	return internal.MarshalJSONWithExtraProperties(marshaler, u.ExtraProperties)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return internal.MarshalJSONWithExtraProperties(explicitMarshaler, u.ExtraProperties)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/extra-properties/user.go
+++ b/seed/go-sdk/extra-properties/user.go
@@ -39,6 +39,8 @@ func (c *CreateUserRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetName(name string) {
 	c.Name = name
 	c.require(createUserRequestFieldName)
@@ -110,6 +112,8 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)

--- a/seed/go-sdk/file-download/internal/explicit_fields.go
+++ b/seed/go-sdk/file-download/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/file-download/internal/explicit_fields_test.go
+++ b/seed/go-sdk/file-download/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/file-upload/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/file-upload/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/file-upload/no-custom-config/service.go
+++ b/seed/go-sdk/file-upload/no-custom-config/service.go
@@ -51,26 +51,36 @@ func (j *JustFileWithQueryParamsRequest) require(field *big.Int) {
 	j.explicitFields.Or(j.explicitFields, field)
 }
 
+// SetMaybeString sets the MaybeString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetMaybeString(maybeString *string) {
 	j.MaybeString = maybeString
 	j.require(justFileWithQueryParamsRequestFieldMaybeString)
 }
 
+// SetInteger sets the Integer field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetInteger(integer int) {
 	j.Integer = integer
 	j.require(justFileWithQueryParamsRequestFieldInteger)
 }
 
+// SetMaybeInteger sets the MaybeInteger field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetMaybeInteger(maybeInteger *int) {
 	j.MaybeInteger = maybeInteger
 	j.require(justFileWithQueryParamsRequestFieldMaybeInteger)
 }
 
+// SetListOfStrings sets the ListOfStrings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetListOfStrings(listOfStrings []string) {
 	j.ListOfStrings = listOfStrings
 	j.require(justFileWithQueryParamsRequestFieldListOfStrings)
 }
 
+// SetOptionalListOfStrings sets the OptionalListOfStrings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetOptionalListOfStrings(optionalListOfStrings []*string) {
 	j.OptionalListOfStrings = optionalListOfStrings
 	j.require(justFileWithQueryParamsRequestFieldOptionalListOfStrings)
@@ -157,6 +167,8 @@ func (m *MyInlineType) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetBar sets the Bar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyInlineType) SetBar(bar string) {
 	m.Bar = bar
 	m.require(myInlineTypeFieldBar)
@@ -233,6 +245,8 @@ func (m *MyObject) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObject) SetFoo(foo string) {
 	m.Foo = foo
 	m.require(myObjectFieldFoo)
@@ -318,11 +332,15 @@ func (m *MyObjectWithOptional) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetProp sets the Prop field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObjectWithOptional) SetProp(prop string) {
 	m.Prop = prop
 	m.require(myObjectWithOptionalFieldProp)
 }
 
+// SetOptionalProp sets the OptionalProp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObjectWithOptional) SetOptionalProp(optionalProp *string) {
 	m.OptionalProp = optionalProp
 	m.require(myObjectWithOptionalFieldOptionalProp)

--- a/seed/go-sdk/file-upload/package-name/internal/explicit_fields.go
+++ b/seed/go-sdk/file-upload/package-name/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/file-upload/package-name/internal/explicit_fields_test.go
+++ b/seed/go-sdk/file-upload/package-name/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/file-upload/package-name/service.go
+++ b/seed/go-sdk/file-upload/package-name/service.go
@@ -7,11 +7,30 @@ import (
 	fmt "fmt"
 	internal "github.com/fern-api/file-upload-go/internal"
 	io "io"
+	big "math/big"
 )
 
 type JustFileRequest struct {
 	File io.Reader `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (j *JustFileRequest) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+var (
+	justFileWithQueryParamsRequestFieldMaybeString           = big.NewInt(1 << 0)
+	justFileWithQueryParamsRequestFieldInteger               = big.NewInt(1 << 1)
+	justFileWithQueryParamsRequestFieldMaybeInteger          = big.NewInt(1 << 2)
+	justFileWithQueryParamsRequestFieldListOfStrings         = big.NewInt(1 << 3)
+	justFileWithQueryParamsRequestFieldOptionalListOfStrings = big.NewInt(1 << 4)
+)
 
 type JustFileWithQueryParamsRequest struct {
 	MaybeString           *string   `json:"-" url:"maybeString,omitempty"`
@@ -20,11 +39,56 @@ type JustFileWithQueryParamsRequest struct {
 	ListOfStrings         []string  `json:"-" url:"listOfStrings"`
 	OptionalListOfStrings []*string `json:"-" url:"optionalListOfStrings,omitempty"`
 	File                  io.Reader `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (j *JustFileWithQueryParamsRequest) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetMaybeString(maybeString *string) {
+	j.MaybeString = maybeString
+	j.require(justFileWithQueryParamsRequestFieldMaybeString)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetInteger(integer int) {
+	j.Integer = integer
+	j.require(justFileWithQueryParamsRequestFieldInteger)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetMaybeInteger(maybeInteger *int) {
+	j.MaybeInteger = maybeInteger
+	j.require(justFileWithQueryParamsRequestFieldMaybeInteger)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetListOfStrings(listOfStrings []string) {
+	j.ListOfStrings = listOfStrings
+	j.require(justFileWithQueryParamsRequestFieldListOfStrings)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetOptionalListOfStrings(optionalListOfStrings []*string) {
+	j.OptionalListOfStrings = optionalListOfStrings
+	j.require(justFileWithQueryParamsRequestFieldOptionalListOfStrings)
 }
 
 type OptionalArgsRequest struct {
 	ImageFile io.Reader   `json:"-" url:"-"`
 	Request   interface{} `json:"request,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (o *OptionalArgsRequest) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
 }
 
 type MyRequest struct {
@@ -43,6 +107,16 @@ type MyRequest struct {
 	AliasObject           MyAliasObject           `json:"alias_object,omitempty" url:"-"`
 	ListOfAliasObject     []MyAliasObject         `json:"list_of_alias_object,omitempty" url:"-"`
 	AliasListOfObject     MyCollectionAliasObject `json:"alias_list_of_object,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (m *MyRequest) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
 }
 
 type Id = string
@@ -51,8 +125,15 @@ type MyAliasObject = *MyObject
 
 type MyCollectionAliasObject = []*MyObject
 
+var (
+	myInlineTypeFieldBar = big.NewInt(1 << 0)
+)
+
 type MyInlineType struct {
 	Bar string `json:"bar" url:"bar"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -67,6 +148,18 @@ func (m *MyInlineType) GetBar() string {
 
 func (m *MyInlineType) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MyInlineType) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MyInlineType) SetBar(bar string) {
+	m.Bar = bar
+	m.require(myInlineTypeFieldBar)
 }
 
 func (m *MyInlineType) UnmarshalJSON(data []byte) error {
@@ -85,6 +178,17 @@ func (m *MyInlineType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MyInlineType) MarshalJSON() ([]byte, error) {
+	type embed MyInlineType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MyInlineType) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -97,8 +201,15 @@ func (m *MyInlineType) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	myObjectFieldFoo = big.NewInt(1 << 0)
+)
+
 type MyObject struct {
 	Foo string `json:"foo" url:"foo"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -113,6 +224,18 @@ func (m *MyObject) GetFoo() string {
 
 func (m *MyObject) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MyObject) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MyObject) SetFoo(foo string) {
+	m.Foo = foo
+	m.require(myObjectFieldFoo)
 }
 
 func (m *MyObject) UnmarshalJSON(data []byte) error {
@@ -131,6 +254,17 @@ func (m *MyObject) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MyObject) MarshalJSON() ([]byte, error) {
+	type embed MyObject
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MyObject) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -143,9 +277,17 @@ func (m *MyObject) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	myObjectWithOptionalFieldProp         = big.NewInt(1 << 0)
+	myObjectWithOptionalFieldOptionalProp = big.NewInt(1 << 1)
+)
+
 type MyObjectWithOptional struct {
 	Prop         string  `json:"prop" url:"prop"`
 	OptionalProp *string `json:"optionalProp,omitempty" url:"optionalProp,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -169,6 +311,23 @@ func (m *MyObjectWithOptional) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *MyObjectWithOptional) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MyObjectWithOptional) SetProp(prop string) {
+	m.Prop = prop
+	m.require(myObjectWithOptionalFieldProp)
+}
+
+func (m *MyObjectWithOptional) SetOptionalProp(optionalProp *string) {
+	m.OptionalProp = optionalProp
+	m.require(myObjectWithOptionalFieldOptionalProp)
+}
+
 func (m *MyObjectWithOptional) UnmarshalJSON(data []byte) error {
 	type unmarshaler MyObjectWithOptional
 	var value unmarshaler
@@ -183,6 +342,17 @@ func (m *MyObjectWithOptional) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *MyObjectWithOptional) MarshalJSON() ([]byte, error) {
+	type embed MyObjectWithOptional
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *MyObjectWithOptional) String() string {
@@ -224,6 +394,16 @@ type WithContentTypeRequest struct {
 	Foo    string    `json:"foo" url:"-"`
 	Bar    *MyObject `json:"bar,omitempty" url:"-"`
 	FooBar *MyObject `json:"foo_bar,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (w *WithContentTypeRequest) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
 }
 
 type MyOtherRequest struct {
@@ -243,15 +423,45 @@ type MyOtherRequest struct {
 	AliasObject                MyAliasObject           `json:"alias_object,omitempty" url:"-"`
 	ListOfAliasObject          []MyAliasObject         `json:"list_of_alias_object,omitempty" url:"-"`
 	AliasListOfObject          MyCollectionAliasObject `json:"alias_list_of_object,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (m *MyOtherRequest) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
 }
 
 type WithFormEncodingRequest struct {
 	File io.Reader `json:"-" url:"-"`
 	Foo  string    `json:"foo" url:"-"`
 	Bar  *MyObject `json:"bar,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (w *WithFormEncodingRequest) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
 }
 
 type InlineTypeRequest struct {
 	File    io.Reader     `json:"-" url:"-"`
 	Request *MyInlineType `json:"request,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (i *InlineTypeRequest) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
 }

--- a/seed/go-sdk/file-upload/package-name/service.go
+++ b/seed/go-sdk/file-upload/package-name/service.go
@@ -51,26 +51,36 @@ func (j *JustFileWithQueryParamsRequest) require(field *big.Int) {
 	j.explicitFields.Or(j.explicitFields, field)
 }
 
+// SetMaybeString sets the MaybeString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetMaybeString(maybeString *string) {
 	j.MaybeString = maybeString
 	j.require(justFileWithQueryParamsRequestFieldMaybeString)
 }
 
+// SetInteger sets the Integer field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetInteger(integer int) {
 	j.Integer = integer
 	j.require(justFileWithQueryParamsRequestFieldInteger)
 }
 
+// SetMaybeInteger sets the MaybeInteger field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetMaybeInteger(maybeInteger *int) {
 	j.MaybeInteger = maybeInteger
 	j.require(justFileWithQueryParamsRequestFieldMaybeInteger)
 }
 
+// SetListOfStrings sets the ListOfStrings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetListOfStrings(listOfStrings []string) {
 	j.ListOfStrings = listOfStrings
 	j.require(justFileWithQueryParamsRequestFieldListOfStrings)
 }
 
+// SetOptionalListOfStrings sets the OptionalListOfStrings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetOptionalListOfStrings(optionalListOfStrings []*string) {
 	j.OptionalListOfStrings = optionalListOfStrings
 	j.require(justFileWithQueryParamsRequestFieldOptionalListOfStrings)
@@ -157,6 +167,8 @@ func (m *MyInlineType) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetBar sets the Bar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyInlineType) SetBar(bar string) {
 	m.Bar = bar
 	m.require(myInlineTypeFieldBar)
@@ -233,6 +245,8 @@ func (m *MyObject) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObject) SetFoo(foo string) {
 	m.Foo = foo
 	m.require(myObjectFieldFoo)
@@ -318,11 +332,15 @@ func (m *MyObjectWithOptional) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetProp sets the Prop field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObjectWithOptional) SetProp(prop string) {
 	m.Prop = prop
 	m.require(myObjectWithOptionalFieldProp)
 }
 
+// SetOptionalProp sets the OptionalProp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObjectWithOptional) SetOptionalProp(optionalProp *string) {
 	m.OptionalProp = optionalProp
 	m.require(myObjectWithOptionalFieldOptionalProp)

--- a/seed/go-sdk/file-upload/v0/internal/explicit_fields.go
+++ b/seed/go-sdk/file-upload/v0/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/file-upload/v0/internal/explicit_fields_test.go
+++ b/seed/go-sdk/file-upload/v0/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/file-upload/v0/service.go
+++ b/seed/go-sdk/file-upload/v0/service.go
@@ -35,26 +35,36 @@ func (j *JustFileWithQueryParamsRequest) require(field *big.Int) {
 	j.explicitFields.Or(j.explicitFields, field)
 }
 
+// SetMaybeString sets the MaybeString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetMaybeString(maybeString *string) {
 	j.MaybeString = maybeString
 	j.require(justFileWithQueryParamsRequestFieldMaybeString)
 }
 
+// SetInteger sets the Integer field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetInteger(integer int) {
 	j.Integer = integer
 	j.require(justFileWithQueryParamsRequestFieldInteger)
 }
 
+// SetMaybeInteger sets the MaybeInteger field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetMaybeInteger(maybeInteger *int) {
 	j.MaybeInteger = maybeInteger
 	j.require(justFileWithQueryParamsRequestFieldMaybeInteger)
 }
 
+// SetListOfStrings sets the ListOfStrings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetListOfStrings(listOfStrings []string) {
 	j.ListOfStrings = listOfStrings
 	j.require(justFileWithQueryParamsRequestFieldListOfStrings)
 }
 
+// SetOptionalListOfStrings sets the OptionalListOfStrings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JustFileWithQueryParamsRequest) SetOptionalListOfStrings(optionalListOfStrings []*string) {
 	j.OptionalListOfStrings = optionalListOfStrings
 	j.require(justFileWithQueryParamsRequestFieldOptionalListOfStrings)
@@ -136,6 +146,8 @@ func (m *MyInlineType) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetBar sets the Bar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyInlineType) SetBar(bar string) {
 	m.Bar = bar
 	m.require(myInlineTypeFieldBar)
@@ -212,6 +224,8 @@ func (m *MyObject) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObject) SetFoo(foo string) {
 	m.Foo = foo
 	m.require(myObjectFieldFoo)
@@ -297,11 +311,15 @@ func (m *MyObjectWithOptional) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetProp sets the Prop field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObjectWithOptional) SetProp(prop string) {
 	m.Prop = prop
 	m.require(myObjectWithOptionalFieldProp)
 }
 
+// SetOptionalProp sets the OptionalProp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObjectWithOptional) SetOptionalProp(optionalProp *string) {
 	m.OptionalProp = optionalProp
 	m.require(myObjectWithOptionalFieldOptionalProp)

--- a/seed/go-sdk/file-upload/v0/service.go
+++ b/seed/go-sdk/file-upload/v0/service.go
@@ -6,6 +6,15 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/file-upload/fern/internal"
+	big "math/big"
+)
+
+var (
+	justFileWithQueryParamsRequestFieldMaybeString           = big.NewInt(1 << 0)
+	justFileWithQueryParamsRequestFieldInteger               = big.NewInt(1 << 1)
+	justFileWithQueryParamsRequestFieldMaybeInteger          = big.NewInt(1 << 2)
+	justFileWithQueryParamsRequestFieldListOfStrings         = big.NewInt(1 << 3)
+	justFileWithQueryParamsRequestFieldOptionalListOfStrings = big.NewInt(1 << 4)
 )
 
 type JustFileWithQueryParamsRequest struct {
@@ -14,10 +23,55 @@ type JustFileWithQueryParamsRequest struct {
 	MaybeInteger          *int      `json:"-" url:"maybeInteger,omitempty"`
 	ListOfStrings         []string  `json:"-" url:"listOfStrings"`
 	OptionalListOfStrings []*string `json:"-" url:"optionalListOfStrings,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (j *JustFileWithQueryParamsRequest) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetMaybeString(maybeString *string) {
+	j.MaybeString = maybeString
+	j.require(justFileWithQueryParamsRequestFieldMaybeString)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetInteger(integer int) {
+	j.Integer = integer
+	j.require(justFileWithQueryParamsRequestFieldInteger)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetMaybeInteger(maybeInteger *int) {
+	j.MaybeInteger = maybeInteger
+	j.require(justFileWithQueryParamsRequestFieldMaybeInteger)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetListOfStrings(listOfStrings []string) {
+	j.ListOfStrings = listOfStrings
+	j.require(justFileWithQueryParamsRequestFieldListOfStrings)
+}
+
+func (j *JustFileWithQueryParamsRequest) SetOptionalListOfStrings(optionalListOfStrings []*string) {
+	j.OptionalListOfStrings = optionalListOfStrings
+	j.require(justFileWithQueryParamsRequestFieldOptionalListOfStrings)
 }
 
 type OptionalArgsRequest struct {
 	Request interface{} `json:"request,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (o *OptionalArgsRequest) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
 }
 
 type MyRequest struct {
@@ -32,6 +86,16 @@ type MyRequest struct {
 	AliasObject           MyAliasObject           `json:"alias_object,omitempty" url:"-"`
 	ListOfAliasObject     []MyAliasObject         `json:"list_of_alias_object,omitempty" url:"-"`
 	AliasListOfObject     MyCollectionAliasObject `json:"alias_list_of_object,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (m *MyRequest) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
 }
 
 type Id = string
@@ -40,8 +104,15 @@ type MyAliasObject = *MyObject
 
 type MyCollectionAliasObject = []*MyObject
 
+var (
+	myInlineTypeFieldBar = big.NewInt(1 << 0)
+)
+
 type MyInlineType struct {
 	Bar string `json:"bar" url:"bar"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -56,6 +127,18 @@ func (m *MyInlineType) GetBar() string {
 
 func (m *MyInlineType) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MyInlineType) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MyInlineType) SetBar(bar string) {
+	m.Bar = bar
+	m.require(myInlineTypeFieldBar)
 }
 
 func (m *MyInlineType) UnmarshalJSON(data []byte) error {
@@ -74,6 +157,17 @@ func (m *MyInlineType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MyInlineType) MarshalJSON() ([]byte, error) {
+	type embed MyInlineType
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MyInlineType) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -86,8 +180,15 @@ func (m *MyInlineType) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	myObjectFieldFoo = big.NewInt(1 << 0)
+)
+
 type MyObject struct {
 	Foo string `json:"foo" url:"foo"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -102,6 +203,18 @@ func (m *MyObject) GetFoo() string {
 
 func (m *MyObject) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MyObject) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MyObject) SetFoo(foo string) {
+	m.Foo = foo
+	m.require(myObjectFieldFoo)
 }
 
 func (m *MyObject) UnmarshalJSON(data []byte) error {
@@ -120,6 +233,17 @@ func (m *MyObject) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MyObject) MarshalJSON() ([]byte, error) {
+	type embed MyObject
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MyObject) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -132,9 +256,17 @@ func (m *MyObject) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	myObjectWithOptionalFieldProp         = big.NewInt(1 << 0)
+	myObjectWithOptionalFieldOptionalProp = big.NewInt(1 << 1)
+)
+
 type MyObjectWithOptional struct {
 	Prop         string  `json:"prop" url:"prop"`
 	OptionalProp *string `json:"optionalProp,omitempty" url:"optionalProp,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -158,6 +290,23 @@ func (m *MyObjectWithOptional) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *MyObjectWithOptional) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MyObjectWithOptional) SetProp(prop string) {
+	m.Prop = prop
+	m.require(myObjectWithOptionalFieldProp)
+}
+
+func (m *MyObjectWithOptional) SetOptionalProp(optionalProp *string) {
+	m.OptionalProp = optionalProp
+	m.require(myObjectWithOptionalFieldOptionalProp)
+}
+
 func (m *MyObjectWithOptional) UnmarshalJSON(data []byte) error {
 	type unmarshaler MyObjectWithOptional
 	var value unmarshaler
@@ -172,6 +321,17 @@ func (m *MyObjectWithOptional) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *MyObjectWithOptional) MarshalJSON() ([]byte, error) {
+	type embed MyObjectWithOptional
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *MyObjectWithOptional) String() string {
@@ -212,6 +372,16 @@ type WithContentTypeRequest struct {
 	Foo    string    `json:"foo" url:"-"`
 	Bar    *MyObject `json:"bar,omitempty" url:"-"`
 	FooBar *MyObject `json:"foo_bar,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (w *WithContentTypeRequest) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
 }
 
 type MyOtherRequest struct {
@@ -227,13 +397,43 @@ type MyOtherRequest struct {
 	AliasObject                MyAliasObject           `json:"alias_object,omitempty" url:"-"`
 	ListOfAliasObject          []MyAliasObject         `json:"list_of_alias_object,omitempty" url:"-"`
 	AliasListOfObject          MyCollectionAliasObject `json:"alias_list_of_object,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (m *MyOtherRequest) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
 }
 
 type WithFormEncodingRequest struct {
 	Foo string    `json:"foo" url:"-"`
 	Bar *MyObject `json:"bar,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (w *WithFormEncodingRequest) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
 }
 
 type InlineTypeRequest struct {
 	Request *MyInlineType `json:"request,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (i *InlineTypeRequest) require(field *big.Int) {
+	if i.explicitFields == nil {
+		i.explicitFields = big.NewInt(0)
+	}
+	i.explicitFields.Or(i.explicitFields, field)
 }

--- a/seed/go-sdk/folders/internal/explicit_fields.go
+++ b/seed/go-sdk/folders/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/folders/internal/explicit_fields_test.go
+++ b/seed/go-sdk/folders/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/explicit_fields.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/explicit_fields_test.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/go-content-type/imdb.go
+++ b/seed/go-sdk/go-content-type/imdb.go
@@ -50,11 +50,15 @@ func (c *CreateMovieRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetTitle(title string) {
 	c.Title = title
 	c.require(createMovieRequestFieldTitle)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetRating(rating float64) {
 	c.Rating = rating
 	c.require(createMovieRequestFieldRating)

--- a/seed/go-sdk/go-content-type/imdb.go
+++ b/seed/go-sdk/go-content-type/imdb.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/go-content-type/fern/internal"
+	big "math/big"
+)
+
+var (
+	createMovieRequestFieldTitle  = big.NewInt(1 << 0)
+	createMovieRequestFieldRating = big.NewInt(1 << 1)
 )
 
 type CreateMovieRequest struct {
 	Title  string  `json:"title" url:"title"`
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateMovieRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateMovieRequest) SetTitle(title string) {
+	c.Title = title
+	c.require(createMovieRequestFieldTitle)
+}
+
+func (c *CreateMovieRequest) SetRating(rating float64) {
+	c.Rating = rating
+	c.require(createMovieRequestFieldRating)
+}
+
 func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateMovieRequest
 	var value unmarshaler
@@ -48,6 +74,17 @@ func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	c.extraProperties = extraProperties
 	c.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (c *CreateMovieRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateMovieRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (c *CreateMovieRequest) String() string {

--- a/seed/go-sdk/go-content-type/internal/explicit_fields.go
+++ b/seed/go-sdk/go-content-type/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/go-content-type/internal/explicit_fields_test.go
+++ b/seed/go-sdk/go-content-type/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/http-head/internal/explicit_fields.go
+++ b/seed/go-sdk/http-head/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/http-head/internal/explicit_fields_test.go
+++ b/seed/go-sdk/http-head/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/http-head/user.go
+++ b/seed/go-sdk/http-head/user.go
@@ -6,15 +6,43 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/http-head/fern/internal"
+	big "math/big"
+)
+
+var (
+	listUsersRequestFieldLimit = big.NewInt(1 << 0)
 )
 
 type ListUsersRequest struct {
 	Limit int `json:"-" url:"limit"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersRequest) SetLimit(limit int) {
+	l.Limit = limit
+	l.require(listUsersRequestFieldLimit)
+}
+
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
 
 type User struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags" url:"tags"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -38,6 +66,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -52,6 +97,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/http-head/user.go
+++ b/seed/go-sdk/http-head/user.go
@@ -27,6 +27,8 @@ func (l *ListUsersRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetLimit(limit int) {
 	l.Limit = limit
 	l.require(listUsersRequestFieldLimit)
@@ -73,11 +75,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)

--- a/seed/go-sdk/idempotency-headers/internal/explicit_fields.go
+++ b/seed/go-sdk/idempotency-headers/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/idempotency-headers/internal/explicit_fields_test.go
+++ b/seed/go-sdk/idempotency-headers/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/idempotency-headers/payment.go
+++ b/seed/go-sdk/idempotency-headers/payment.go
@@ -4,11 +4,37 @@ package fern
 
 import (
 	fmt "fmt"
+	big "math/big"
+)
+
+var (
+	createPaymentRequestFieldAmount   = big.NewInt(1 << 0)
+	createPaymentRequestFieldCurrency = big.NewInt(1 << 1)
 )
 
 type CreatePaymentRequest struct {
 	Amount   int      `json:"amount" url:"-"`
 	Currency Currency `json:"currency" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (c *CreatePaymentRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreatePaymentRequest) SetAmount(amount int) {
+	c.Amount = amount
+	c.require(createPaymentRequestFieldAmount)
+}
+
+func (c *CreatePaymentRequest) SetCurrency(currency Currency) {
+	c.Currency = currency
+	c.require(createPaymentRequestFieldCurrency)
 }
 
 type Currency string

--- a/seed/go-sdk/idempotency-headers/payment.go
+++ b/seed/go-sdk/idempotency-headers/payment.go
@@ -27,11 +27,15 @@ func (c *CreatePaymentRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetAmount sets the Amount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreatePaymentRequest) SetAmount(amount int) {
 	c.Amount = amount
 	c.require(createPaymentRequestFieldAmount)
 }
 
+// SetCurrency sets the Currency field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreatePaymentRequest) SetCurrency(currency Currency) {
 	c.Currency = currency
 	c.require(createPaymentRequestFieldCurrency)

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/imdb.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/imdb.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/imdb/fern/all/the/way/in/here/please/internal"
+	big "math/big"
+)
+
+var (
+	createMovieRequestFieldTitle  = big.NewInt(1 << 0)
+	createMovieRequestFieldRating = big.NewInt(1 << 1)
 )
 
 type CreateMovieRequest struct {
 	Title  string  `json:"title" url:"title"`
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateMovieRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateMovieRequest) SetTitle(title string) {
+	c.Title = title
+	c.require(createMovieRequestFieldTitle)
+}
+
+func (c *CreateMovieRequest) SetRating(rating float64) {
+	c.Rating = rating
+	c.require(createMovieRequestFieldRating)
+}
+
 func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateMovieRequest
 	var value unmarshaler
@@ -50,6 +76,17 @@ func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateMovieRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateMovieRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateMovieRequest) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -62,11 +99,20 @@ func (c *CreateMovieRequest) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	movieFieldId     = big.NewInt(1 << 0)
+	movieFieldTitle  = big.NewInt(1 << 1)
+	movieFieldRating = big.NewInt(1 << 2)
+)
+
 type Movie struct {
 	Id    MovieId `json:"id" url:"id"`
 	Title string  `json:"title" url:"title"`
 	// The rating scale is one to five stars
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -97,6 +143,28 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type unmarshaler Movie
 	var value unmarshaler
@@ -111,6 +179,17 @@ func (m *Movie) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Movie) MarshalJSON() ([]byte, error) {
+	type embed Movie
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/imdb.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/imdb.go
@@ -50,11 +50,15 @@ func (c *CreateMovieRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetTitle(title string) {
 	c.Title = title
 	c.require(createMovieRequestFieldTitle)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetRating(rating float64) {
 	c.Rating = rating
 	c.require(createMovieRequestFieldRating)
@@ -150,16 +154,22 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/explicit_fields.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/explicit_fields_test.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/imdb/no-custom-config/imdb.go
+++ b/seed/go-sdk/imdb/no-custom-config/imdb.go
@@ -50,11 +50,15 @@ func (c *CreateMovieRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetTitle(title string) {
 	c.Title = title
 	c.require(createMovieRequestFieldTitle)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetRating(rating float64) {
 	c.Rating = rating
 	c.require(createMovieRequestFieldRating)
@@ -150,16 +154,22 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)

--- a/seed/go-sdk/imdb/no-custom-config/imdb.go
+++ b/seed/go-sdk/imdb/no-custom-config/imdb.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/imdb/fern/internal"
+	big "math/big"
+)
+
+var (
+	createMovieRequestFieldTitle  = big.NewInt(1 << 0)
+	createMovieRequestFieldRating = big.NewInt(1 << 1)
 )
 
 type CreateMovieRequest struct {
 	Title  string  `json:"title" url:"title"`
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateMovieRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateMovieRequest) SetTitle(title string) {
+	c.Title = title
+	c.require(createMovieRequestFieldTitle)
+}
+
+func (c *CreateMovieRequest) SetRating(rating float64) {
+	c.Rating = rating
+	c.require(createMovieRequestFieldRating)
+}
+
 func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateMovieRequest
 	var value unmarshaler
@@ -50,6 +76,17 @@ func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateMovieRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateMovieRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateMovieRequest) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -62,11 +99,20 @@ func (c *CreateMovieRequest) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	movieFieldId     = big.NewInt(1 << 0)
+	movieFieldTitle  = big.NewInt(1 << 1)
+	movieFieldRating = big.NewInt(1 << 2)
+)
+
 type Movie struct {
 	Id    MovieId `json:"id" url:"id"`
 	Title string  `json:"title" url:"title"`
 	// The rating scale is one to five stars
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -97,6 +143,28 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type unmarshaler Movie
 	var value unmarshaler
@@ -111,6 +179,17 @@ func (m *Movie) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Movie) MarshalJSON() ([]byte, error) {
+	type embed Movie
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {

--- a/seed/go-sdk/imdb/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/imdb/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/imdb/package-path/inhereplease/imdb.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/imdb.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/imdb/fern/inhereplease/internal"
+	big "math/big"
+)
+
+var (
+	createMovieRequestFieldTitle  = big.NewInt(1 << 0)
+	createMovieRequestFieldRating = big.NewInt(1 << 1)
 )
 
 type CreateMovieRequest struct {
 	Title  string  `json:"title" url:"title"`
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (c *CreateMovieRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateMovieRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateMovieRequest) SetTitle(title string) {
+	c.Title = title
+	c.require(createMovieRequestFieldTitle)
+}
+
+func (c *CreateMovieRequest) SetRating(rating float64) {
+	c.Rating = rating
+	c.require(createMovieRequestFieldRating)
+}
+
 func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateMovieRequest
 	var value unmarshaler
@@ -50,6 +76,17 @@ func (c *CreateMovieRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateMovieRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateMovieRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateMovieRequest) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -62,11 +99,20 @@ func (c *CreateMovieRequest) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	movieFieldId     = big.NewInt(1 << 0)
+	movieFieldTitle  = big.NewInt(1 << 1)
+	movieFieldRating = big.NewInt(1 << 2)
+)
+
 type Movie struct {
 	Id    MovieId `json:"id" url:"id"`
 	Title string  `json:"title" url:"title"`
 	// The rating scale is one to five stars
 	Rating float64 `json:"rating" url:"rating"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -97,6 +143,28 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id MovieId) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetTitle(title string) {
+	m.Title = title
+	m.require(movieFieldTitle)
+}
+
+func (m *Movie) SetRating(rating float64) {
+	m.Rating = rating
+	m.require(movieFieldRating)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type unmarshaler Movie
 	var value unmarshaler
@@ -111,6 +179,17 @@ func (m *Movie) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Movie) MarshalJSON() ([]byte, error) {
+	type embed Movie
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Movie) String() string {

--- a/seed/go-sdk/imdb/package-path/inhereplease/imdb.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/imdb.go
@@ -50,11 +50,15 @@ func (c *CreateMovieRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetTitle(title string) {
 	c.Title = title
 	c.require(createMovieRequestFieldTitle)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateMovieRequest) SetRating(rating float64) {
 	c.Rating = rating
 	c.require(createMovieRequestFieldRating)
@@ -150,16 +154,22 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id MovieId) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetTitle(title string) {
 	m.Title = title
 	m.require(movieFieldTitle)
 }
 
+// SetRating sets the Rating field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetRating(rating float64) {
 	m.Rating = rating
 	m.require(movieFieldRating)

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/explicit_fields.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/explicit_fields_test.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/inferred-auth-explicit/auth.go
+++ b/seed/go-sdk/inferred-auth-explicit/auth.go
@@ -43,21 +43,29 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
 	g.XApiKey = xApiKey
 	g.require(getTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -126,26 +134,36 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
 	r.XApiKey = xApiKey
 	r.require(refreshTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -229,16 +247,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/inferred-auth-explicit/auth.go
+++ b/seed/go-sdk/inferred-auth-explicit/auth.go
@@ -6,6 +6,14 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/inferred-auth-explicit/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	getTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	getTokenRequestFieldScope        = big.NewInt(1 << 3)
 )
 
 type GetTokenRequest struct {
@@ -15,6 +23,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -23,6 +34,33 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
+	g.XApiKey = xApiKey
+	g.require(getTokenRequestFieldXApiKey)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -48,8 +86,17 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 3)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 4)
+)
 
 type RefreshTokenRequest struct {
 	XApiKey      string  `json:"-" url:"-"`
@@ -59,6 +106,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -67,6 +117,38 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
+	r.XApiKey = xApiKey
+	r.require(refreshTokenRequestFieldXApiKey)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -92,14 +174,24 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -130,6 +222,28 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -144,6 +258,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/inferred-auth-explicit/internal/explicit_fields.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/inferred-auth-explicit/internal/explicit_fields_test.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/auth.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/auth.go
@@ -6,6 +6,14 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/inferred-auth-implicit-no-expiry/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	getTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	getTokenRequestFieldScope        = big.NewInt(1 << 3)
 )
 
 type GetTokenRequest struct {
@@ -15,6 +23,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -23,6 +34,33 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
+	g.XApiKey = xApiKey
+	g.require(getTokenRequestFieldXApiKey)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -48,8 +86,17 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 3)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 4)
+)
 
 type RefreshTokenRequest struct {
 	XApiKey      string  `json:"-" url:"-"`
@@ -59,6 +106,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -67,6 +117,38 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
+	r.XApiKey = xApiKey
+	r.require(refreshTokenRequestFieldXApiKey)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -92,13 +174,22 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 1)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -122,6 +213,23 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -136,6 +244,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/auth.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/auth.go
@@ -43,21 +43,29 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
 	g.XApiKey = xApiKey
 	g.require(getTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -126,26 +134,36 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
 	r.XApiKey = xApiKey
 	r.require(refreshTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -220,11 +238,15 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/explicit_fields.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/explicit_fields_test.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/inferred-auth-implicit/auth.go
+++ b/seed/go-sdk/inferred-auth-implicit/auth.go
@@ -43,21 +43,29 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
 	g.XApiKey = xApiKey
 	g.require(getTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -126,26 +134,36 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
 	r.XApiKey = xApiKey
 	r.require(refreshTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -229,16 +247,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/inferred-auth-implicit/auth.go
+++ b/seed/go-sdk/inferred-auth-implicit/auth.go
@@ -6,6 +6,14 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/inferred-auth-implicit/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	getTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	getTokenRequestFieldScope        = big.NewInt(1 << 3)
 )
 
 type GetTokenRequest struct {
@@ -15,6 +23,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -23,6 +34,33 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
+	g.XApiKey = xApiKey
+	g.require(getTokenRequestFieldXApiKey)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -48,8 +86,17 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 3)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 4)
+)
 
 type RefreshTokenRequest struct {
 	XApiKey      string  `json:"-" url:"-"`
@@ -59,6 +106,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -67,6 +117,38 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
+	r.XApiKey = xApiKey
+	r.require(refreshTokenRequestFieldXApiKey)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -92,14 +174,24 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -130,6 +222,28 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -144,6 +258,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/inferred-auth-implicit/internal/explicit_fields.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/inferred-auth-implicit/internal/explicit_fields_test.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/license/internal/explicit_fields.go
+++ b/seed/go-sdk/license/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/license/internal/explicit_fields_test.go
+++ b/seed/go-sdk/license/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/license/types.go
+++ b/seed/go-sdk/license/types.go
@@ -42,6 +42,8 @@ func (t *Type) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetName(name string) {
 	t.Name = name
 	t.require(typeFieldName)

--- a/seed/go-sdk/license/types.go
+++ b/seed/go-sdk/license/types.go
@@ -6,11 +6,19 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/license/fern/internal"
+	big "math/big"
 )
 
 // A simple type with just a name.
+var (
+	typeFieldName = big.NewInt(1 << 0)
+)
+
 type Type struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -27,6 +35,18 @@ func (t *Type) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Type) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Type) SetName(name string) {
+	t.Name = name
+	t.require(typeFieldName)
+}
+
 func (t *Type) UnmarshalJSON(data []byte) error {
 	type unmarshaler Type
 	var value unmarshaler
@@ -41,6 +61,17 @@ func (t *Type) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Type) MarshalJSON() ([]byte, error) {
+	type embed Type
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Type) String() string {

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/mixed-case/default-values/internal/explicit_fields.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/mixed-case/default-values/internal/explicit_fields_test.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/mixed-case/default-values/service.go
+++ b/seed/go-sdk/mixed-case/default-values/service.go
@@ -6,17 +6,51 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/mixed-case/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	listResourcesRequestFieldPageLimit  = big.NewInt(1 << 0)
+	listResourcesRequestFieldBeforeDate = big.NewInt(1 << 1)
 )
 
 type ListResourcesRequest struct {
 	PageLimit  int       `json:"-" url:"page_limit"`
 	BeforeDate time.Time `json:"-" url:"beforeDate" format:"date"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListResourcesRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListResourcesRequest) SetPageLimit(pageLimit int) {
+	l.PageLimit = pageLimit
+	l.require(listResourcesRequestFieldPageLimit)
+}
+
+func (l *ListResourcesRequest) SetBeforeDate(beforeDate time.Time) {
+	l.BeforeDate = beforeDate
+	l.require(listResourcesRequestFieldBeforeDate)
+}
+
+var (
+	nestedUserFieldName       = big.NewInt(1 << 0)
+	nestedUserFieldNestedUser = big.NewInt(1 << 1)
+)
 
 type NestedUser struct {
 	Name       string `json:"Name" url:"Name"`
 	NestedUser *User  `json:"NestedUser" url:"NestedUser"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -40,6 +74,23 @@ func (n *NestedUser) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedUser) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NestedUser) SetName(name string) {
+	n.Name = name
+	n.require(nestedUserFieldName)
+}
+
+func (n *NestedUser) SetNestedUser(nestedUser *User) {
+	n.NestedUser = nestedUser
+	n.require(nestedUserFieldNestedUser)
+}
+
 func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedUser
 	var value unmarshaler
@@ -56,6 +107,17 @@ func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedUser) MarshalJSON() ([]byte, error) {
+	type embed NestedUser
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedUser) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -68,8 +130,15 @@ func (n *NestedUser) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	organizationFieldName = big.NewInt(1 << 0)
+)
+
 type Organization struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -86,6 +155,18 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -100,6 +181,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *Organization) String() string {
@@ -263,10 +355,19 @@ func (r ResourceStatus) Ptr() *ResourceStatus {
 	return &r
 }
 
+var (
+	userFieldUserName        = big.NewInt(1 << 0)
+	userFieldMetadataTags    = big.NewInt(1 << 1)
+	userFieldExtraProperties = big.NewInt(1 << 2)
+)
+
 type User struct {
 	UserName        string            `json:"userName" url:"userName"`
 	MetadataTags    []string          `json:"metadata_tags" url:"metadata_tags"`
 	ExtraProperties map[string]string `json:"EXTRA_PROPERTIES" url:"EXTRA_PROPERTIES"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -297,6 +398,28 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetUserName(userName string) {
+	u.UserName = userName
+	u.require(userFieldUserName)
+}
+
+func (u *User) SetMetadataTags(metadataTags []string) {
+	u.MetadataTags = metadataTags
+	u.require(userFieldMetadataTags)
+}
+
+func (u *User) SetExtraProperties(extraProperties map[string]string) {
+	u.ExtraProperties = extraProperties
+	u.require(userFieldExtraProperties)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -311,6 +434,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/mixed-case/default-values/service.go
+++ b/seed/go-sdk/mixed-case/default-values/service.go
@@ -30,11 +30,15 @@ func (l *ListResourcesRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPageLimit sets the PageLimit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetPageLimit(pageLimit int) {
 	l.PageLimit = pageLimit
 	l.require(listResourcesRequestFieldPageLimit)
 }
 
+// SetBeforeDate sets the BeforeDate field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetBeforeDate(beforeDate time.Time) {
 	l.BeforeDate = beforeDate
 	l.require(listResourcesRequestFieldBeforeDate)
@@ -81,11 +85,15 @@ func (n *NestedUser) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetName(name string) {
 	n.Name = name
 	n.require(nestedUserFieldName)
 }
 
+// SetNestedUser sets the NestedUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetNestedUser(nestedUser *User) {
 	n.NestedUser = nestedUser
 	n.require(nestedUserFieldNestedUser)
@@ -162,6 +170,8 @@ func (o *Organization) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetName(name string) {
 	o.Name = name
 	o.require(organizationFieldName)
@@ -405,16 +415,22 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetUserName sets the UserName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetUserName(userName string) {
 	u.UserName = userName
 	u.require(userFieldUserName)
 }
 
+// SetMetadataTags sets the MetadataTags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetMetadataTags(metadataTags []string) {
 	u.MetadataTags = metadataTags
 	u.require(userFieldMetadataTags)
 }
 
+// SetExtraProperties sets the ExtraProperties field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetExtraProperties(extraProperties map[string]string) {
 	u.ExtraProperties = extraProperties
 	u.require(userFieldExtraProperties)

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/mixed-case/no-custom-config/service.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/service.go
@@ -6,17 +6,51 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/mixed-case/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	listResourcesRequestFieldPageLimit  = big.NewInt(1 << 0)
+	listResourcesRequestFieldBeforeDate = big.NewInt(1 << 1)
 )
 
 type ListResourcesRequest struct {
 	PageLimit  int       `json:"-" url:"page_limit"`
 	BeforeDate time.Time `json:"-" url:"beforeDate" format:"date"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListResourcesRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListResourcesRequest) SetPageLimit(pageLimit int) {
+	l.PageLimit = pageLimit
+	l.require(listResourcesRequestFieldPageLimit)
+}
+
+func (l *ListResourcesRequest) SetBeforeDate(beforeDate time.Time) {
+	l.BeforeDate = beforeDate
+	l.require(listResourcesRequestFieldBeforeDate)
+}
+
+var (
+	nestedUserFieldName       = big.NewInt(1 << 0)
+	nestedUserFieldNestedUser = big.NewInt(1 << 1)
+)
 
 type NestedUser struct {
 	Name       string `json:"Name" url:"Name"`
 	NestedUser *User  `json:"NestedUser" url:"NestedUser"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -40,6 +74,23 @@ func (n *NestedUser) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedUser) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NestedUser) SetName(name string) {
+	n.Name = name
+	n.require(nestedUserFieldName)
+}
+
+func (n *NestedUser) SetNestedUser(nestedUser *User) {
+	n.NestedUser = nestedUser
+	n.require(nestedUserFieldNestedUser)
+}
+
 func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedUser
 	var value unmarshaler
@@ -56,6 +107,17 @@ func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedUser) MarshalJSON() ([]byte, error) {
+	type embed NestedUser
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedUser) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -68,8 +130,15 @@ func (n *NestedUser) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	organizationFieldName = big.NewInt(1 << 0)
+)
+
 type Organization struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -86,6 +155,18 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -100,6 +181,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *Organization) String() string {
@@ -263,10 +355,19 @@ func (r ResourceStatus) Ptr() *ResourceStatus {
 	return &r
 }
 
+var (
+	userFieldUserName        = big.NewInt(1 << 0)
+	userFieldMetadataTags    = big.NewInt(1 << 1)
+	userFieldExtraProperties = big.NewInt(1 << 2)
+)
+
 type User struct {
 	UserName        string            `json:"userName" url:"userName"`
 	MetadataTags    []string          `json:"metadata_tags" url:"metadata_tags"`
 	ExtraProperties map[string]string `json:"EXTRA_PROPERTIES" url:"EXTRA_PROPERTIES"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -297,6 +398,28 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetUserName(userName string) {
+	u.UserName = userName
+	u.require(userFieldUserName)
+}
+
+func (u *User) SetMetadataTags(metadataTags []string) {
+	u.MetadataTags = metadataTags
+	u.require(userFieldMetadataTags)
+}
+
+func (u *User) SetExtraProperties(extraProperties map[string]string) {
+	u.ExtraProperties = extraProperties
+	u.require(userFieldExtraProperties)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -311,6 +434,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/mixed-case/no-custom-config/service.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/service.go
@@ -30,11 +30,15 @@ func (l *ListResourcesRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPageLimit sets the PageLimit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetPageLimit(pageLimit int) {
 	l.PageLimit = pageLimit
 	l.require(listResourcesRequestFieldPageLimit)
 }
 
+// SetBeforeDate sets the BeforeDate field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListResourcesRequest) SetBeforeDate(beforeDate time.Time) {
 	l.BeforeDate = beforeDate
 	l.require(listResourcesRequestFieldBeforeDate)
@@ -81,11 +85,15 @@ func (n *NestedUser) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetName(name string) {
 	n.Name = name
 	n.require(nestedUserFieldName)
 }
 
+// SetNestedUser sets the NestedUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetNestedUser(nestedUser *User) {
 	n.NestedUser = nestedUser
 	n.require(nestedUserFieldNestedUser)
@@ -162,6 +170,8 @@ func (o *Organization) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetName(name string) {
 	o.Name = name
 	o.require(organizationFieldName)
@@ -405,16 +415,22 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetUserName sets the UserName field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetUserName(userName string) {
 	u.UserName = userName
 	u.require(userFieldUserName)
 }
 
+// SetMetadataTags sets the MetadataTags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetMetadataTags(metadataTags []string) {
 	u.MetadataTags = metadataTags
 	u.require(userFieldMetadataTags)
 }
 
+// SetExtraProperties sets the ExtraProperties field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetExtraProperties(extraProperties map[string]string) {
 	u.ExtraProperties = extraProperties
 	u.require(userFieldExtraProperties)

--- a/seed/go-sdk/mixed-file-directory/internal/explicit_fields.go
+++ b/seed/go-sdk/mixed-file-directory/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/mixed-file-directory/internal/explicit_fields_test.go
+++ b/seed/go-sdk/mixed-file-directory/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/mixed-file-directory/organization.go
+++ b/seed/go-sdk/mixed-file-directory/organization.go
@@ -41,6 +41,8 @@ func (c *CreateOrganizationRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateOrganizationRequest) SetName(name string) {
 	c.Name = name
 	c.require(createOrganizationRequestFieldName)
@@ -135,16 +137,22 @@ func (o *Organization) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetId(id Id) {
 	o.Id = id
 	o.require(organizationFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetName(name string) {
 	o.Name = name
 	o.require(organizationFieldName)
 }
 
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetUsers(users []*User) {
 	o.Users = users
 	o.require(organizationFieldUsers)

--- a/seed/go-sdk/mixed-file-directory/organization.go
+++ b/seed/go-sdk/mixed-file-directory/organization.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/mixed-file-directory/fern/internal"
+	big "math/big"
+)
+
+var (
+	createOrganizationRequestFieldName = big.NewInt(1 << 0)
 )
 
 type CreateOrganizationRequest struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -24,6 +32,18 @@ func (c *CreateOrganizationRequest) GetName() string {
 
 func (c *CreateOrganizationRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CreateOrganizationRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateOrganizationRequest) SetName(name string) {
+	c.Name = name
+	c.require(createOrganizationRequestFieldName)
 }
 
 func (c *CreateOrganizationRequest) UnmarshalJSON(data []byte) error {
@@ -42,6 +62,17 @@ func (c *CreateOrganizationRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateOrganizationRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateOrganizationRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateOrganizationRequest) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -54,10 +85,19 @@ func (c *CreateOrganizationRequest) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	organizationFieldId    = big.NewInt(1 << 0)
+	organizationFieldName  = big.NewInt(1 << 1)
+	organizationFieldUsers = big.NewInt(1 << 2)
+)
+
 type Organization struct {
 	Id    Id      `json:"id" url:"id"`
 	Name  string  `json:"name" url:"name"`
 	Users []*User `json:"users" url:"users"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -88,6 +128,28 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *Organization) SetId(id Id) {
+	o.Id = id
+	o.require(organizationFieldId)
+}
+
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
+func (o *Organization) SetUsers(users []*User) {
+	o.Users = users
+	o.require(organizationFieldUsers)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -102,6 +164,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *Organization) String() string {

--- a/seed/go-sdk/mixed-file-directory/user.go
+++ b/seed/go-sdk/mixed-file-directory/user.go
@@ -6,17 +6,46 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/mixed-file-directory/fern/internal"
+	big "math/big"
+)
+
+var (
+	listUsersRequestFieldLimit = big.NewInt(1 << 0)
 )
 
 type ListUsersRequest struct {
 	// The maximum number of results to return.
 	Limit *int `json:"-" url:"limit,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersRequest) SetLimit(limit *int) {
+	l.Limit = limit
+	l.require(listUsersRequestFieldLimit)
+}
+
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
+	userFieldAge  = big.NewInt(1 << 2)
+)
 
 type User struct {
 	Id   Id     `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
 	Age  int    `json:"age" url:"age"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -47,6 +76,28 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetId(id Id) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetAge(age int) {
+	u.Age = age
+	u.require(userFieldAge)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -61,6 +112,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/mixed-file-directory/user.go
+++ b/seed/go-sdk/mixed-file-directory/user.go
@@ -28,6 +28,8 @@ func (l *ListUsersRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetLimit(limit *int) {
 	l.Limit = limit
 	l.require(listUsersRequestFieldLimit)
@@ -83,16 +85,22 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id Id) {
 	u.Id = id
 	u.require(userFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetAge(age int) {
 	u.Age = age
 	u.require(userFieldAge)

--- a/seed/go-sdk/mixed-file-directory/user/events.go
+++ b/seed/go-sdk/mixed-file-directory/user/events.go
@@ -7,16 +7,44 @@ import (
 	fmt "fmt"
 	fern "github.com/mixed-file-directory/fern"
 	internal "github.com/mixed-file-directory/fern/internal"
+	big "math/big"
+)
+
+var (
+	listUserEventsRequestFieldLimit = big.NewInt(1 << 0)
 )
 
 type ListUserEventsRequest struct {
 	// The maximum number of results to return.
 	Limit *int `json:"-" url:"limit,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUserEventsRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUserEventsRequest) SetLimit(limit *int) {
+	l.Limit = limit
+	l.require(listUserEventsRequestFieldLimit)
+}
+
+var (
+	eventFieldId   = big.NewInt(1 << 0)
+	eventFieldName = big.NewInt(1 << 1)
+)
 
 type Event struct {
 	Id   fern.Id `json:"id" url:"id"`
 	Name string  `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -40,6 +68,23 @@ func (e *Event) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *Event) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *Event) SetId(id fern.Id) {
+	e.Id = id
+	e.require(eventFieldId)
+}
+
+func (e *Event) SetName(name string) {
+	e.Name = name
+	e.require(eventFieldName)
+}
+
 func (e *Event) UnmarshalJSON(data []byte) error {
 	type unmarshaler Event
 	var value unmarshaler
@@ -54,6 +99,17 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *Event) MarshalJSON() ([]byte, error) {
+	type embed Event
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *Event) String() string {

--- a/seed/go-sdk/mixed-file-directory/user/events.go
+++ b/seed/go-sdk/mixed-file-directory/user/events.go
@@ -29,6 +29,8 @@ func (l *ListUserEventsRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUserEventsRequest) SetLimit(limit *int) {
 	l.Limit = limit
 	l.require(listUserEventsRequestFieldLimit)
@@ -75,11 +77,15 @@ func (e *Event) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Event) SetId(id fern.Id) {
 	e.Id = id
 	e.require(eventFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *Event) SetName(name string) {
 	e.Name = name
 	e.require(eventFieldName)

--- a/seed/go-sdk/mixed-file-directory/user/events/metadata.go
+++ b/seed/go-sdk/mixed-file-directory/user/events/metadata.go
@@ -7,15 +7,43 @@ import (
 	fmt "fmt"
 	fern "github.com/mixed-file-directory/fern"
 	internal "github.com/mixed-file-directory/fern/internal"
+	big "math/big"
+)
+
+var (
+	getEventMetadataRequestFieldId = big.NewInt(1 << 0)
 )
 
 type GetEventMetadataRequest struct {
 	Id fern.Id `json:"-" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetEventMetadataRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetEventMetadataRequest) SetId(id fern.Id) {
+	g.Id = id
+	g.require(getEventMetadataRequestFieldId)
+}
+
+var (
+	metadataFieldId    = big.NewInt(1 << 0)
+	metadataFieldValue = big.NewInt(1 << 1)
+)
 
 type Metadata struct {
 	Id    fern.Id     `json:"id" url:"id"`
 	Value interface{} `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -39,6 +67,23 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id fern.Id) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetValue(value interface{}) {
+	m.Value = value
+	m.require(metadataFieldValue)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -53,6 +98,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/mixed-file-directory/user/events/metadata.go
+++ b/seed/go-sdk/mixed-file-directory/user/events/metadata.go
@@ -28,6 +28,8 @@ func (g *GetEventMetadataRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetEventMetadataRequest) SetId(id fern.Id) {
 	g.Id = id
 	g.require(getEventMetadataRequestFieldId)
@@ -74,11 +76,15 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id fern.Id) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetValue(value interface{}) {
 	m.Value = value
 	m.require(metadataFieldValue)

--- a/seed/go-sdk/multi-line-docs/internal/explicit_fields.go
+++ b/seed/go-sdk/multi-line-docs/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/multi-line-docs/internal/explicit_fields_test.go
+++ b/seed/go-sdk/multi-line-docs/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/multi-line-docs/user.go
+++ b/seed/go-sdk/multi-line-docs/user.go
@@ -33,11 +33,15 @@ func (c *CreateUserRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetName(name string) {
 	c.Name = name
 	c.require(createUserRequestFieldName)
 }
 
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetAge(age *int) {
 	c.Age = age
 	c.require(createUserRequestFieldAge)
@@ -101,16 +105,22 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id string) {
 	u.Id = id
 	u.require(userFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetAge(age *int) {
 	u.Age = age
 	u.require(userFieldAge)

--- a/seed/go-sdk/multi-line-docs/user.go
+++ b/seed/go-sdk/multi-line-docs/user.go
@@ -6,6 +6,12 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/multi-line-docs/fern/internal"
+	big "math/big"
+)
+
+var (
+	createUserRequestFieldName = big.NewInt(1 << 0)
+	createUserRequestFieldAge  = big.NewInt(1 << 1)
 )
 
 type CreateUserRequest struct {
@@ -15,11 +21,37 @@ type CreateUserRequest struct {
 	// The age of the user.
 	// This property is not required.
 	Age *int `json:"age,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (c *CreateUserRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateUserRequest) SetName(name string) {
+	c.Name = name
+	c.require(createUserRequestFieldName)
+}
+
+func (c *CreateUserRequest) SetAge(age *int) {
+	c.Age = age
+	c.require(createUserRequestFieldAge)
 }
 
 // A user object. This type is used throughout the following APIs:
 //   - createUser
 //   - getUser
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
+	userFieldAge  = big.NewInt(1 << 2)
+)
+
 type User struct {
 	Id string `json:"id" url:"id"`
 	// The user's name. This name is unique to each user. A few examples are included below:
@@ -29,6 +61,9 @@ type User struct {
 	Name string `json:"name" url:"name"`
 	// The user's age.
 	Age *int `json:"age,omitempty" url:"age,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -59,6 +94,28 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetId(id string) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetAge(age *int) {
+	u.Age = age
+	u.require(userFieldAge)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -73,6 +130,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/multi-url-environment-no-default/ec_2.go
+++ b/seed/go-sdk/multi-url-environment-no-default/ec_2.go
@@ -24,6 +24,8 @@ func (b *BootInstanceRequest) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetSize sets the Size field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BootInstanceRequest) SetSize(size string) {
 	b.Size = size
 	b.require(bootInstanceRequestFieldSize)

--- a/seed/go-sdk/multi-url-environment-no-default/ec_2.go
+++ b/seed/go-sdk/multi-url-environment-no-default/ec_2.go
@@ -2,6 +2,29 @@
 
 package multiurlenvironmentnodefault
 
+import (
+	big "math/big"
+)
+
+var (
+	bootInstanceRequestFieldSize = big.NewInt(1 << 0)
+)
+
 type BootInstanceRequest struct {
 	Size string `json:"size" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (b *BootInstanceRequest) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BootInstanceRequest) SetSize(size string) {
+	b.Size = size
+	b.require(bootInstanceRequestFieldSize)
 }

--- a/seed/go-sdk/multi-url-environment-no-default/internal/explicit_fields.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/multi-url-environment-no-default/internal/explicit_fields_test.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/multi-url-environment-no-default/s_3.go
+++ b/seed/go-sdk/multi-url-environment-no-default/s_3.go
@@ -2,6 +2,29 @@
 
 package multiurlenvironmentnodefault
 
+import (
+	big "math/big"
+)
+
+var (
+	getPresignedUrlRequestFieldS3Key = big.NewInt(1 << 0)
+)
+
 type GetPresignedUrlRequest struct {
 	S3Key string `json:"s3Key" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetPresignedUrlRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetPresignedUrlRequest) SetS3Key(s3Key string) {
+	g.S3Key = s3Key
+	g.require(getPresignedUrlRequestFieldS3Key)
 }

--- a/seed/go-sdk/multi-url-environment-no-default/s_3.go
+++ b/seed/go-sdk/multi-url-environment-no-default/s_3.go
@@ -24,6 +24,8 @@ func (g *GetPresignedUrlRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetS3Key sets the S3Key field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetPresignedUrlRequest) SetS3Key(s3Key string) {
 	g.S3Key = s3Key
 	g.require(getPresignedUrlRequestFieldS3Key)

--- a/seed/go-sdk/multi-url-environment/ec_2.go
+++ b/seed/go-sdk/multi-url-environment/ec_2.go
@@ -24,6 +24,8 @@ func (b *BootInstanceRequest) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetSize sets the Size field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BootInstanceRequest) SetSize(size string) {
 	b.Size = size
 	b.require(bootInstanceRequestFieldSize)

--- a/seed/go-sdk/multi-url-environment/ec_2.go
+++ b/seed/go-sdk/multi-url-environment/ec_2.go
@@ -2,6 +2,29 @@
 
 package multiurlenvironment
 
+import (
+	big "math/big"
+)
+
+var (
+	bootInstanceRequestFieldSize = big.NewInt(1 << 0)
+)
+
 type BootInstanceRequest struct {
 	Size string `json:"size" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (b *BootInstanceRequest) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BootInstanceRequest) SetSize(size string) {
+	b.Size = size
+	b.require(bootInstanceRequestFieldSize)
 }

--- a/seed/go-sdk/multi-url-environment/internal/explicit_fields.go
+++ b/seed/go-sdk/multi-url-environment/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/multi-url-environment/internal/explicit_fields_test.go
+++ b/seed/go-sdk/multi-url-environment/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/multi-url-environment/s_3.go
+++ b/seed/go-sdk/multi-url-environment/s_3.go
@@ -2,6 +2,29 @@
 
 package multiurlenvironment
 
+import (
+	big "math/big"
+)
+
+var (
+	getPresignedUrlRequestFieldS3Key = big.NewInt(1 << 0)
+)
+
 type GetPresignedUrlRequest struct {
 	S3Key string `json:"s3Key" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetPresignedUrlRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetPresignedUrlRequest) SetS3Key(s3Key string) {
+	g.S3Key = s3Key
+	g.require(getPresignedUrlRequestFieldS3Key)
 }

--- a/seed/go-sdk/multi-url-environment/s_3.go
+++ b/seed/go-sdk/multi-url-environment/s_3.go
@@ -24,6 +24,8 @@ func (g *GetPresignedUrlRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetS3Key sets the S3Key field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetPresignedUrlRequest) SetS3Key(s3Key string) {
 	g.S3Key = s3Key
 	g.require(getPresignedUrlRequestFieldS3Key)

--- a/seed/go-sdk/multiple-request-bodies/internal/explicit_fields.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/multiple-request-bodies/internal/explicit_fields_test.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/multiple-request-bodies/types.go
+++ b/seed/go-sdk/multiple-request-bodies/types.go
@@ -68,21 +68,29 @@ func (d *DocumentMetadata) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetAuthor sets the Author field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DocumentMetadata) SetAuthor(author *string) {
 	d.Author = author
 	d.require(documentMetadataFieldAuthor)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DocumentMetadata) SetId(id *int) {
 	d.Id = id
 	d.require(documentMetadataFieldId)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DocumentMetadata) SetTags(tags []interface{}) {
 	d.Tags = tags
 	d.require(documentMetadataFieldTags)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DocumentMetadata) SetTitle(title *string) {
 	d.Title = title
 	d.require(documentMetadataFieldTitle)
@@ -168,11 +176,15 @@ func (d *DocumentUploadResult) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetFileId sets the FileId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DocumentUploadResult) SetFileId(fileId *string) {
 	d.FileId = fileId
 	d.require(documentUploadResultFieldFileId)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DocumentUploadResult) SetStatus(status *string) {
 	d.Status = status
 	d.require(documentUploadResultFieldStatus)
@@ -301,16 +313,22 @@ func (u *UploadDocumentRequest) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetAuthor sets the Author field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UploadDocumentRequest) SetAuthor(author *string) {
 	u.Author = author
 	u.require(uploadDocumentRequestFieldAuthor)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UploadDocumentRequest) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(uploadDocumentRequestFieldTags)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UploadDocumentRequest) SetTitle(title *string) {
 	u.Title = title
 	u.require(uploadDocumentRequestFieldTitle)

--- a/seed/go-sdk/multiple-request-bodies/types.go
+++ b/seed/go-sdk/multiple-request-bodies/types.go
@@ -6,6 +6,14 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/multiple-request-bodies/fern/internal"
+	big "math/big"
+)
+
+var (
+	documentMetadataFieldAuthor = big.NewInt(1 << 0)
+	documentMetadataFieldId     = big.NewInt(1 << 1)
+	documentMetadataFieldTags   = big.NewInt(1 << 2)
+	documentMetadataFieldTitle  = big.NewInt(1 << 3)
 )
 
 type DocumentMetadata struct {
@@ -13,6 +21,9 @@ type DocumentMetadata struct {
 	Id     *int          `json:"id,omitempty" url:"id,omitempty"`
 	Tags   []interface{} `json:"tags,omitempty" url:"tags,omitempty"`
 	Title  *string       `json:"title,omitempty" url:"title,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -50,6 +61,33 @@ func (d *DocumentMetadata) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *DocumentMetadata) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DocumentMetadata) SetAuthor(author *string) {
+	d.Author = author
+	d.require(documentMetadataFieldAuthor)
+}
+
+func (d *DocumentMetadata) SetId(id *int) {
+	d.Id = id
+	d.require(documentMetadataFieldId)
+}
+
+func (d *DocumentMetadata) SetTags(tags []interface{}) {
+	d.Tags = tags
+	d.require(documentMetadataFieldTags)
+}
+
+func (d *DocumentMetadata) SetTitle(title *string) {
+	d.Title = title
+	d.require(documentMetadataFieldTitle)
+}
+
 func (d *DocumentMetadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler DocumentMetadata
 	var value unmarshaler
@@ -66,6 +104,17 @@ func (d *DocumentMetadata) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DocumentMetadata) MarshalJSON() ([]byte, error) {
+	type embed DocumentMetadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DocumentMetadata) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -78,9 +127,17 @@ func (d *DocumentMetadata) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	documentUploadResultFieldFileId = big.NewInt(1 << 0)
+	documentUploadResultFieldStatus = big.NewInt(1 << 1)
+)
+
 type DocumentUploadResult struct {
 	FileId *string `json:"fileId,omitempty" url:"fileId,omitempty"`
 	Status *string `json:"status,omitempty" url:"status,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -104,6 +161,23 @@ func (d *DocumentUploadResult) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *DocumentUploadResult) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DocumentUploadResult) SetFileId(fileId *string) {
+	d.FileId = fileId
+	d.require(documentUploadResultFieldFileId)
+}
+
+func (d *DocumentUploadResult) SetStatus(status *string) {
+	d.Status = status
+	d.require(documentUploadResultFieldStatus)
+}
+
 func (d *DocumentUploadResult) UnmarshalJSON(data []byte) error {
 	type unmarshaler DocumentUploadResult
 	var value unmarshaler
@@ -118,6 +192,17 @@ func (d *DocumentUploadResult) UnmarshalJSON(data []byte) error {
 	d.extraProperties = extraProperties
 	d.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (d *DocumentUploadResult) MarshalJSON() ([]byte, error) {
+	type embed DocumentUploadResult
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (d *DocumentUploadResult) String() string {
@@ -194,8 +279,39 @@ func (u *UploadDocumentResponse) Accept(visitor UploadDocumentResponseVisitor) e
 	return fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
+var (
+	uploadDocumentRequestFieldAuthor = big.NewInt(1 << 0)
+	uploadDocumentRequestFieldTags   = big.NewInt(1 << 1)
+	uploadDocumentRequestFieldTitle  = big.NewInt(1 << 2)
+)
+
 type UploadDocumentRequest struct {
 	Author *string  `json:"author,omitempty" url:"-"`
 	Tags   []string `json:"tags,omitempty" url:"-"`
 	Title  *string  `json:"title,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (u *UploadDocumentRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UploadDocumentRequest) SetAuthor(author *string) {
+	u.Author = author
+	u.require(uploadDocumentRequestFieldAuthor)
+}
+
+func (u *UploadDocumentRequest) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(uploadDocumentRequestFieldTags)
+}
+
+func (u *UploadDocumentRequest) SetTitle(title *string) {
+	u.Title = title
+	u.require(uploadDocumentRequestFieldTitle)
 }

--- a/seed/go-sdk/no-environment/internal/explicit_fields.go
+++ b/seed/go-sdk/no-environment/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/no-environment/internal/explicit_fields_test.go
+++ b/seed/go-sdk/no-environment/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/nullable-optional/internal/explicit_fields.go
+++ b/seed/go-sdk/nullable-optional/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/nullable-optional/internal/explicit_fields_test.go
+++ b/seed/go-sdk/nullable-optional/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/nullable-optional/nullable_optional.go
+++ b/seed/go-sdk/nullable-optional/nullable_optional.go
@@ -32,16 +32,22 @@ func (f *FilterByRoleRequest) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetRole sets the Role field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FilterByRoleRequest) SetRole(role *UserRole) {
 	f.Role = role
 	f.require(filterByRoleRequestFieldRole)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FilterByRoleRequest) SetStatus(status *UserStatus) {
 	f.Status = status
 	f.require(filterByRoleRequestFieldStatus)
 }
 
+// SetSecondaryRole sets the SecondaryRole field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FilterByRoleRequest) SetSecondaryRole(secondaryRole *UserRole) {
 	f.SecondaryRole = secondaryRole
 	f.require(filterByRoleRequestFieldSecondaryRole)
@@ -69,16 +75,22 @@ func (s *SearchRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetQuery(query string) {
 	s.Query = query
 	s.require(searchRequestFieldQuery)
 }
 
+// SetFilters sets the Filters field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetFilters(filters map[string]*string) {
 	s.Filters = filters
 	s.require(searchRequestFieldFilters)
 }
 
+// SetIncludeTypes sets the IncludeTypes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetIncludeTypes(includeTypes []string) {
 	s.IncludeTypes = includeTypes
 	s.require(searchRequestFieldIncludeTypes)
@@ -108,21 +120,29 @@ func (l *ListUsersRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetLimit(limit *int) {
 	l.Limit = limit
 	l.require(listUsersRequestFieldLimit)
 }
 
+// SetOffset sets the Offset field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetOffset(offset *int) {
 	l.Offset = offset
 	l.require(listUsersRequestFieldOffset)
 }
 
+// SetIncludeDeleted sets the IncludeDeleted field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetIncludeDeleted(includeDeleted *bool) {
 	l.IncludeDeleted = includeDeleted
 	l.require(listUsersRequestFieldIncludeDeleted)
 }
 
+// SetSortBy sets the SortBy field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersRequest) SetSortBy(sortBy *string) {
 	l.SortBy = sortBy
 	l.require(listUsersRequestFieldSortBy)
@@ -152,21 +172,29 @@ func (s *SearchUsersRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetQuery(query string) {
 	s.Query = query
 	s.require(searchUsersRequestFieldQuery)
 }
 
+// SetDepartment sets the Department field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetDepartment(department *string) {
 	s.Department = department
 	s.require(searchUsersRequestFieldDepartment)
 }
 
+// SetRole sets the Role field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetRole(role *string) {
 	s.Role = role
 	s.require(searchUsersRequestFieldRole)
 }
 
+// SetIsActive sets the IsActive field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetIsActive(isActive *bool) {
 	s.IsActive = isActive
 	s.require(searchUsersRequestFieldIsActive)
@@ -259,36 +287,50 @@ func (a *Address) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetStreet sets the Street field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetStreet(street string) {
 	a.Street = street
 	a.require(addressFieldStreet)
 }
 
+// SetCity sets the City field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetCity(city *string) {
 	a.City = city
 	a.require(addressFieldCity)
 }
 
+// SetState sets the State field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetState(state *string) {
 	a.State = state
 	a.require(addressFieldState)
 }
 
+// SetZipCode sets the ZipCode field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetZipCode(zipCode string) {
 	a.ZipCode = zipCode
 	a.require(addressFieldZipCode)
 }
 
+// SetCountry sets the Country field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetCountry(country *string) {
 	a.Country = country
 	a.require(addressFieldCountry)
 }
 
+// SetBuildingId sets the BuildingId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetBuildingId(buildingId NullableUserId) {
 	a.BuildingId = buildingId
 	a.require(addressFieldBuildingId)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Address) SetTenantId(tenantId OptionalUserId) {
 	a.TenantId = tenantId
 	a.require(addressFieldTenantId)
@@ -528,96 +570,134 @@ func (c *ComplexProfile) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetId(id string) {
 	c.Id = id
 	c.require(complexProfileFieldId)
 }
 
+// SetNullableRole sets the NullableRole field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableRole(nullableRole *UserRole) {
 	c.NullableRole = nullableRole
 	c.require(complexProfileFieldNullableRole)
 }
 
+// SetOptionalRole sets the OptionalRole field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalRole(optionalRole *UserRole) {
 	c.OptionalRole = optionalRole
 	c.require(complexProfileFieldOptionalRole)
 }
 
+// SetOptionalNullableRole sets the OptionalNullableRole field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalNullableRole(optionalNullableRole *UserRole) {
 	c.OptionalNullableRole = optionalNullableRole
 	c.require(complexProfileFieldOptionalNullableRole)
 }
 
+// SetNullableStatus sets the NullableStatus field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableStatus(nullableStatus *UserStatus) {
 	c.NullableStatus = nullableStatus
 	c.require(complexProfileFieldNullableStatus)
 }
 
+// SetOptionalStatus sets the OptionalStatus field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalStatus(optionalStatus *UserStatus) {
 	c.OptionalStatus = optionalStatus
 	c.require(complexProfileFieldOptionalStatus)
 }
 
+// SetOptionalNullableStatus sets the OptionalNullableStatus field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalNullableStatus(optionalNullableStatus *UserStatus) {
 	c.OptionalNullableStatus = optionalNullableStatus
 	c.require(complexProfileFieldOptionalNullableStatus)
 }
 
+// SetNullableNotification sets the NullableNotification field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableNotification(nullableNotification *NotificationMethod) {
 	c.NullableNotification = nullableNotification
 	c.require(complexProfileFieldNullableNotification)
 }
 
+// SetOptionalNotification sets the OptionalNotification field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalNotification(optionalNotification *NotificationMethod) {
 	c.OptionalNotification = optionalNotification
 	c.require(complexProfileFieldOptionalNotification)
 }
 
+// SetOptionalNullableNotification sets the OptionalNullableNotification field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalNullableNotification(optionalNullableNotification *NotificationMethod) {
 	c.OptionalNullableNotification = optionalNullableNotification
 	c.require(complexProfileFieldOptionalNullableNotification)
 }
 
+// SetNullableSearchResult sets the NullableSearchResult field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableSearchResult(nullableSearchResult *SearchResult) {
 	c.NullableSearchResult = nullableSearchResult
 	c.require(complexProfileFieldNullableSearchResult)
 }
 
+// SetOptionalSearchResult sets the OptionalSearchResult field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalSearchResult(optionalSearchResult *SearchResult) {
 	c.OptionalSearchResult = optionalSearchResult
 	c.require(complexProfileFieldOptionalSearchResult)
 }
 
+// SetNullableArray sets the NullableArray field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableArray(nullableArray []string) {
 	c.NullableArray = nullableArray
 	c.require(complexProfileFieldNullableArray)
 }
 
+// SetOptionalArray sets the OptionalArray field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalArray(optionalArray []string) {
 	c.OptionalArray = optionalArray
 	c.require(complexProfileFieldOptionalArray)
 }
 
+// SetOptionalNullableArray sets the OptionalNullableArray field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalNullableArray(optionalNullableArray []string) {
 	c.OptionalNullableArray = optionalNullableArray
 	c.require(complexProfileFieldOptionalNullableArray)
 }
 
+// SetNullableListOfNullables sets the NullableListOfNullables field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableListOfNullables(nullableListOfNullables []*string) {
 	c.NullableListOfNullables = nullableListOfNullables
 	c.require(complexProfileFieldNullableListOfNullables)
 }
 
+// SetNullableMapOfNullables sets the NullableMapOfNullables field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableMapOfNullables(nullableMapOfNullables map[string]*Address) {
 	c.NullableMapOfNullables = nullableMapOfNullables
 	c.require(complexProfileFieldNullableMapOfNullables)
 }
 
+// SetNullableListOfUnions sets the NullableListOfUnions field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetNullableListOfUnions(nullableListOfUnions []*NotificationMethod) {
 	c.NullableListOfUnions = nullableListOfUnions
 	c.require(complexProfileFieldNullableListOfUnions)
 }
 
+// SetOptionalMapOfEnums sets the OptionalMapOfEnums field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ComplexProfile) SetOptionalMapOfEnums(optionalMapOfEnums map[string]UserRole) {
 	c.OptionalMapOfEnums = optionalMapOfEnums
 	c.require(complexProfileFieldOptionalMapOfEnums)
@@ -721,21 +801,29 @@ func (c *CreateUserRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetUsername(username string) {
 	c.Username = username
 	c.require(createUserRequestFieldUsername)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetEmail(email *string) {
 	c.Email = email
 	c.require(createUserRequestFieldEmail)
 }
 
+// SetPhone sets the Phone field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetPhone(phone *string) {
 	c.Phone = phone
 	c.require(createUserRequestFieldPhone)
 }
 
+// SetAddress sets the Address field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetAddress(address *Address) {
 	c.Address = address
 	c.require(createUserRequestFieldAddress)
@@ -912,61 +1000,85 @@ func (d *DeserializationTestRequest) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetRequiredString sets the RequiredString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetRequiredString(requiredString string) {
 	d.RequiredString = requiredString
 	d.require(deserializationTestRequestFieldRequiredString)
 }
 
+// SetNullableString sets the NullableString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetNullableString(nullableString *string) {
 	d.NullableString = nullableString
 	d.require(deserializationTestRequestFieldNullableString)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetOptionalString(optionalString *string) {
 	d.OptionalString = optionalString
 	d.require(deserializationTestRequestFieldOptionalString)
 }
 
+// SetOptionalNullableString sets the OptionalNullableString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetOptionalNullableString(optionalNullableString *string) {
 	d.OptionalNullableString = optionalNullableString
 	d.require(deserializationTestRequestFieldOptionalNullableString)
 }
 
+// SetNullableEnum sets the NullableEnum field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetNullableEnum(nullableEnum *UserRole) {
 	d.NullableEnum = nullableEnum
 	d.require(deserializationTestRequestFieldNullableEnum)
 }
 
+// SetOptionalEnum sets the OptionalEnum field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetOptionalEnum(optionalEnum *UserStatus) {
 	d.OptionalEnum = optionalEnum
 	d.require(deserializationTestRequestFieldOptionalEnum)
 }
 
+// SetNullableUnion sets the NullableUnion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetNullableUnion(nullableUnion *NotificationMethod) {
 	d.NullableUnion = nullableUnion
 	d.require(deserializationTestRequestFieldNullableUnion)
 }
 
+// SetOptionalUnion sets the OptionalUnion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetOptionalUnion(optionalUnion *SearchResult) {
 	d.OptionalUnion = optionalUnion
 	d.require(deserializationTestRequestFieldOptionalUnion)
 }
 
+// SetNullableList sets the NullableList field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetNullableList(nullableList []string) {
 	d.NullableList = nullableList
 	d.require(deserializationTestRequestFieldNullableList)
 }
 
+// SetNullableMap sets the NullableMap field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetNullableMap(nullableMap map[string]int) {
 	d.NullableMap = nullableMap
 	d.require(deserializationTestRequestFieldNullableMap)
 }
 
+// SetNullableObject sets the NullableObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetNullableObject(nullableObject *Address) {
 	d.NullableObject = nullableObject
 	d.require(deserializationTestRequestFieldNullableObject)
 }
 
+// SetOptionalObject sets the OptionalObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestRequest) SetOptionalObject(optionalObject *Organization) {
 	d.OptionalObject = optionalObject
 	d.require(deserializationTestRequestFieldOptionalObject)
@@ -1071,21 +1183,29 @@ func (d *DeserializationTestResponse) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetEcho sets the Echo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestResponse) SetEcho(echo *DeserializationTestRequest) {
 	d.Echo = echo
 	d.require(deserializationTestResponseFieldEcho)
 }
 
+// SetProcessedAt sets the ProcessedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestResponse) SetProcessedAt(processedAt time.Time) {
 	d.ProcessedAt = processedAt
 	d.require(deserializationTestResponseFieldProcessedAt)
 }
 
+// SetNullCount sets the NullCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestResponse) SetNullCount(nullCount int) {
 	d.NullCount = nullCount
 	d.require(deserializationTestResponseFieldNullCount)
 }
 
+// SetPresentFieldsCount sets the PresentFieldsCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeserializationTestResponse) SetPresentFieldsCount(presentFieldsCount int) {
 	d.PresentFieldsCount = presentFieldsCount
 	d.require(deserializationTestResponseFieldPresentFieldsCount)
@@ -1206,26 +1326,36 @@ func (d *Document) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Document) SetId(id string) {
 	d.Id = id
 	d.require(documentFieldId)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Document) SetTitle(title string) {
 	d.Title = title
 	d.require(documentFieldTitle)
 }
 
+// SetContent sets the Content field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Document) SetContent(content string) {
 	d.Content = content
 	d.require(documentFieldContent)
 }
 
+// SetAuthor sets the Author field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Document) SetAuthor(author *string) {
 	d.Author = author
 	d.require(documentFieldAuthor)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Document) SetTags(tags []string) {
 	d.Tags = tags
 	d.require(documentFieldTags)
@@ -1320,16 +1450,22 @@ func (e *EmailNotification) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetEmailAddress sets the EmailAddress field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *EmailNotification) SetEmailAddress(emailAddress string) {
 	e.EmailAddress = emailAddress
 	e.require(emailNotificationFieldEmailAddress)
 }
 
+// SetSubject sets the Subject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *EmailNotification) SetSubject(subject string) {
 	e.Subject = subject
 	e.require(emailNotificationFieldSubject)
 }
 
+// SetHtmlContent sets the HtmlContent field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *EmailNotification) SetHtmlContent(htmlContent *string) {
 	e.HtmlContent = htmlContent
 	e.require(emailNotificationFieldHtmlContent)
@@ -1581,21 +1717,29 @@ func (o *Organization) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetId(id string) {
 	o.Id = id
 	o.require(organizationFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetName(name string) {
 	o.Name = name
 	o.require(organizationFieldName)
 }
 
+// SetDomain sets the Domain field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetDomain(domain *string) {
 	o.Domain = domain
 	o.require(organizationFieldDomain)
 }
 
+// SetEmployeeCount sets the EmployeeCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetEmployeeCount(employeeCount *int) {
 	o.EmployeeCount = employeeCount
 	o.require(organizationFieldEmployeeCount)
@@ -1699,21 +1843,29 @@ func (p *PushNotification) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetDeviceToken sets the DeviceToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PushNotification) SetDeviceToken(deviceToken string) {
 	p.DeviceToken = deviceToken
 	p.require(pushNotificationFieldDeviceToken)
 }
 
+// SetTitle sets the Title field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PushNotification) SetTitle(title string) {
 	p.Title = title
 	p.require(pushNotificationFieldTitle)
 }
 
+// SetBody sets the Body field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PushNotification) SetBody(body string) {
 	p.Body = body
 	p.require(pushNotificationFieldBody)
 }
 
+// SetBadge sets the Badge field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PushNotification) SetBadge(badge *int) {
 	p.Badge = badge
 	p.require(pushNotificationFieldBadge)
@@ -1950,16 +2102,22 @@ func (s *SmsNotification) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetPhoneNumber sets the PhoneNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SmsNotification) SetPhoneNumber(phoneNumber string) {
 	s.PhoneNumber = phoneNumber
 	s.require(smsNotificationFieldPhoneNumber)
 }
 
+// SetMessage sets the Message field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SmsNotification) SetMessage(message string) {
 	s.Message = message
 	s.require(smsNotificationFieldMessage)
 }
 
+// SetShortCode sets the ShortCode field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SmsNotification) SetShortCode(shortCode *string) {
 	s.ShortCode = shortCode
 	s.require(smsNotificationFieldShortCode)
@@ -2064,21 +2222,29 @@ func (u *UpdateUserRequest) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetUsername(username *string) {
 	u.Username = username
 	u.require(updateUserRequestFieldUsername)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetEmail(email *string) {
 	u.Email = email
 	u.require(updateUserRequestFieldEmail)
 }
 
+// SetPhone sets the Phone field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetPhone(phone *string) {
 	u.Phone = phone
 	u.require(updateUserRequestFieldPhone)
 }
 
+// SetAddress sets the Address field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetAddress(address *Address) {
 	u.Address = address
 	u.require(updateUserRequestFieldAddress)
@@ -2309,91 +2475,127 @@ func (u *UserProfile) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetId(id string) {
 	u.Id = id
 	u.require(userProfileFieldId)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetUsername(username string) {
 	u.Username = username
 	u.require(userProfileFieldUsername)
 }
 
+// SetNullableString sets the NullableString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetNullableString(nullableString *string) {
 	u.NullableString = nullableString
 	u.require(userProfileFieldNullableString)
 }
 
+// SetNullableInteger sets the NullableInteger field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetNullableInteger(nullableInteger *int) {
 	u.NullableInteger = nullableInteger
 	u.require(userProfileFieldNullableInteger)
 }
 
+// SetNullableBoolean sets the NullableBoolean field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetNullableBoolean(nullableBoolean *bool) {
 	u.NullableBoolean = nullableBoolean
 	u.require(userProfileFieldNullableBoolean)
 }
 
+// SetNullableDate sets the NullableDate field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetNullableDate(nullableDate *time.Time) {
 	u.NullableDate = nullableDate
 	u.require(userProfileFieldNullableDate)
 }
 
+// SetNullableObject sets the NullableObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetNullableObject(nullableObject *Address) {
 	u.NullableObject = nullableObject
 	u.require(userProfileFieldNullableObject)
 }
 
+// SetNullableList sets the NullableList field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetNullableList(nullableList []string) {
 	u.NullableList = nullableList
 	u.require(userProfileFieldNullableList)
 }
 
+// SetNullableMap sets the NullableMap field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetNullableMap(nullableMap map[string]string) {
 	u.NullableMap = nullableMap
 	u.require(userProfileFieldNullableMap)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalString(optionalString *string) {
 	u.OptionalString = optionalString
 	u.require(userProfileFieldOptionalString)
 }
 
+// SetOptionalInteger sets the OptionalInteger field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalInteger(optionalInteger *int) {
 	u.OptionalInteger = optionalInteger
 	u.require(userProfileFieldOptionalInteger)
 }
 
+// SetOptionalBoolean sets the OptionalBoolean field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalBoolean(optionalBoolean *bool) {
 	u.OptionalBoolean = optionalBoolean
 	u.require(userProfileFieldOptionalBoolean)
 }
 
+// SetOptionalDate sets the OptionalDate field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalDate(optionalDate *time.Time) {
 	u.OptionalDate = optionalDate
 	u.require(userProfileFieldOptionalDate)
 }
 
+// SetOptionalObject sets the OptionalObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalObject(optionalObject *Address) {
 	u.OptionalObject = optionalObject
 	u.require(userProfileFieldOptionalObject)
 }
 
+// SetOptionalList sets the OptionalList field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalList(optionalList []string) {
 	u.OptionalList = optionalList
 	u.require(userProfileFieldOptionalList)
 }
 
+// SetOptionalMap sets the OptionalMap field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalMap(optionalMap map[string]string) {
 	u.OptionalMap = optionalMap
 	u.require(userProfileFieldOptionalMap)
 }
 
+// SetOptionalNullableString sets the OptionalNullableString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalNullableString(optionalNullableString *string) {
 	u.OptionalNullableString = optionalNullableString
 	u.require(userProfileFieldOptionalNullableString)
 }
 
+// SetOptionalNullableObject sets the OptionalNullableObject field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserProfile) SetOptionalNullableObject(optionalNullableObject *Address) {
 	u.OptionalNullableObject = optionalNullableObject
 	u.require(userProfileFieldOptionalNullableObject)
@@ -2536,36 +2738,50 @@ func (u *UserResponse) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserResponse) SetId(id string) {
 	u.Id = id
 	u.require(userResponseFieldId)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserResponse) SetUsername(username string) {
 	u.Username = username
 	u.require(userResponseFieldUsername)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserResponse) SetEmail(email *string) {
 	u.Email = email
 	u.require(userResponseFieldEmail)
 }
 
+// SetPhone sets the Phone field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserResponse) SetPhone(phone *string) {
 	u.Phone = phone
 	u.require(userResponseFieldPhone)
 }
 
+// SetCreatedAt sets the CreatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserResponse) SetCreatedAt(createdAt time.Time) {
 	u.CreatedAt = createdAt
 	u.require(userResponseFieldCreatedAt)
 }
 
+// SetUpdatedAt sets the UpdatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserResponse) SetUpdatedAt(updatedAt *time.Time) {
 	u.UpdatedAt = updatedAt
 	u.require(userResponseFieldUpdatedAt)
 }
 
+// SetAddress sets the Address field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserResponse) SetAddress(address *Address) {
 	u.Address = address
 	u.require(userResponseFieldAddress)
@@ -2706,26 +2922,36 @@ func (u *UpdateComplexProfileRequest) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetNullableRole sets the NullableRole field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateComplexProfileRequest) SetNullableRole(nullableRole *UserRole) {
 	u.NullableRole = nullableRole
 	u.require(updateComplexProfileRequestFieldNullableRole)
 }
 
+// SetNullableStatus sets the NullableStatus field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateComplexProfileRequest) SetNullableStatus(nullableStatus *UserStatus) {
 	u.NullableStatus = nullableStatus
 	u.require(updateComplexProfileRequestFieldNullableStatus)
 }
 
+// SetNullableNotification sets the NullableNotification field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateComplexProfileRequest) SetNullableNotification(nullableNotification *NotificationMethod) {
 	u.NullableNotification = nullableNotification
 	u.require(updateComplexProfileRequestFieldNullableNotification)
 }
 
+// SetNullableSearchResult sets the NullableSearchResult field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateComplexProfileRequest) SetNullableSearchResult(nullableSearchResult *SearchResult) {
 	u.NullableSearchResult = nullableSearchResult
 	u.require(updateComplexProfileRequestFieldNullableSearchResult)
 }
 
+// SetNullableArray sets the NullableArray field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateComplexProfileRequest) SetNullableArray(nullableArray []string) {
 	u.NullableArray = nullableArray
 	u.require(updateComplexProfileRequestFieldNullableArray)
@@ -2753,16 +2979,22 @@ func (u *UpdateTagsRequest) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateTagsRequest) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(updateTagsRequestFieldTags)
 }
 
+// SetCategories sets the Categories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateTagsRequest) SetCategories(categories []string) {
 	u.Categories = categories
 	u.require(updateTagsRequestFieldCategories)
 }
 
+// SetLabels sets the Labels field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateTagsRequest) SetLabels(labels []string) {
 	u.Labels = labels
 	u.require(updateTagsRequestFieldLabels)

--- a/seed/go-sdk/nullable-optional/nullable_optional.go
+++ b/seed/go-sdk/nullable-optional/nullable_optional.go
@@ -6,36 +6,183 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/nullable-optional/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	filterByRoleRequestFieldRole          = big.NewInt(1 << 0)
+	filterByRoleRequestFieldStatus        = big.NewInt(1 << 1)
+	filterByRoleRequestFieldSecondaryRole = big.NewInt(1 << 2)
 )
 
 type FilterByRoleRequest struct {
 	Role          *UserRole   `json:"-" url:"role,omitempty"`
 	Status        *UserStatus `json:"-" url:"status,omitempty"`
 	SecondaryRole *UserRole   `json:"-" url:"secondaryRole,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (f *FilterByRoleRequest) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FilterByRoleRequest) SetRole(role *UserRole) {
+	f.Role = role
+	f.require(filterByRoleRequestFieldRole)
+}
+
+func (f *FilterByRoleRequest) SetStatus(status *UserStatus) {
+	f.Status = status
+	f.require(filterByRoleRequestFieldStatus)
+}
+
+func (f *FilterByRoleRequest) SetSecondaryRole(secondaryRole *UserRole) {
+	f.SecondaryRole = secondaryRole
+	f.require(filterByRoleRequestFieldSecondaryRole)
+}
+
+var (
+	searchRequestFieldQuery        = big.NewInt(1 << 0)
+	searchRequestFieldFilters      = big.NewInt(1 << 1)
+	searchRequestFieldIncludeTypes = big.NewInt(1 << 2)
+)
 
 type SearchRequest struct {
 	Query        string             `json:"query" url:"-"`
 	Filters      map[string]*string `json:"filters,omitempty" url:"-"`
 	IncludeTypes []string           `json:"includeTypes,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *SearchRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchRequest) SetQuery(query string) {
+	s.Query = query
+	s.require(searchRequestFieldQuery)
+}
+
+func (s *SearchRequest) SetFilters(filters map[string]*string) {
+	s.Filters = filters
+	s.require(searchRequestFieldFilters)
+}
+
+func (s *SearchRequest) SetIncludeTypes(includeTypes []string) {
+	s.IncludeTypes = includeTypes
+	s.require(searchRequestFieldIncludeTypes)
+}
+
+var (
+	listUsersRequestFieldLimit          = big.NewInt(1 << 0)
+	listUsersRequestFieldOffset         = big.NewInt(1 << 1)
+	listUsersRequestFieldIncludeDeleted = big.NewInt(1 << 2)
+	listUsersRequestFieldSortBy         = big.NewInt(1 << 3)
+)
 
 type ListUsersRequest struct {
 	Limit          *int    `json:"-" url:"limit,omitempty"`
 	Offset         *int    `json:"-" url:"offset,omitempty"`
 	IncludeDeleted *bool   `json:"-" url:"includeDeleted,omitempty"`
 	SortBy         *string `json:"-" url:"sortBy,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersRequest) SetLimit(limit *int) {
+	l.Limit = limit
+	l.require(listUsersRequestFieldLimit)
+}
+
+func (l *ListUsersRequest) SetOffset(offset *int) {
+	l.Offset = offset
+	l.require(listUsersRequestFieldOffset)
+}
+
+func (l *ListUsersRequest) SetIncludeDeleted(includeDeleted *bool) {
+	l.IncludeDeleted = includeDeleted
+	l.require(listUsersRequestFieldIncludeDeleted)
+}
+
+func (l *ListUsersRequest) SetSortBy(sortBy *string) {
+	l.SortBy = sortBy
+	l.require(listUsersRequestFieldSortBy)
+}
+
+var (
+	searchUsersRequestFieldQuery      = big.NewInt(1 << 0)
+	searchUsersRequestFieldDepartment = big.NewInt(1 << 1)
+	searchUsersRequestFieldRole       = big.NewInt(1 << 2)
+	searchUsersRequestFieldIsActive   = big.NewInt(1 << 3)
+)
 
 type SearchUsersRequest struct {
 	Query      string  `json:"-" url:"query"`
 	Department *string `json:"-" url:"department,omitempty"`
 	Role       *string `json:"-" url:"role,omitempty"`
 	IsActive   *bool   `json:"-" url:"isActive,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (s *SearchUsersRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchUsersRequest) SetQuery(query string) {
+	s.Query = query
+	s.require(searchUsersRequestFieldQuery)
+}
+
+func (s *SearchUsersRequest) SetDepartment(department *string) {
+	s.Department = department
+	s.require(searchUsersRequestFieldDepartment)
+}
+
+func (s *SearchUsersRequest) SetRole(role *string) {
+	s.Role = role
+	s.require(searchUsersRequestFieldRole)
+}
+
+func (s *SearchUsersRequest) SetIsActive(isActive *bool) {
+	s.IsActive = isActive
+	s.require(searchUsersRequestFieldIsActive)
 }
 
 // Nested object for testing
+var (
+	addressFieldStreet     = big.NewInt(1 << 0)
+	addressFieldCity       = big.NewInt(1 << 1)
+	addressFieldState      = big.NewInt(1 << 2)
+	addressFieldZipCode    = big.NewInt(1 << 3)
+	addressFieldCountry    = big.NewInt(1 << 4)
+	addressFieldBuildingId = big.NewInt(1 << 5)
+	addressFieldTenantId   = big.NewInt(1 << 6)
+)
+
 type Address struct {
 	Street     string         `json:"street" url:"street"`
 	City       *string        `json:"city,omitempty" url:"city,omitempty"`
@@ -44,6 +191,9 @@ type Address struct {
 	Country    *string        `json:"country,omitempty" url:"country,omitempty"`
 	BuildingId NullableUserId `json:"buildingId,omitempty" url:"buildingId,omitempty"`
 	TenantId   OptionalUserId `json:"tenantId,omitempty" url:"tenantId,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -102,6 +252,48 @@ func (a *Address) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Address) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Address) SetStreet(street string) {
+	a.Street = street
+	a.require(addressFieldStreet)
+}
+
+func (a *Address) SetCity(city *string) {
+	a.City = city
+	a.require(addressFieldCity)
+}
+
+func (a *Address) SetState(state *string) {
+	a.State = state
+	a.require(addressFieldState)
+}
+
+func (a *Address) SetZipCode(zipCode string) {
+	a.ZipCode = zipCode
+	a.require(addressFieldZipCode)
+}
+
+func (a *Address) SetCountry(country *string) {
+	a.Country = country
+	a.require(addressFieldCountry)
+}
+
+func (a *Address) SetBuildingId(buildingId NullableUserId) {
+	a.BuildingId = buildingId
+	a.require(addressFieldBuildingId)
+}
+
+func (a *Address) SetTenantId(tenantId OptionalUserId) {
+	a.TenantId = tenantId
+	a.require(addressFieldTenantId)
+}
+
 func (a *Address) UnmarshalJSON(data []byte) error {
 	type unmarshaler Address
 	var value unmarshaler
@@ -118,6 +310,17 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *Address) MarshalJSON() ([]byte, error) {
+	type embed Address
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *Address) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -131,6 +334,28 @@ func (a *Address) String() string {
 }
 
 // Test object with nullable enums, unions, and arrays
+var (
+	complexProfileFieldId                           = big.NewInt(1 << 0)
+	complexProfileFieldNullableRole                 = big.NewInt(1 << 1)
+	complexProfileFieldOptionalRole                 = big.NewInt(1 << 2)
+	complexProfileFieldOptionalNullableRole         = big.NewInt(1 << 3)
+	complexProfileFieldNullableStatus               = big.NewInt(1 << 4)
+	complexProfileFieldOptionalStatus               = big.NewInt(1 << 5)
+	complexProfileFieldOptionalNullableStatus       = big.NewInt(1 << 6)
+	complexProfileFieldNullableNotification         = big.NewInt(1 << 7)
+	complexProfileFieldOptionalNotification         = big.NewInt(1 << 8)
+	complexProfileFieldOptionalNullableNotification = big.NewInt(1 << 9)
+	complexProfileFieldNullableSearchResult         = big.NewInt(1 << 10)
+	complexProfileFieldOptionalSearchResult         = big.NewInt(1 << 11)
+	complexProfileFieldNullableArray                = big.NewInt(1 << 12)
+	complexProfileFieldOptionalArray                = big.NewInt(1 << 13)
+	complexProfileFieldOptionalNullableArray        = big.NewInt(1 << 14)
+	complexProfileFieldNullableListOfNullables      = big.NewInt(1 << 15)
+	complexProfileFieldNullableMapOfNullables       = big.NewInt(1 << 16)
+	complexProfileFieldNullableListOfUnions         = big.NewInt(1 << 17)
+	complexProfileFieldOptionalMapOfEnums           = big.NewInt(1 << 18)
+)
+
 type ComplexProfile struct {
 	Id                           string                `json:"id" url:"id"`
 	NullableRole                 *UserRole             `json:"nullableRole,omitempty" url:"nullableRole,omitempty"`
@@ -151,6 +376,9 @@ type ComplexProfile struct {
 	NullableMapOfNullables       map[string]*Address   `json:"nullableMapOfNullables,omitempty" url:"nullableMapOfNullables,omitempty"`
 	NullableListOfUnions         []*NotificationMethod `json:"nullableListOfUnions,omitempty" url:"nullableListOfUnions,omitempty"`
 	OptionalMapOfEnums           map[string]UserRole   `json:"optionalMapOfEnums,omitempty" url:"optionalMapOfEnums,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -293,6 +521,108 @@ func (c *ComplexProfile) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *ComplexProfile) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *ComplexProfile) SetId(id string) {
+	c.Id = id
+	c.require(complexProfileFieldId)
+}
+
+func (c *ComplexProfile) SetNullableRole(nullableRole *UserRole) {
+	c.NullableRole = nullableRole
+	c.require(complexProfileFieldNullableRole)
+}
+
+func (c *ComplexProfile) SetOptionalRole(optionalRole *UserRole) {
+	c.OptionalRole = optionalRole
+	c.require(complexProfileFieldOptionalRole)
+}
+
+func (c *ComplexProfile) SetOptionalNullableRole(optionalNullableRole *UserRole) {
+	c.OptionalNullableRole = optionalNullableRole
+	c.require(complexProfileFieldOptionalNullableRole)
+}
+
+func (c *ComplexProfile) SetNullableStatus(nullableStatus *UserStatus) {
+	c.NullableStatus = nullableStatus
+	c.require(complexProfileFieldNullableStatus)
+}
+
+func (c *ComplexProfile) SetOptionalStatus(optionalStatus *UserStatus) {
+	c.OptionalStatus = optionalStatus
+	c.require(complexProfileFieldOptionalStatus)
+}
+
+func (c *ComplexProfile) SetOptionalNullableStatus(optionalNullableStatus *UserStatus) {
+	c.OptionalNullableStatus = optionalNullableStatus
+	c.require(complexProfileFieldOptionalNullableStatus)
+}
+
+func (c *ComplexProfile) SetNullableNotification(nullableNotification *NotificationMethod) {
+	c.NullableNotification = nullableNotification
+	c.require(complexProfileFieldNullableNotification)
+}
+
+func (c *ComplexProfile) SetOptionalNotification(optionalNotification *NotificationMethod) {
+	c.OptionalNotification = optionalNotification
+	c.require(complexProfileFieldOptionalNotification)
+}
+
+func (c *ComplexProfile) SetOptionalNullableNotification(optionalNullableNotification *NotificationMethod) {
+	c.OptionalNullableNotification = optionalNullableNotification
+	c.require(complexProfileFieldOptionalNullableNotification)
+}
+
+func (c *ComplexProfile) SetNullableSearchResult(nullableSearchResult *SearchResult) {
+	c.NullableSearchResult = nullableSearchResult
+	c.require(complexProfileFieldNullableSearchResult)
+}
+
+func (c *ComplexProfile) SetOptionalSearchResult(optionalSearchResult *SearchResult) {
+	c.OptionalSearchResult = optionalSearchResult
+	c.require(complexProfileFieldOptionalSearchResult)
+}
+
+func (c *ComplexProfile) SetNullableArray(nullableArray []string) {
+	c.NullableArray = nullableArray
+	c.require(complexProfileFieldNullableArray)
+}
+
+func (c *ComplexProfile) SetOptionalArray(optionalArray []string) {
+	c.OptionalArray = optionalArray
+	c.require(complexProfileFieldOptionalArray)
+}
+
+func (c *ComplexProfile) SetOptionalNullableArray(optionalNullableArray []string) {
+	c.OptionalNullableArray = optionalNullableArray
+	c.require(complexProfileFieldOptionalNullableArray)
+}
+
+func (c *ComplexProfile) SetNullableListOfNullables(nullableListOfNullables []*string) {
+	c.NullableListOfNullables = nullableListOfNullables
+	c.require(complexProfileFieldNullableListOfNullables)
+}
+
+func (c *ComplexProfile) SetNullableMapOfNullables(nullableMapOfNullables map[string]*Address) {
+	c.NullableMapOfNullables = nullableMapOfNullables
+	c.require(complexProfileFieldNullableMapOfNullables)
+}
+
+func (c *ComplexProfile) SetNullableListOfUnions(nullableListOfUnions []*NotificationMethod) {
+	c.NullableListOfUnions = nullableListOfUnions
+	c.require(complexProfileFieldNullableListOfUnions)
+}
+
+func (c *ComplexProfile) SetOptionalMapOfEnums(optionalMapOfEnums map[string]UserRole) {
+	c.OptionalMapOfEnums = optionalMapOfEnums
+	c.require(complexProfileFieldOptionalMapOfEnums)
+}
+
 func (c *ComplexProfile) UnmarshalJSON(data []byte) error {
 	type unmarshaler ComplexProfile
 	var value unmarshaler
@@ -309,6 +639,17 @@ func (c *ComplexProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *ComplexProfile) MarshalJSON() ([]byte, error) {
+	type embed ComplexProfile
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *ComplexProfile) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -321,11 +662,21 @@ func (c *ComplexProfile) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	createUserRequestFieldUsername = big.NewInt(1 << 0)
+	createUserRequestFieldEmail    = big.NewInt(1 << 1)
+	createUserRequestFieldPhone    = big.NewInt(1 << 2)
+	createUserRequestFieldAddress  = big.NewInt(1 << 3)
+)
+
 type CreateUserRequest struct {
 	Username string   `json:"username" url:"username"`
 	Email    *string  `json:"email,omitempty" url:"email,omitempty"`
 	Phone    *string  `json:"phone,omitempty" url:"phone,omitempty"`
 	Address  *Address `json:"address,omitempty" url:"address,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -363,6 +714,33 @@ func (c *CreateUserRequest) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CreateUserRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateUserRequest) SetUsername(username string) {
+	c.Username = username
+	c.require(createUserRequestFieldUsername)
+}
+
+func (c *CreateUserRequest) SetEmail(email *string) {
+	c.Email = email
+	c.require(createUserRequestFieldEmail)
+}
+
+func (c *CreateUserRequest) SetPhone(phone *string) {
+	c.Phone = phone
+	c.require(createUserRequestFieldPhone)
+}
+
+func (c *CreateUserRequest) SetAddress(address *Address) {
+	c.Address = address
+	c.require(createUserRequestFieldAddress)
+}
+
 func (c *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler CreateUserRequest
 	var value unmarshaler
@@ -379,6 +757,17 @@ func (c *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CreateUserRequest) MarshalJSON() ([]byte, error) {
+	type embed CreateUserRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CreateUserRequest) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -392,6 +781,21 @@ func (c *CreateUserRequest) String() string {
 }
 
 // Request body for testing deserialization of null values
+var (
+	deserializationTestRequestFieldRequiredString         = big.NewInt(1 << 0)
+	deserializationTestRequestFieldNullableString         = big.NewInt(1 << 1)
+	deserializationTestRequestFieldOptionalString         = big.NewInt(1 << 2)
+	deserializationTestRequestFieldOptionalNullableString = big.NewInt(1 << 3)
+	deserializationTestRequestFieldNullableEnum           = big.NewInt(1 << 4)
+	deserializationTestRequestFieldOptionalEnum           = big.NewInt(1 << 5)
+	deserializationTestRequestFieldNullableUnion          = big.NewInt(1 << 6)
+	deserializationTestRequestFieldOptionalUnion          = big.NewInt(1 << 7)
+	deserializationTestRequestFieldNullableList           = big.NewInt(1 << 8)
+	deserializationTestRequestFieldNullableMap            = big.NewInt(1 << 9)
+	deserializationTestRequestFieldNullableObject         = big.NewInt(1 << 10)
+	deserializationTestRequestFieldOptionalObject         = big.NewInt(1 << 11)
+)
+
 type DeserializationTestRequest struct {
 	RequiredString         string              `json:"requiredString" url:"requiredString"`
 	NullableString         *string             `json:"nullableString,omitempty" url:"nullableString,omitempty"`
@@ -405,6 +809,9 @@ type DeserializationTestRequest struct {
 	NullableMap            map[string]int      `json:"nullableMap,omitempty" url:"nullableMap,omitempty"`
 	NullableObject         *Address            `json:"nullableObject,omitempty" url:"nullableObject,omitempty"`
 	OptionalObject         *Organization       `json:"optionalObject,omitempty" url:"optionalObject,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -498,6 +905,73 @@ func (d *DeserializationTestRequest) GetExtraProperties() map[string]interface{}
 	return d.extraProperties
 }
 
+func (d *DeserializationTestRequest) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DeserializationTestRequest) SetRequiredString(requiredString string) {
+	d.RequiredString = requiredString
+	d.require(deserializationTestRequestFieldRequiredString)
+}
+
+func (d *DeserializationTestRequest) SetNullableString(nullableString *string) {
+	d.NullableString = nullableString
+	d.require(deserializationTestRequestFieldNullableString)
+}
+
+func (d *DeserializationTestRequest) SetOptionalString(optionalString *string) {
+	d.OptionalString = optionalString
+	d.require(deserializationTestRequestFieldOptionalString)
+}
+
+func (d *DeserializationTestRequest) SetOptionalNullableString(optionalNullableString *string) {
+	d.OptionalNullableString = optionalNullableString
+	d.require(deserializationTestRequestFieldOptionalNullableString)
+}
+
+func (d *DeserializationTestRequest) SetNullableEnum(nullableEnum *UserRole) {
+	d.NullableEnum = nullableEnum
+	d.require(deserializationTestRequestFieldNullableEnum)
+}
+
+func (d *DeserializationTestRequest) SetOptionalEnum(optionalEnum *UserStatus) {
+	d.OptionalEnum = optionalEnum
+	d.require(deserializationTestRequestFieldOptionalEnum)
+}
+
+func (d *DeserializationTestRequest) SetNullableUnion(nullableUnion *NotificationMethod) {
+	d.NullableUnion = nullableUnion
+	d.require(deserializationTestRequestFieldNullableUnion)
+}
+
+func (d *DeserializationTestRequest) SetOptionalUnion(optionalUnion *SearchResult) {
+	d.OptionalUnion = optionalUnion
+	d.require(deserializationTestRequestFieldOptionalUnion)
+}
+
+func (d *DeserializationTestRequest) SetNullableList(nullableList []string) {
+	d.NullableList = nullableList
+	d.require(deserializationTestRequestFieldNullableList)
+}
+
+func (d *DeserializationTestRequest) SetNullableMap(nullableMap map[string]int) {
+	d.NullableMap = nullableMap
+	d.require(deserializationTestRequestFieldNullableMap)
+}
+
+func (d *DeserializationTestRequest) SetNullableObject(nullableObject *Address) {
+	d.NullableObject = nullableObject
+	d.require(deserializationTestRequestFieldNullableObject)
+}
+
+func (d *DeserializationTestRequest) SetOptionalObject(optionalObject *Organization) {
+	d.OptionalObject = optionalObject
+	d.require(deserializationTestRequestFieldOptionalObject)
+}
+
 func (d *DeserializationTestRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler DeserializationTestRequest
 	var value unmarshaler
@@ -514,6 +988,17 @@ func (d *DeserializationTestRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DeserializationTestRequest) MarshalJSON() ([]byte, error) {
+	type embed DeserializationTestRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DeserializationTestRequest) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -527,11 +1012,21 @@ func (d *DeserializationTestRequest) String() string {
 }
 
 // Response for deserialization test
+var (
+	deserializationTestResponseFieldEcho               = big.NewInt(1 << 0)
+	deserializationTestResponseFieldProcessedAt        = big.NewInt(1 << 1)
+	deserializationTestResponseFieldNullCount          = big.NewInt(1 << 2)
+	deserializationTestResponseFieldPresentFieldsCount = big.NewInt(1 << 3)
+)
+
 type DeserializationTestResponse struct {
 	Echo               *DeserializationTestRequest `json:"echo" url:"echo"`
 	ProcessedAt        time.Time                   `json:"processedAt" url:"processedAt"`
 	NullCount          int                         `json:"nullCount" url:"nullCount"`
 	PresentFieldsCount int                         `json:"presentFieldsCount" url:"presentFieldsCount"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -569,6 +1064,33 @@ func (d *DeserializationTestResponse) GetExtraProperties() map[string]interface{
 	return d.extraProperties
 }
 
+func (d *DeserializationTestResponse) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DeserializationTestResponse) SetEcho(echo *DeserializationTestRequest) {
+	d.Echo = echo
+	d.require(deserializationTestResponseFieldEcho)
+}
+
+func (d *DeserializationTestResponse) SetProcessedAt(processedAt time.Time) {
+	d.ProcessedAt = processedAt
+	d.require(deserializationTestResponseFieldProcessedAt)
+}
+
+func (d *DeserializationTestResponse) SetNullCount(nullCount int) {
+	d.NullCount = nullCount
+	d.require(deserializationTestResponseFieldNullCount)
+}
+
+func (d *DeserializationTestResponse) SetPresentFieldsCount(presentFieldsCount int) {
+	d.PresentFieldsCount = presentFieldsCount
+	d.require(deserializationTestResponseFieldPresentFieldsCount)
+}
+
 func (d *DeserializationTestResponse) UnmarshalJSON(data []byte) error {
 	type embed DeserializationTestResponse
 	var unmarshaler = struct {
@@ -600,7 +1122,8 @@ func (d *DeserializationTestResponse) MarshalJSON() ([]byte, error) {
 		embed:       embed(*d),
 		ProcessedAt: internal.NewDateTime(d.ProcessedAt),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (d *DeserializationTestResponse) String() string {
@@ -615,12 +1138,23 @@ func (d *DeserializationTestResponse) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	documentFieldId      = big.NewInt(1 << 0)
+	documentFieldTitle   = big.NewInt(1 << 1)
+	documentFieldContent = big.NewInt(1 << 2)
+	documentFieldAuthor  = big.NewInt(1 << 3)
+	documentFieldTags    = big.NewInt(1 << 4)
+)
+
 type Document struct {
 	Id      string   `json:"id" url:"id"`
 	Title   string   `json:"title" url:"title"`
 	Content string   `json:"content" url:"content"`
 	Author  *string  `json:"author,omitempty" url:"author,omitempty"`
 	Tags    []string `json:"tags,omitempty" url:"tags,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -665,6 +1199,38 @@ func (d *Document) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Document) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Document) SetId(id string) {
+	d.Id = id
+	d.require(documentFieldId)
+}
+
+func (d *Document) SetTitle(title string) {
+	d.Title = title
+	d.require(documentFieldTitle)
+}
+
+func (d *Document) SetContent(content string) {
+	d.Content = content
+	d.require(documentFieldContent)
+}
+
+func (d *Document) SetAuthor(author *string) {
+	d.Author = author
+	d.require(documentFieldAuthor)
+}
+
+func (d *Document) SetTags(tags []string) {
+	d.Tags = tags
+	d.require(documentFieldTags)
+}
+
 func (d *Document) UnmarshalJSON(data []byte) error {
 	type unmarshaler Document
 	var value unmarshaler
@@ -681,6 +1247,17 @@ func (d *Document) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Document) MarshalJSON() ([]byte, error) {
+	type embed Document
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *Document) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -693,10 +1270,19 @@ func (d *Document) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	emailNotificationFieldEmailAddress = big.NewInt(1 << 0)
+	emailNotificationFieldSubject      = big.NewInt(1 << 1)
+	emailNotificationFieldHtmlContent  = big.NewInt(1 << 2)
+)
+
 type EmailNotification struct {
 	EmailAddress string  `json:"emailAddress" url:"emailAddress"`
 	Subject      string  `json:"subject" url:"subject"`
 	HtmlContent  *string `json:"htmlContent,omitempty" url:"htmlContent,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -727,6 +1313,28 @@ func (e *EmailNotification) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *EmailNotification) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *EmailNotification) SetEmailAddress(emailAddress string) {
+	e.EmailAddress = emailAddress
+	e.require(emailNotificationFieldEmailAddress)
+}
+
+func (e *EmailNotification) SetSubject(subject string) {
+	e.Subject = subject
+	e.require(emailNotificationFieldSubject)
+}
+
+func (e *EmailNotification) SetHtmlContent(htmlContent *string) {
+	e.HtmlContent = htmlContent
+	e.require(emailNotificationFieldHtmlContent)
+}
+
 func (e *EmailNotification) UnmarshalJSON(data []byte) error {
 	type unmarshaler EmailNotification
 	var value unmarshaler
@@ -741,6 +1349,17 @@ func (e *EmailNotification) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *EmailNotification) MarshalJSON() ([]byte, error) {
+	type embed EmailNotification
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *EmailNotification) String() string {
@@ -903,11 +1522,21 @@ type NullableUserId = *string
 // An alias for an optional user ID
 type OptionalUserId = *string
 
+var (
+	organizationFieldId            = big.NewInt(1 << 0)
+	organizationFieldName          = big.NewInt(1 << 1)
+	organizationFieldDomain        = big.NewInt(1 << 2)
+	organizationFieldEmployeeCount = big.NewInt(1 << 3)
+)
+
 type Organization struct {
 	Id            string  `json:"id" url:"id"`
 	Name          string  `json:"name" url:"name"`
 	Domain        *string `json:"domain,omitempty" url:"domain,omitempty"`
 	EmployeeCount *int    `json:"employeeCount,omitempty" url:"employeeCount,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -945,6 +1574,33 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *Organization) SetId(id string) {
+	o.Id = id
+	o.require(organizationFieldId)
+}
+
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
+func (o *Organization) SetDomain(domain *string) {
+	o.Domain = domain
+	o.require(organizationFieldDomain)
+}
+
+func (o *Organization) SetEmployeeCount(employeeCount *int) {
+	o.EmployeeCount = employeeCount
+	o.require(organizationFieldEmployeeCount)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -961,6 +1617,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (o *Organization) String() string {
 	if len(o.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(o.rawJSON); err == nil {
@@ -973,11 +1640,21 @@ func (o *Organization) String() string {
 	return fmt.Sprintf("%#v", o)
 }
 
+var (
+	pushNotificationFieldDeviceToken = big.NewInt(1 << 0)
+	pushNotificationFieldTitle       = big.NewInt(1 << 1)
+	pushNotificationFieldBody        = big.NewInt(1 << 2)
+	pushNotificationFieldBadge       = big.NewInt(1 << 3)
+)
+
 type PushNotification struct {
 	DeviceToken string `json:"deviceToken" url:"deviceToken"`
 	Title       string `json:"title" url:"title"`
 	Body        string `json:"body" url:"body"`
 	Badge       *int   `json:"badge,omitempty" url:"badge,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1015,6 +1692,33 @@ func (p *PushNotification) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *PushNotification) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PushNotification) SetDeviceToken(deviceToken string) {
+	p.DeviceToken = deviceToken
+	p.require(pushNotificationFieldDeviceToken)
+}
+
+func (p *PushNotification) SetTitle(title string) {
+	p.Title = title
+	p.require(pushNotificationFieldTitle)
+}
+
+func (p *PushNotification) SetBody(body string) {
+	p.Body = body
+	p.require(pushNotificationFieldBody)
+}
+
+func (p *PushNotification) SetBadge(badge *int) {
+	p.Badge = badge
+	p.require(pushNotificationFieldBadge)
+}
+
 func (p *PushNotification) UnmarshalJSON(data []byte) error {
 	type unmarshaler PushNotification
 	var value unmarshaler
@@ -1029,6 +1733,17 @@ func (p *PushNotification) UnmarshalJSON(data []byte) error {
 	p.extraProperties = extraProperties
 	p.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (p *PushNotification) MarshalJSON() ([]byte, error) {
+	type embed PushNotification
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *PushNotification) String() string {
@@ -1185,10 +1900,19 @@ func (s *SearchResult) validate() error {
 	return nil
 }
 
+var (
+	smsNotificationFieldPhoneNumber = big.NewInt(1 << 0)
+	smsNotificationFieldMessage     = big.NewInt(1 << 1)
+	smsNotificationFieldShortCode   = big.NewInt(1 << 2)
+)
+
 type SmsNotification struct {
 	PhoneNumber string  `json:"phoneNumber" url:"phoneNumber"`
 	Message     string  `json:"message" url:"message"`
 	ShortCode   *string `json:"shortCode,omitempty" url:"shortCode,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1219,6 +1943,28 @@ func (s *SmsNotification) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SmsNotification) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SmsNotification) SetPhoneNumber(phoneNumber string) {
+	s.PhoneNumber = phoneNumber
+	s.require(smsNotificationFieldPhoneNumber)
+}
+
+func (s *SmsNotification) SetMessage(message string) {
+	s.Message = message
+	s.require(smsNotificationFieldMessage)
+}
+
+func (s *SmsNotification) SetShortCode(shortCode *string) {
+	s.ShortCode = shortCode
+	s.require(smsNotificationFieldShortCode)
+}
+
 func (s *SmsNotification) UnmarshalJSON(data []byte) error {
 	type unmarshaler SmsNotification
 	var value unmarshaler
@@ -1235,6 +1981,17 @@ func (s *SmsNotification) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SmsNotification) MarshalJSON() ([]byte, error) {
+	type embed SmsNotification
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SmsNotification) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -1248,11 +2005,21 @@ func (s *SmsNotification) String() string {
 }
 
 // For testing PATCH operations
+var (
+	updateUserRequestFieldUsername = big.NewInt(1 << 0)
+	updateUserRequestFieldEmail    = big.NewInt(1 << 1)
+	updateUserRequestFieldPhone    = big.NewInt(1 << 2)
+	updateUserRequestFieldAddress  = big.NewInt(1 << 3)
+)
+
 type UpdateUserRequest struct {
 	Username *string  `json:"username,omitempty" url:"username,omitempty"`
 	Email    *string  `json:"email,omitempty" url:"email,omitempty"`
 	Phone    *string  `json:"phone,omitempty" url:"phone,omitempty"`
 	Address  *Address `json:"address,omitempty" url:"address,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1290,6 +2057,33 @@ func (u *UpdateUserRequest) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UpdateUserRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UpdateUserRequest) SetUsername(username *string) {
+	u.Username = username
+	u.require(updateUserRequestFieldUsername)
+}
+
+func (u *UpdateUserRequest) SetEmail(email *string) {
+	u.Email = email
+	u.require(updateUserRequestFieldEmail)
+}
+
+func (u *UpdateUserRequest) SetPhone(phone *string) {
+	u.Phone = phone
+	u.require(updateUserRequestFieldPhone)
+}
+
+func (u *UpdateUserRequest) SetAddress(address *Address) {
+	u.Address = address
+	u.require(updateUserRequestFieldAddress)
+}
+
 func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler UpdateUserRequest
 	var value unmarshaler
@@ -1306,6 +2100,17 @@ func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UpdateUserRequest) MarshalJSON() ([]byte, error) {
+	type embed UpdateUserRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UpdateUserRequest) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -1319,6 +2124,27 @@ func (u *UpdateUserRequest) String() string {
 }
 
 // Test object with nullable and optional fields
+var (
+	userProfileFieldId                     = big.NewInt(1 << 0)
+	userProfileFieldUsername               = big.NewInt(1 << 1)
+	userProfileFieldNullableString         = big.NewInt(1 << 2)
+	userProfileFieldNullableInteger        = big.NewInt(1 << 3)
+	userProfileFieldNullableBoolean        = big.NewInt(1 << 4)
+	userProfileFieldNullableDate           = big.NewInt(1 << 5)
+	userProfileFieldNullableObject         = big.NewInt(1 << 6)
+	userProfileFieldNullableList           = big.NewInt(1 << 7)
+	userProfileFieldNullableMap            = big.NewInt(1 << 8)
+	userProfileFieldOptionalString         = big.NewInt(1 << 9)
+	userProfileFieldOptionalInteger        = big.NewInt(1 << 10)
+	userProfileFieldOptionalBoolean        = big.NewInt(1 << 11)
+	userProfileFieldOptionalDate           = big.NewInt(1 << 12)
+	userProfileFieldOptionalObject         = big.NewInt(1 << 13)
+	userProfileFieldOptionalList           = big.NewInt(1 << 14)
+	userProfileFieldOptionalMap            = big.NewInt(1 << 15)
+	userProfileFieldOptionalNullableString = big.NewInt(1 << 16)
+	userProfileFieldOptionalNullableObject = big.NewInt(1 << 17)
+)
+
 type UserProfile struct {
 	Id                     string            `json:"id" url:"id"`
 	Username               string            `json:"username" url:"username"`
@@ -1338,6 +2164,9 @@ type UserProfile struct {
 	OptionalMap            map[string]string `json:"optionalMap,omitempty" url:"optionalMap,omitempty"`
 	OptionalNullableString *string           `json:"optionalNullableString,omitempty" url:"optionalNullableString,omitempty"`
 	OptionalNullableObject *Address          `json:"optionalNullableObject,omitempty" url:"optionalNullableObject,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1473,6 +2302,103 @@ func (u *UserProfile) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserProfile) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UserProfile) SetId(id string) {
+	u.Id = id
+	u.require(userProfileFieldId)
+}
+
+func (u *UserProfile) SetUsername(username string) {
+	u.Username = username
+	u.require(userProfileFieldUsername)
+}
+
+func (u *UserProfile) SetNullableString(nullableString *string) {
+	u.NullableString = nullableString
+	u.require(userProfileFieldNullableString)
+}
+
+func (u *UserProfile) SetNullableInteger(nullableInteger *int) {
+	u.NullableInteger = nullableInteger
+	u.require(userProfileFieldNullableInteger)
+}
+
+func (u *UserProfile) SetNullableBoolean(nullableBoolean *bool) {
+	u.NullableBoolean = nullableBoolean
+	u.require(userProfileFieldNullableBoolean)
+}
+
+func (u *UserProfile) SetNullableDate(nullableDate *time.Time) {
+	u.NullableDate = nullableDate
+	u.require(userProfileFieldNullableDate)
+}
+
+func (u *UserProfile) SetNullableObject(nullableObject *Address) {
+	u.NullableObject = nullableObject
+	u.require(userProfileFieldNullableObject)
+}
+
+func (u *UserProfile) SetNullableList(nullableList []string) {
+	u.NullableList = nullableList
+	u.require(userProfileFieldNullableList)
+}
+
+func (u *UserProfile) SetNullableMap(nullableMap map[string]string) {
+	u.NullableMap = nullableMap
+	u.require(userProfileFieldNullableMap)
+}
+
+func (u *UserProfile) SetOptionalString(optionalString *string) {
+	u.OptionalString = optionalString
+	u.require(userProfileFieldOptionalString)
+}
+
+func (u *UserProfile) SetOptionalInteger(optionalInteger *int) {
+	u.OptionalInteger = optionalInteger
+	u.require(userProfileFieldOptionalInteger)
+}
+
+func (u *UserProfile) SetOptionalBoolean(optionalBoolean *bool) {
+	u.OptionalBoolean = optionalBoolean
+	u.require(userProfileFieldOptionalBoolean)
+}
+
+func (u *UserProfile) SetOptionalDate(optionalDate *time.Time) {
+	u.OptionalDate = optionalDate
+	u.require(userProfileFieldOptionalDate)
+}
+
+func (u *UserProfile) SetOptionalObject(optionalObject *Address) {
+	u.OptionalObject = optionalObject
+	u.require(userProfileFieldOptionalObject)
+}
+
+func (u *UserProfile) SetOptionalList(optionalList []string) {
+	u.OptionalList = optionalList
+	u.require(userProfileFieldOptionalList)
+}
+
+func (u *UserProfile) SetOptionalMap(optionalMap map[string]string) {
+	u.OptionalMap = optionalMap
+	u.require(userProfileFieldOptionalMap)
+}
+
+func (u *UserProfile) SetOptionalNullableString(optionalNullableString *string) {
+	u.OptionalNullableString = optionalNullableString
+	u.require(userProfileFieldOptionalNullableString)
+}
+
+func (u *UserProfile) SetOptionalNullableObject(optionalNullableObject *Address) {
+	u.OptionalNullableObject = optionalNullableObject
+	u.require(userProfileFieldOptionalNullableObject)
+}
+
 func (u *UserProfile) UnmarshalJSON(data []byte) error {
 	type embed UserProfile
 	var unmarshaler = struct {
@@ -1508,7 +2434,8 @@ func (u *UserProfile) MarshalJSON() ([]byte, error) {
 		NullableDate: internal.NewOptionalDateTime(u.NullableDate),
 		OptionalDate: internal.NewOptionalDateTime(u.OptionalDate),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UserProfile) String() string {
@@ -1523,6 +2450,16 @@ func (u *UserProfile) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userResponseFieldId        = big.NewInt(1 << 0)
+	userResponseFieldUsername  = big.NewInt(1 << 1)
+	userResponseFieldEmail     = big.NewInt(1 << 2)
+	userResponseFieldPhone     = big.NewInt(1 << 3)
+	userResponseFieldCreatedAt = big.NewInt(1 << 4)
+	userResponseFieldUpdatedAt = big.NewInt(1 << 5)
+	userResponseFieldAddress   = big.NewInt(1 << 6)
+)
+
 type UserResponse struct {
 	Id        string     `json:"id" url:"id"`
 	Username  string     `json:"username" url:"username"`
@@ -1531,6 +2468,9 @@ type UserResponse struct {
 	CreatedAt time.Time  `json:"createdAt" url:"createdAt"`
 	UpdatedAt *time.Time `json:"updatedAt,omitempty" url:"updatedAt,omitempty"`
 	Address   *Address   `json:"address,omitempty" url:"address,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1589,6 +2529,48 @@ func (u *UserResponse) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserResponse) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UserResponse) SetId(id string) {
+	u.Id = id
+	u.require(userResponseFieldId)
+}
+
+func (u *UserResponse) SetUsername(username string) {
+	u.Username = username
+	u.require(userResponseFieldUsername)
+}
+
+func (u *UserResponse) SetEmail(email *string) {
+	u.Email = email
+	u.require(userResponseFieldEmail)
+}
+
+func (u *UserResponse) SetPhone(phone *string) {
+	u.Phone = phone
+	u.require(userResponseFieldPhone)
+}
+
+func (u *UserResponse) SetCreatedAt(createdAt time.Time) {
+	u.CreatedAt = createdAt
+	u.require(userResponseFieldCreatedAt)
+}
+
+func (u *UserResponse) SetUpdatedAt(updatedAt *time.Time) {
+	u.UpdatedAt = updatedAt
+	u.require(userResponseFieldUpdatedAt)
+}
+
+func (u *UserResponse) SetAddress(address *Address) {
+	u.Address = address
+	u.require(userResponseFieldAddress)
+}
+
 func (u *UserResponse) UnmarshalJSON(data []byte) error {
 	type embed UserResponse
 	var unmarshaler = struct {
@@ -1624,7 +2606,8 @@ func (u *UserResponse) MarshalJSON() ([]byte, error) {
 		CreatedAt: internal.NewDateTime(u.CreatedAt),
 		UpdatedAt: internal.NewOptionalDateTime(u.UpdatedAt),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *UserResponse) String() string {
@@ -1697,16 +2680,90 @@ func (u UserStatus) Ptr() *UserStatus {
 	return &u
 }
 
+var (
+	updateComplexProfileRequestFieldNullableRole         = big.NewInt(1 << 0)
+	updateComplexProfileRequestFieldNullableStatus       = big.NewInt(1 << 1)
+	updateComplexProfileRequestFieldNullableNotification = big.NewInt(1 << 2)
+	updateComplexProfileRequestFieldNullableSearchResult = big.NewInt(1 << 3)
+	updateComplexProfileRequestFieldNullableArray        = big.NewInt(1 << 4)
+)
+
 type UpdateComplexProfileRequest struct {
 	NullableRole         *UserRole           `json:"nullableRole,omitempty" url:"-"`
 	NullableStatus       *UserStatus         `json:"nullableStatus,omitempty" url:"-"`
 	NullableNotification *NotificationMethod `json:"nullableNotification,omitempty" url:"-"`
 	NullableSearchResult *SearchResult       `json:"nullableSearchResult,omitempty" url:"-"`
 	NullableArray        []string            `json:"nullableArray,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (u *UpdateComplexProfileRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UpdateComplexProfileRequest) SetNullableRole(nullableRole *UserRole) {
+	u.NullableRole = nullableRole
+	u.require(updateComplexProfileRequestFieldNullableRole)
+}
+
+func (u *UpdateComplexProfileRequest) SetNullableStatus(nullableStatus *UserStatus) {
+	u.NullableStatus = nullableStatus
+	u.require(updateComplexProfileRequestFieldNullableStatus)
+}
+
+func (u *UpdateComplexProfileRequest) SetNullableNotification(nullableNotification *NotificationMethod) {
+	u.NullableNotification = nullableNotification
+	u.require(updateComplexProfileRequestFieldNullableNotification)
+}
+
+func (u *UpdateComplexProfileRequest) SetNullableSearchResult(nullableSearchResult *SearchResult) {
+	u.NullableSearchResult = nullableSearchResult
+	u.require(updateComplexProfileRequestFieldNullableSearchResult)
+}
+
+func (u *UpdateComplexProfileRequest) SetNullableArray(nullableArray []string) {
+	u.NullableArray = nullableArray
+	u.require(updateComplexProfileRequestFieldNullableArray)
+}
+
+var (
+	updateTagsRequestFieldTags       = big.NewInt(1 << 0)
+	updateTagsRequestFieldCategories = big.NewInt(1 << 1)
+	updateTagsRequestFieldLabels     = big.NewInt(1 << 2)
+)
 
 type UpdateTagsRequest struct {
 	Tags       []string `json:"tags,omitempty" url:"-"`
 	Categories []string `json:"categories,omitempty" url:"-"`
 	Labels     []string `json:"labels,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (u *UpdateTagsRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UpdateTagsRequest) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(updateTagsRequestFieldTags)
+}
+
+func (u *UpdateTagsRequest) SetCategories(categories []string) {
+	u.Categories = categories
+	u.require(updateTagsRequestFieldCategories)
+}
+
+func (u *UpdateTagsRequest) SetLabels(labels []string) {
+	u.Labels = labels
+	u.require(updateTagsRequestFieldLabels)
 }

--- a/seed/go-sdk/nullable/internal/explicit_fields.go
+++ b/seed/go-sdk/nullable/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/nullable/internal/explicit_fields_test.go
+++ b/seed/go-sdk/nullable/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/nullable/nullable.go
+++ b/seed/go-sdk/nullable/nullable.go
@@ -6,7 +6,15 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/nullable/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	createUserRequestFieldUsername = big.NewInt(1 << 0)
+	createUserRequestFieldTags     = big.NewInt(1 << 1)
+	createUserRequestFieldMetadata = big.NewInt(1 << 2)
+	createUserRequestFieldAvatar   = big.NewInt(1 << 3)
 )
 
 type CreateUserRequest struct {
@@ -14,12 +22,69 @@ type CreateUserRequest struct {
 	Tags     []string  `json:"tags,omitempty" url:"-"`
 	Metadata *Metadata `json:"metadata,omitempty" url:"-"`
 	Avatar   *string   `json:"avatar,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (c *CreateUserRequest) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CreateUserRequest) SetUsername(username string) {
+	c.Username = username
+	c.require(createUserRequestFieldUsername)
+}
+
+func (c *CreateUserRequest) SetTags(tags []string) {
+	c.Tags = tags
+	c.require(createUserRequestFieldTags)
+}
+
+func (c *CreateUserRequest) SetMetadata(metadata *Metadata) {
+	c.Metadata = metadata
+	c.require(createUserRequestFieldMetadata)
+}
+
+func (c *CreateUserRequest) SetAvatar(avatar *string) {
+	c.Avatar = avatar
+	c.require(createUserRequestFieldAvatar)
+}
+
+var (
+	deleteUserRequestFieldUsername = big.NewInt(1 << 0)
+)
 
 type DeleteUserRequest struct {
 	// The user to delete.
 	Username *string `json:"username,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (d *DeleteUserRequest) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DeleteUserRequest) SetUsername(username *string) {
+	d.Username = username
+	d.require(deleteUserRequestFieldUsername)
+}
+
+var (
+	getUsersRequestFieldUsernames = big.NewInt(1 << 0)
+	getUsersRequestFieldAvatar    = big.NewInt(1 << 1)
+	getUsersRequestFieldActivated = big.NewInt(1 << 2)
+	getUsersRequestFieldTags      = big.NewInt(1 << 3)
+	getUsersRequestFieldExtra     = big.NewInt(1 << 4)
+)
 
 type GetUsersRequest struct {
 	Usernames []*string `json:"-" url:"usernames,omitempty"`
@@ -27,9 +92,53 @@ type GetUsersRequest struct {
 	Activated []*bool   `json:"-" url:"activated,omitempty"`
 	Tags      []*string `json:"-" url:"tags,omitempty"`
 	Extra     *bool     `json:"-" url:"extra,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (g *GetUsersRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetUsersRequest) SetUsernames(usernames []*string) {
+	g.Usernames = usernames
+	g.require(getUsersRequestFieldUsernames)
+}
+
+func (g *GetUsersRequest) SetAvatar(avatar *string) {
+	g.Avatar = avatar
+	g.require(getUsersRequestFieldAvatar)
+}
+
+func (g *GetUsersRequest) SetActivated(activated []*bool) {
+	g.Activated = activated
+	g.require(getUsersRequestFieldActivated)
+}
+
+func (g *GetUsersRequest) SetTags(tags []*string) {
+	g.Tags = tags
+	g.require(getUsersRequestFieldTags)
+}
+
+func (g *GetUsersRequest) SetExtra(extra *bool) {
+	g.Extra = extra
+	g.require(getUsersRequestFieldExtra)
 }
 
 type Email = *string
+
+var (
+	metadataFieldCreatedAt = big.NewInt(1 << 0)
+	metadataFieldUpdatedAt = big.NewInt(1 << 1)
+	metadataFieldAvatar    = big.NewInt(1 << 2)
+	metadataFieldActivated = big.NewInt(1 << 3)
+	metadataFieldStatus    = big.NewInt(1 << 4)
+	metadataFieldValues    = big.NewInt(1 << 5)
+)
 
 type Metadata struct {
 	CreatedAt time.Time          `json:"createdAt" url:"createdAt"`
@@ -38,6 +147,9 @@ type Metadata struct {
 	Activated *bool              `json:"activated,omitempty" url:"activated,omitempty"`
 	Status    *Status            `json:"status" url:"status"`
 	Values    map[string]*string `json:"values,omitempty" url:"values,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -89,6 +201,43 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetCreatedAt(createdAt time.Time) {
+	m.CreatedAt = createdAt
+	m.require(metadataFieldCreatedAt)
+}
+
+func (m *Metadata) SetUpdatedAt(updatedAt time.Time) {
+	m.UpdatedAt = updatedAt
+	m.require(metadataFieldUpdatedAt)
+}
+
+func (m *Metadata) SetAvatar(avatar *string) {
+	m.Avatar = avatar
+	m.require(metadataFieldAvatar)
+}
+
+func (m *Metadata) SetActivated(activated *bool) {
+	m.Activated = activated
+	m.require(metadataFieldActivated)
+}
+
+func (m *Metadata) SetStatus(status *Status) {
+	m.Status = status
+	m.require(metadataFieldStatus)
+}
+
+func (m *Metadata) SetValues(values map[string]*string) {
+	m.Values = values
+	m.require(metadataFieldValues)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type embed Metadata
 	var unmarshaler = struct {
@@ -124,7 +273,8 @@ func (m *Metadata) MarshalJSON() ([]byte, error) {
 		CreatedAt: internal.NewDateTime(m.CreatedAt),
 		UpdatedAt: internal.NewDateTime(m.UpdatedAt),
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {
@@ -305,6 +455,17 @@ func (s *Status) validate() error {
 	return nil
 }
 
+var (
+	userFieldName           = big.NewInt(1 << 0)
+	userFieldId             = big.NewInt(1 << 1)
+	userFieldTags           = big.NewInt(1 << 2)
+	userFieldMetadata       = big.NewInt(1 << 3)
+	userFieldEmail          = big.NewInt(1 << 4)
+	userFieldFavoriteNumber = big.NewInt(1 << 5)
+	userFieldNumbers        = big.NewInt(1 << 6)
+	userFieldStrings        = big.NewInt(1 << 7)
+)
+
 type User struct {
 	Name           string                 `json:"name" url:"name"`
 	Id             UserId                 `json:"id" url:"id"`
@@ -314,6 +475,9 @@ type User struct {
 	FavoriteNumber *WeirdNumber           `json:"favorite-number" url:"favorite-number"`
 	Numbers        []int                  `json:"numbers,omitempty" url:"numbers,omitempty"`
 	Strings        map[string]interface{} `json:"strings,omitempty" url:"strings,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -379,6 +543,53 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetId(id UserId) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
+func (u *User) SetMetadata(metadata *Metadata) {
+	u.Metadata = metadata
+	u.require(userFieldMetadata)
+}
+
+func (u *User) SetEmail(email Email) {
+	u.Email = email
+	u.require(userFieldEmail)
+}
+
+func (u *User) SetFavoriteNumber(favoriteNumber *WeirdNumber) {
+	u.FavoriteNumber = favoriteNumber
+	u.require(userFieldFavoriteNumber)
+}
+
+func (u *User) SetNumbers(numbers []int) {
+	u.Numbers = numbers
+	u.require(userFieldNumbers)
+}
+
+func (u *User) SetStrings(strings map[string]interface{}) {
+	u.Strings = strings
+	u.require(userFieldStrings)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -393,6 +604,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/nullable/nullable.go
+++ b/seed/go-sdk/nullable/nullable.go
@@ -34,21 +34,29 @@ func (c *CreateUserRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetUsername(username string) {
 	c.Username = username
 	c.require(createUserRequestFieldUsername)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetTags(tags []string) {
 	c.Tags = tags
 	c.require(createUserRequestFieldTags)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetMetadata(metadata *Metadata) {
 	c.Metadata = metadata
 	c.require(createUserRequestFieldMetadata)
 }
 
+// SetAvatar sets the Avatar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateUserRequest) SetAvatar(avatar *string) {
 	c.Avatar = avatar
 	c.require(createUserRequestFieldAvatar)
@@ -73,6 +81,8 @@ func (d *DeleteUserRequest) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetUsername sets the Username field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DeleteUserRequest) SetUsername(username *string) {
 	d.Username = username
 	d.require(deleteUserRequestFieldUsername)
@@ -104,26 +114,36 @@ func (g *GetUsersRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetUsernames sets the Usernames field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetUsernames(usernames []*string) {
 	g.Usernames = usernames
 	g.require(getUsersRequestFieldUsernames)
 }
 
+// SetAvatar sets the Avatar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetAvatar(avatar *string) {
 	g.Avatar = avatar
 	g.require(getUsersRequestFieldAvatar)
 }
 
+// SetActivated sets the Activated field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetActivated(activated []*bool) {
 	g.Activated = activated
 	g.require(getUsersRequestFieldActivated)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetTags(tags []*string) {
 	g.Tags = tags
 	g.require(getUsersRequestFieldTags)
 }
 
+// SetExtra sets the Extra field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetExtra(extra *bool) {
 	g.Extra = extra
 	g.require(getUsersRequestFieldExtra)
@@ -208,31 +228,43 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetCreatedAt sets the CreatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetCreatedAt(createdAt time.Time) {
 	m.CreatedAt = createdAt
 	m.require(metadataFieldCreatedAt)
 }
 
+// SetUpdatedAt sets the UpdatedAt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetUpdatedAt(updatedAt time.Time) {
 	m.UpdatedAt = updatedAt
 	m.require(metadataFieldUpdatedAt)
 }
 
+// SetAvatar sets the Avatar field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetAvatar(avatar *string) {
 	m.Avatar = avatar
 	m.require(metadataFieldAvatar)
 }
 
+// SetActivated sets the Activated field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetActivated(activated *bool) {
 	m.Activated = activated
 	m.require(metadataFieldActivated)
 }
 
+// SetStatus sets the Status field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetStatus(status *Status) {
 	m.Status = status
 	m.require(metadataFieldStatus)
 }
 
+// SetValues sets the Values field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetValues(values map[string]*string) {
 	m.Values = values
 	m.require(metadataFieldValues)
@@ -550,41 +582,57 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id UserId) {
 	u.Id = id
 	u.require(userFieldId)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetMetadata(metadata *Metadata) {
 	u.Metadata = metadata
 	u.require(userFieldMetadata)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetEmail(email Email) {
 	u.Email = email
 	u.require(userFieldEmail)
 }
 
+// SetFavoriteNumber sets the FavoriteNumber field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetFavoriteNumber(favoriteNumber *WeirdNumber) {
 	u.FavoriteNumber = favoriteNumber
 	u.require(userFieldFavoriteNumber)
 }
 
+// SetNumbers sets the Numbers field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetNumbers(numbers []int) {
 	u.Numbers = numbers
 	u.require(userFieldNumbers)
 }
 
+// SetStrings sets the Strings field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetStrings(strings map[string]interface{}) {
 	u.Strings = strings
 	u.require(userFieldStrings)

--- a/seed/go-sdk/oauth-client-credentials-custom/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/auth.go
@@ -6,6 +6,15 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-custom/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldCid      = big.NewInt(1 << 0)
+	getTokenRequestFieldCsr      = big.NewInt(1 << 1)
+	getTokenRequestFieldScp      = big.NewInt(1 << 2)
+	getTokenRequestFieldEntityId = big.NewInt(1 << 3)
+	getTokenRequestFieldScope    = big.NewInt(1 << 4)
 )
 
 type GetTokenRequest struct {
@@ -16,6 +25,9 @@ type GetTokenRequest struct {
 	Scope     *string `json:"scope,omitempty" url:"-"`
 	audience  string
 	grantType string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -24,6 +36,38 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetCid(cid string) {
+	g.Cid = cid
+	g.require(getTokenRequestFieldCid)
+}
+
+func (g *GetTokenRequest) SetCsr(csr string) {
+	g.Csr = csr
+	g.require(getTokenRequestFieldCsr)
+}
+
+func (g *GetTokenRequest) SetScp(scp string) {
+	g.Scp = scp
+	g.require(getTokenRequestFieldScp)
+}
+
+func (g *GetTokenRequest) SetEntityId(entityId string) {
+	g.EntityId = entityId
+	g.require(getTokenRequestFieldEntityId)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -49,8 +93,16 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 2)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 3)
+)
 
 type RefreshTokenRequest struct {
 	ClientId     string  `json:"client_id" url:"-"`
@@ -59,6 +111,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -67,6 +122,33 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -92,14 +174,24 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -130,6 +222,28 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -144,6 +258,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/oauth-client-credentials-custom/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/auth.go
@@ -45,26 +45,36 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetCid sets the Cid field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetCid(cid string) {
 	g.Cid = cid
 	g.require(getTokenRequestFieldCid)
 }
 
+// SetCsr sets the Csr field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetCsr(csr string) {
 	g.Csr = csr
 	g.require(getTokenRequestFieldCsr)
 }
 
+// SetScp sets the Scp field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScp(scp string) {
 	g.Scp = scp
 	g.require(getTokenRequestFieldScp)
 }
 
+// SetEntityId sets the EntityId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetEntityId(entityId string) {
 	g.EntityId = entityId
 	g.require(getTokenRequestFieldEntityId)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -131,21 +141,29 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -229,16 +247,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/explicit_fields.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/explicit_fields_test.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/oauth-client-credentials-default/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-default/auth.go
@@ -6,16 +6,42 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-default/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 1)
 )
 
 type GetTokenRequest struct {
 	ClientId     string `json:"client_id" url:"-"`
 	ClientSecret string `json:"client_secret" url:"-"`
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -38,13 +64,22 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		embed:     embed(*g),
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn   = big.NewInt(1 << 1)
+)
+
 type TokenResponse struct {
 	AccessToken string `json:"access_token" url:"access_token"`
 	ExpiresIn   int    `json:"expires_in" url:"expires_in"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -68,6 +103,23 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -82,6 +134,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/oauth-client-credentials-default/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-default/auth.go
@@ -34,11 +34,15 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
@@ -110,11 +114,15 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)

--- a/seed/go-sdk/oauth-client-credentials-default/internal/explicit_fields.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/oauth-client-credentials-default/internal/explicit_fields_test.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/auth.go
@@ -6,6 +6,13 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-environment-variables/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	getTokenRequestFieldScope        = big.NewInt(1 << 2)
 )
 
 type GetTokenRequest struct {
@@ -14,6 +21,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -22,6 +32,28 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -47,8 +79,16 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 2)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 3)
+)
 
 type RefreshTokenRequest struct {
 	ClientId     string  `json:"client_id" url:"-"`
@@ -57,6 +97,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -65,6 +108,33 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -90,14 +160,24 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -128,6 +208,28 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -142,6 +244,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/auth.go
@@ -41,16 +41,22 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -117,21 +123,29 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -215,16 +229,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/explicit_fields.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/explicit_fields_test.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/oauth-client-credentials-nested-root/auth/types.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/auth/types.go
@@ -41,16 +41,22 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -134,16 +140,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/explicit_fields.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/explicit_fields_test.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/oauth-client-credentials-with-variables/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/auth.go
@@ -41,16 +41,22 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -117,21 +123,29 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -215,16 +229,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/oauth-client-credentials-with-variables/auth.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/auth.go
@@ -6,6 +6,13 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials-with-variables/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	getTokenRequestFieldScope        = big.NewInt(1 << 2)
 )
 
 type GetTokenRequest struct {
@@ -14,6 +21,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -22,6 +32,28 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -47,8 +79,16 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 2)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 3)
+)
 
 type RefreshTokenRequest struct {
 	ClientId     string  `json:"client_id" url:"-"`
@@ -57,6 +97,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -65,6 +108,33 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -90,14 +160,24 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -128,6 +208,28 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -142,6 +244,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/explicit_fields.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/explicit_fields_test.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/oauth-client-credentials/auth.go
+++ b/seed/go-sdk/oauth-client-credentials/auth.go
@@ -6,6 +6,13 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/oauth-client-credentials/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	getTokenRequestFieldScope        = big.NewInt(1 << 2)
 )
 
 type GetTokenRequest struct {
@@ -14,6 +21,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -22,6 +32,28 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -47,8 +79,16 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 1)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 2)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 3)
+)
 
 type RefreshTokenRequest struct {
 	ClientId     string  `json:"client_id" url:"-"`
@@ -57,6 +97,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -65,6 +108,33 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -90,14 +160,24 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldExpiresIn    = big.NewInt(1 << 1)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 2)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	ExpiresIn    int     `json:"expires_in" url:"expires_in"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -128,6 +208,28 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetExpiresIn(expiresIn int) {
+	t.ExpiresIn = expiresIn
+	t.require(tokenResponseFieldExpiresIn)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -142,6 +244,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/oauth-client-credentials/auth.go
+++ b/seed/go-sdk/oauth-client-credentials/auth.go
@@ -41,16 +41,22 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -117,21 +123,29 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -215,16 +229,22 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetExpiresIn sets the ExpiresIn field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetExpiresIn(expiresIn int) {
 	t.ExpiresIn = expiresIn
 	t.require(tokenResponseFieldExpiresIn)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/oauth-client-credentials/internal/explicit_fields.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/oauth-client-credentials/internal/explicit_fields_test.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/object/internal/explicit_fields.go
+++ b/seed/go-sdk/object/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/object/internal/explicit_fields_test.go
+++ b/seed/go-sdk/object/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/object/types.go
+++ b/seed/go-sdk/object/types.go
@@ -7,12 +7,21 @@ import (
 	fmt "fmt"
 	uuid "github.com/google/uuid"
 	internal "github.com/object/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	nameFieldId    = big.NewInt(1 << 0)
+	nameFieldValue = big.NewInt(1 << 1)
 )
 
 type Name struct {
 	Id    string `json:"id" url:"id"`
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -36,6 +45,23 @@ func (n *Name) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Name) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Name) SetId(id string) {
+	n.Id = id
+	n.require(nameFieldId)
+}
+
+func (n *Name) SetValue(value string) {
+	n.Value = value
+	n.require(nameFieldValue)
+}
+
 func (n *Name) UnmarshalJSON(data []byte) error {
 	type unmarshaler Name
 	var value unmarshaler
@@ -52,6 +78,17 @@ func (n *Name) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Name) MarshalJSON() ([]byte, error) {
+	type embed Name
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Name) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -65,6 +102,33 @@ func (n *Name) String() string {
 }
 
 // Exercises all of the built-in types.
+var (
+	typeFieldOne         = big.NewInt(1 << 0)
+	typeFieldTwo         = big.NewInt(1 << 1)
+	typeFieldThree       = big.NewInt(1 << 2)
+	typeFieldFour        = big.NewInt(1 << 3)
+	typeFieldFive        = big.NewInt(1 << 4)
+	typeFieldSix         = big.NewInt(1 << 5)
+	typeFieldSeven       = big.NewInt(1 << 6)
+	typeFieldEight       = big.NewInt(1 << 7)
+	typeFieldNine        = big.NewInt(1 << 8)
+	typeFieldTen         = big.NewInt(1 << 9)
+	typeFieldEleven      = big.NewInt(1 << 10)
+	typeFieldTwelve      = big.NewInt(1 << 11)
+	typeFieldThirteen    = big.NewInt(1 << 12)
+	typeFieldFourteen    = big.NewInt(1 << 13)
+	typeFieldFifteen     = big.NewInt(1 << 14)
+	typeFieldSixteen     = big.NewInt(1 << 15)
+	typeFieldSeventeen   = big.NewInt(1 << 16)
+	typeFieldNineteen    = big.NewInt(1 << 17)
+	typeFieldTwenty      = big.NewInt(1 << 18)
+	typeFieldTwentyone   = big.NewInt(1 << 19)
+	typeFieldTwentytwo   = big.NewInt(1 << 20)
+	typeFieldTwentythree = big.NewInt(1 << 21)
+	typeFieldTwentyfour  = big.NewInt(1 << 22)
+	typeFieldTwentyfive  = big.NewInt(1 << 23)
+)
+
 type Type struct {
 	One         int              `json:"one" url:"one"`
 	Two         float64          `json:"two" url:"two"`
@@ -90,7 +154,10 @@ type Type struct {
 	Twentythree string           `json:"twentythree" url:"twentythree"`
 	Twentyfour  *time.Time       `json:"twentyfour,omitempty" url:"twentyfour,omitempty"`
 	Twentyfive  *time.Time       `json:"twentyfive,omitempty" url:"twentyfive,omitempty" format:"date"`
-	eighteen    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	eighteen       string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -272,6 +339,133 @@ func (t *Type) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Type) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Type) SetOne(one int) {
+	t.One = one
+	t.require(typeFieldOne)
+}
+
+func (t *Type) SetTwo(two float64) {
+	t.Two = two
+	t.require(typeFieldTwo)
+}
+
+func (t *Type) SetThree(three string) {
+	t.Three = three
+	t.require(typeFieldThree)
+}
+
+func (t *Type) SetFour(four bool) {
+	t.Four = four
+	t.require(typeFieldFour)
+}
+
+func (t *Type) SetFive(five int64) {
+	t.Five = five
+	t.require(typeFieldFive)
+}
+
+func (t *Type) SetSix(six time.Time) {
+	t.Six = six
+	t.require(typeFieldSix)
+}
+
+func (t *Type) SetSeven(seven time.Time) {
+	t.Seven = seven
+	t.require(typeFieldSeven)
+}
+
+func (t *Type) SetEight(eight uuid.UUID) {
+	t.Eight = eight
+	t.require(typeFieldEight)
+}
+
+func (t *Type) SetNine(nine []byte) {
+	t.Nine = nine
+	t.require(typeFieldNine)
+}
+
+func (t *Type) SetTen(ten []int) {
+	t.Ten = ten
+	t.require(typeFieldTen)
+}
+
+func (t *Type) SetEleven(eleven []float64) {
+	t.Eleven = eleven
+	t.require(typeFieldEleven)
+}
+
+func (t *Type) SetTwelve(twelve map[string]bool) {
+	t.Twelve = twelve
+	t.require(typeFieldTwelve)
+}
+
+func (t *Type) SetThirteen(thirteen *int64) {
+	t.Thirteen = thirteen
+	t.require(typeFieldThirteen)
+}
+
+func (t *Type) SetFourteen(fourteen interface{}) {
+	t.Fourteen = fourteen
+	t.require(typeFieldFourteen)
+}
+
+func (t *Type) SetFifteen(fifteen [][]int) {
+	t.Fifteen = fifteen
+	t.require(typeFieldFifteen)
+}
+
+func (t *Type) SetSixteen(sixteen []map[string]int) {
+	t.Sixteen = sixteen
+	t.require(typeFieldSixteen)
+}
+
+func (t *Type) SetSeventeen(seventeen []*uuid.UUID) {
+	t.Seventeen = seventeen
+	t.require(typeFieldSeventeen)
+}
+
+func (t *Type) SetNineteen(nineteen *Name) {
+	t.Nineteen = nineteen
+	t.require(typeFieldNineteen)
+}
+
+func (t *Type) SetTwenty(twenty int) {
+	t.Twenty = twenty
+	t.require(typeFieldTwenty)
+}
+
+func (t *Type) SetTwentyone(twentyone int64) {
+	t.Twentyone = twentyone
+	t.require(typeFieldTwentyone)
+}
+
+func (t *Type) SetTwentytwo(twentytwo float64) {
+	t.Twentytwo = twentytwo
+	t.require(typeFieldTwentytwo)
+}
+
+func (t *Type) SetTwentythree(twentythree string) {
+	t.Twentythree = twentythree
+	t.require(typeFieldTwentythree)
+}
+
+func (t *Type) SetTwentyfour(twentyfour *time.Time) {
+	t.Twentyfour = twentyfour
+	t.require(typeFieldTwentyfour)
+}
+
+func (t *Type) SetTwentyfive(twentyfive *time.Time) {
+	t.Twentyfive = twentyfive
+	t.require(typeFieldTwentyfive)
+}
+
 func (t *Type) UnmarshalJSON(data []byte) error {
 	type embed Type
 	var unmarshaler = struct {
@@ -322,7 +516,8 @@ func (t *Type) MarshalJSON() ([]byte, error) {
 		Twentyfive: internal.NewOptionalDate(t.Twentyfive),
 		Eighteen:   "eighteen",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Type) String() string {

--- a/seed/go-sdk/object/types.go
+++ b/seed/go-sdk/object/types.go
@@ -52,11 +52,15 @@ func (n *Name) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Name) SetId(id string) {
 	n.Id = id
 	n.require(nameFieldId)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Name) SetValue(value string) {
 	n.Value = value
 	n.require(nameFieldValue)
@@ -346,121 +350,169 @@ func (t *Type) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetOne sets the One field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetOne(one int) {
 	t.One = one
 	t.require(typeFieldOne)
 }
 
+// SetTwo sets the Two field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwo(two float64) {
 	t.Two = two
 	t.require(typeFieldTwo)
 }
 
+// SetThree sets the Three field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetThree(three string) {
 	t.Three = three
 	t.require(typeFieldThree)
 }
 
+// SetFour sets the Four field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetFour(four bool) {
 	t.Four = four
 	t.require(typeFieldFour)
 }
 
+// SetFive sets the Five field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetFive(five int64) {
 	t.Five = five
 	t.require(typeFieldFive)
 }
 
+// SetSix sets the Six field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetSix(six time.Time) {
 	t.Six = six
 	t.require(typeFieldSix)
 }
 
+// SetSeven sets the Seven field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetSeven(seven time.Time) {
 	t.Seven = seven
 	t.require(typeFieldSeven)
 }
 
+// SetEight sets the Eight field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetEight(eight uuid.UUID) {
 	t.Eight = eight
 	t.require(typeFieldEight)
 }
 
+// SetNine sets the Nine field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetNine(nine []byte) {
 	t.Nine = nine
 	t.require(typeFieldNine)
 }
 
+// SetTen sets the Ten field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTen(ten []int) {
 	t.Ten = ten
 	t.require(typeFieldTen)
 }
 
+// SetEleven sets the Eleven field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetEleven(eleven []float64) {
 	t.Eleven = eleven
 	t.require(typeFieldEleven)
 }
 
+// SetTwelve sets the Twelve field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwelve(twelve map[string]bool) {
 	t.Twelve = twelve
 	t.require(typeFieldTwelve)
 }
 
+// SetThirteen sets the Thirteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetThirteen(thirteen *int64) {
 	t.Thirteen = thirteen
 	t.require(typeFieldThirteen)
 }
 
+// SetFourteen sets the Fourteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetFourteen(fourteen interface{}) {
 	t.Fourteen = fourteen
 	t.require(typeFieldFourteen)
 }
 
+// SetFifteen sets the Fifteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetFifteen(fifteen [][]int) {
 	t.Fifteen = fifteen
 	t.require(typeFieldFifteen)
 }
 
+// SetSixteen sets the Sixteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetSixteen(sixteen []map[string]int) {
 	t.Sixteen = sixteen
 	t.require(typeFieldSixteen)
 }
 
+// SetSeventeen sets the Seventeen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetSeventeen(seventeen []*uuid.UUID) {
 	t.Seventeen = seventeen
 	t.require(typeFieldSeventeen)
 }
 
+// SetNineteen sets the Nineteen field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetNineteen(nineteen *Name) {
 	t.Nineteen = nineteen
 	t.require(typeFieldNineteen)
 }
 
+// SetTwenty sets the Twenty field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwenty(twenty int) {
 	t.Twenty = twenty
 	t.require(typeFieldTwenty)
 }
 
+// SetTwentyone sets the Twentyone field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwentyone(twentyone int64) {
 	t.Twentyone = twentyone
 	t.require(typeFieldTwentyone)
 }
 
+// SetTwentytwo sets the Twentytwo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwentytwo(twentytwo float64) {
 	t.Twentytwo = twentytwo
 	t.require(typeFieldTwentytwo)
 }
 
+// SetTwentythree sets the Twentythree field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwentythree(twentythree string) {
 	t.Twentythree = twentythree
 	t.require(typeFieldTwentythree)
 }
 
+// SetTwentyfour sets the Twentyfour field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwentyfour(twentyfour *time.Time) {
 	t.Twentyfour = twentyfour
 	t.require(typeFieldTwentyfour)
 }
 
+// SetTwentyfive sets the Twentyfive field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetTwentyfive(twentyfive *time.Time) {
 	t.Twentyfive = twentyfive
 	t.require(typeFieldTwentyfive)

--- a/seed/go-sdk/objects-with-imports/commons/metadata.go
+++ b/seed/go-sdk/objects-with-imports/commons/metadata.go
@@ -50,11 +50,15 @@ func (m *Metadata) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetId(id string) {
 	m.Id = id
 	m.require(metadataFieldId)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Metadata) SetData(data map[string]string) {
 	m.Data = data
 	m.require(metadataFieldData)

--- a/seed/go-sdk/objects-with-imports/commons/metadata.go
+++ b/seed/go-sdk/objects-with-imports/commons/metadata.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/objects-with-imports/fern/internal"
+	big "math/big"
+)
+
+var (
+	metadataFieldId   = big.NewInt(1 << 0)
+	metadataFieldData = big.NewInt(1 << 1)
 )
 
 type Metadata struct {
 	Id   string            `json:"id" url:"id"`
 	Data map[string]string `json:"data,omitempty" url:"data,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (m *Metadata) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Metadata) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Metadata) SetId(id string) {
+	m.Id = id
+	m.require(metadataFieldId)
+}
+
+func (m *Metadata) SetData(data map[string]string) {
+	m.Data = data
+	m.require(metadataFieldData)
+}
+
 func (m *Metadata) UnmarshalJSON(data []byte) error {
 	type unmarshaler Metadata
 	var value unmarshaler
@@ -48,6 +74,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *Metadata) MarshalJSON() ([]byte, error) {
+	type embed Metadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *Metadata) String() string {

--- a/seed/go-sdk/objects-with-imports/file.go
+++ b/seed/go-sdk/objects-with-imports/file.go
@@ -59,16 +59,22 @@ func (f *File) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetName(name string) {
 	f.Name = name
 	f.require(fileFieldName)
 }
 
+// SetContents sets the Contents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetContents(contents string) {
 	f.Contents = contents
 	f.require(fileFieldContents)
 }
 
+// SetInfo sets the Info field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *File) SetInfo(info FileInfo) {
 	f.Info = info
 	f.require(fileFieldInfo)

--- a/seed/go-sdk/objects-with-imports/file/directory.go
+++ b/seed/go-sdk/objects-with-imports/file/directory.go
@@ -7,12 +7,22 @@ import (
 	fmt "fmt"
 	fern "github.com/objects-with-imports/fern"
 	internal "github.com/objects-with-imports/fern/internal"
+	big "math/big"
+)
+
+var (
+	directoryFieldName        = big.NewInt(1 << 0)
+	directoryFieldFiles       = big.NewInt(1 << 1)
+	directoryFieldDirectories = big.NewInt(1 << 2)
 )
 
 type Directory struct {
 	Name        string       `json:"name" url:"name"`
 	Files       []*fern.File `json:"files,omitempty" url:"files,omitempty"`
 	Directories []*Directory `json:"directories,omitempty" url:"directories,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -43,6 +53,28 @@ func (d *Directory) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
 }
 
+func (d *Directory) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *Directory) SetName(name string) {
+	d.Name = name
+	d.require(directoryFieldName)
+}
+
+func (d *Directory) SetFiles(files []*fern.File) {
+	d.Files = files
+	d.require(directoryFieldFiles)
+}
+
+func (d *Directory) SetDirectories(directories []*Directory) {
+	d.Directories = directories
+	d.require(directoryFieldDirectories)
+}
+
 func (d *Directory) UnmarshalJSON(data []byte) error {
 	type unmarshaler Directory
 	var value unmarshaler
@@ -57,6 +89,17 @@ func (d *Directory) UnmarshalJSON(data []byte) error {
 	d.extraProperties = extraProperties
 	d.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (d *Directory) MarshalJSON() ([]byte, error) {
+	type embed Directory
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (d *Directory) String() string {

--- a/seed/go-sdk/objects-with-imports/file/directory.go
+++ b/seed/go-sdk/objects-with-imports/file/directory.go
@@ -60,16 +60,22 @@ func (d *Directory) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetName(name string) {
 	d.Name = name
 	d.require(directoryFieldName)
 }
 
+// SetFiles sets the Files field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetFiles(files []*fern.File) {
 	d.Files = files
 	d.require(directoryFieldFiles)
 }
 
+// SetDirectories sets the Directories field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *Directory) SetDirectories(directories []*Directory) {
 	d.Directories = directories
 	d.require(directoryFieldDirectories)

--- a/seed/go-sdk/objects-with-imports/internal/explicit_fields.go
+++ b/seed/go-sdk/objects-with-imports/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/objects-with-imports/internal/explicit_fields_test.go
+++ b/seed/go-sdk/objects-with-imports/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/objects-with-imports/types.go
+++ b/seed/go-sdk/objects-with-imports/types.go
@@ -60,16 +60,22 @@ func (n *Node) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetId(id string) {
 	n.Id = id
 	n.require(nodeFieldId)
 }
 
+// SetLabel sets the Label field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetLabel(label *string) {
 	n.Label = label
 	n.require(nodeFieldLabel)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *Node) SetMetadata(metadata *commons.Metadata) {
 	n.Metadata = metadata
 	n.require(nodeFieldMetadata)
@@ -146,6 +152,8 @@ func (t *Tree) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetNodes sets the Nodes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Tree) SetNodes(nodes []*Node) {
 	t.Nodes = nodes
 	t.require(treeFieldNodes)

--- a/seed/go-sdk/objects-with-imports/types.go
+++ b/seed/go-sdk/objects-with-imports/types.go
@@ -7,12 +7,22 @@ import (
 	fmt "fmt"
 	commons "github.com/objects-with-imports/fern/commons"
 	internal "github.com/objects-with-imports/fern/internal"
+	big "math/big"
+)
+
+var (
+	nodeFieldId       = big.NewInt(1 << 0)
+	nodeFieldLabel    = big.NewInt(1 << 1)
+	nodeFieldMetadata = big.NewInt(1 << 2)
 )
 
 type Node struct {
 	Id       string            `json:"id" url:"id"`
 	Label    *string           `json:"label,omitempty" url:"label,omitempty"`
 	Metadata *commons.Metadata `json:"metadata,omitempty" url:"metadata,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -43,6 +53,28 @@ func (n *Node) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *Node) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *Node) SetId(id string) {
+	n.Id = id
+	n.require(nodeFieldId)
+}
+
+func (n *Node) SetLabel(label *string) {
+	n.Label = label
+	n.require(nodeFieldLabel)
+}
+
+func (n *Node) SetMetadata(metadata *commons.Metadata) {
+	n.Metadata = metadata
+	n.require(nodeFieldMetadata)
+}
+
 func (n *Node) UnmarshalJSON(data []byte) error {
 	type unmarshaler Node
 	var value unmarshaler
@@ -59,6 +91,17 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *Node) MarshalJSON() ([]byte, error) {
+	type embed Node
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *Node) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -71,8 +114,15 @@ func (n *Node) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	treeFieldNodes = big.NewInt(1 << 0)
+)
+
 type Tree struct {
 	Nodes []*Node `json:"nodes,omitempty" url:"nodes,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -89,6 +139,18 @@ func (t *Tree) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *Tree) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *Tree) SetNodes(nodes []*Node) {
+	t.Nodes = nodes
+	t.require(treeFieldNodes)
+}
+
 func (t *Tree) UnmarshalJSON(data []byte) error {
 	type unmarshaler Tree
 	var value unmarshaler
@@ -103,6 +165,17 @@ func (t *Tree) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	type embed Tree
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *Tree) String() string {

--- a/seed/go-sdk/optional/internal/explicit_fields.go
+++ b/seed/go-sdk/optional/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/optional/internal/explicit_fields_test.go
+++ b/seed/go-sdk/optional/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/package-yml/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/package-yml/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/package-yml/no-custom-config/types.go
+++ b/seed/go-sdk/package-yml/no-custom-config/types.go
@@ -50,11 +50,15 @@ func (e *EchoRequest) require(field *big.Int) {
 	e.explicitFields.Or(e.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *EchoRequest) SetName(name string) {
 	e.Name = name
 	e.require(echoRequestFieldName)
 }
 
+// SetSize sets the Size field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (e *EchoRequest) SetSize(size int) {
 	e.Size = size
 	e.require(echoRequestFieldSize)

--- a/seed/go-sdk/package-yml/no-custom-config/types.go
+++ b/seed/go-sdk/package-yml/no-custom-config/types.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/package-yml/fern/internal"
+	big "math/big"
+)
+
+var (
+	echoRequestFieldName = big.NewInt(1 << 0)
+	echoRequestFieldSize = big.NewInt(1 << 1)
 )
 
 type EchoRequest struct {
 	Name string `json:"name" url:"name"`
 	Size int    `json:"size" url:"size"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (e *EchoRequest) GetExtraProperties() map[string]interface{} {
 	return e.extraProperties
 }
 
+func (e *EchoRequest) require(field *big.Int) {
+	if e.explicitFields == nil {
+		e.explicitFields = big.NewInt(0)
+	}
+	e.explicitFields.Or(e.explicitFields, field)
+}
+
+func (e *EchoRequest) SetName(name string) {
+	e.Name = name
+	e.require(echoRequestFieldName)
+}
+
+func (e *EchoRequest) SetSize(size int) {
+	e.Size = size
+	e.require(echoRequestFieldSize)
+}
+
 func (e *EchoRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler EchoRequest
 	var value unmarshaler
@@ -48,6 +74,17 @@ func (e *EchoRequest) UnmarshalJSON(data []byte) error {
 	e.extraProperties = extraProperties
 	e.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (e *EchoRequest) MarshalJSON() ([]byte, error) {
+	type embed EchoRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*e),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, e.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (e *EchoRequest) String() string {

--- a/seed/go-sdk/pagination/complex.go
+++ b/seed/go-sdk/pagination/complex.go
@@ -41,6 +41,8 @@ func (c *Conversation) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetFoo sets the Foo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Conversation) SetFoo(foo string) {
 	c.Foo = foo
 	c.require(conversationFieldFoo)
@@ -149,21 +151,29 @@ func (c *CursorPages) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CursorPages) SetNext(next *StartingAfterPaging) {
 	c.Next = next
 	c.require(cursorPagesFieldNext)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CursorPages) SetPage(page *int) {
 	c.Page = page
 	c.require(cursorPagesFieldPage)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CursorPages) SetPerPage(perPage *int) {
 	c.PerPage = perPage
 	c.require(cursorPagesFieldPerPage)
 }
 
+// SetTotalPages sets the TotalPages field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CursorPages) SetTotalPages(totalPages *int) {
 	c.TotalPages = totalPages
 	c.require(cursorPagesFieldTotalPages)
@@ -260,11 +270,15 @@ func (m *MultipleFilterSearchRequest) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetOperator sets the Operator field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MultipleFilterSearchRequest) SetOperator(operator *MultipleFilterSearchRequestOperator) {
 	m.Operator = operator
 	m.require(multipleFilterSearchRequestFieldOperator)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MultipleFilterSearchRequest) SetValue(value *MultipleFilterSearchRequestValue) {
 	m.Value = value
 	m.require(multipleFilterSearchRequestFieldValue)
@@ -448,16 +462,22 @@ func (p *PaginatedConversationResponse) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetConversations sets the Conversations field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedConversationResponse) SetConversations(conversations []*Conversation) {
 	p.Conversations = conversations
 	p.require(paginatedConversationResponseFieldConversations)
 }
 
+// SetPages sets the Pages field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedConversationResponse) SetPages(pages *CursorPages) {
 	p.Pages = pages
 	p.require(paginatedConversationResponseFieldPages)
 }
 
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PaginatedConversationResponse) SetTotalCount(totalCount int) {
 	p.TotalCount = totalCount
 	p.require(paginatedConversationResponseFieldTotalCount)
@@ -554,11 +574,15 @@ func (s *SearchRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetPagination sets the Pagination field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetPagination(pagination *StartingAfterPaging) {
 	s.Pagination = pagination
 	s.require(searchRequestFieldPagination)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetQuery(query *SearchRequestQuery) {
 	s.Query = query
 	s.require(searchRequestFieldQuery)
@@ -715,16 +739,22 @@ func (s *SingleFilterSearchRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetField sets the Field field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SingleFilterSearchRequest) SetField(field *string) {
 	s.Field = field
 	s.require(singleFilterSearchRequestFieldField)
 }
 
+// SetOperator sets the Operator field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SingleFilterSearchRequest) SetOperator(operator *SingleFilterSearchRequestOperator) {
 	s.Operator = operator
 	s.require(singleFilterSearchRequestFieldOperator)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SingleFilterSearchRequest) SetValue(value *string) {
 	s.Value = value
 	s.require(singleFilterSearchRequestFieldValue)
@@ -856,11 +886,15 @@ func (s *StartingAfterPaging) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StartingAfterPaging) SetPerPage(perPage int) {
 	s.PerPage = perPage
 	s.require(startingAfterPagingFieldPerPage)
 }
 
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StartingAfterPaging) SetStartingAfter(startingAfter *string) {
 	s.StartingAfter = startingAfter
 	s.require(startingAfterPagingFieldStartingAfter)

--- a/seed/go-sdk/pagination/complex.go
+++ b/seed/go-sdk/pagination/complex.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/pagination/fern/internal"
+	big "math/big"
+)
+
+var (
+	conversationFieldFoo = big.NewInt(1 << 0)
 )
 
 type Conversation struct {
 	Foo string `json:"foo" url:"foo"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -24,6 +32,18 @@ func (c *Conversation) GetFoo() string {
 
 func (c *Conversation) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *Conversation) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Conversation) SetFoo(foo string) {
+	c.Foo = foo
+	c.require(conversationFieldFoo)
 }
 
 func (c *Conversation) UnmarshalJSON(data []byte) error {
@@ -42,6 +62,17 @@ func (c *Conversation) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Conversation) MarshalJSON() ([]byte, error) {
+	type embed Conversation
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Conversation) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -54,12 +85,22 @@ func (c *Conversation) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	cursorPagesFieldNext       = big.NewInt(1 << 0)
+	cursorPagesFieldPage       = big.NewInt(1 << 1)
+	cursorPagesFieldPerPage    = big.NewInt(1 << 2)
+	cursorPagesFieldTotalPages = big.NewInt(1 << 3)
+)
+
 type CursorPages struct {
 	Next       *StartingAfterPaging `json:"next,omitempty" url:"next,omitempty"`
 	Page       *int                 `json:"page,omitempty" url:"page,omitempty"`
 	PerPage    *int                 `json:"per_page,omitempty" url:"per_page,omitempty"`
 	TotalPages *int                 `json:"total_pages,omitempty" url:"total_pages,omitempty"`
-	type_      string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -101,6 +142,33 @@ func (c *CursorPages) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
 }
 
+func (c *CursorPages) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CursorPages) SetNext(next *StartingAfterPaging) {
+	c.Next = next
+	c.require(cursorPagesFieldNext)
+}
+
+func (c *CursorPages) SetPage(page *int) {
+	c.Page = page
+	c.require(cursorPagesFieldPage)
+}
+
+func (c *CursorPages) SetPerPage(perPage *int) {
+	c.PerPage = perPage
+	c.require(cursorPagesFieldPerPage)
+}
+
+func (c *CursorPages) SetTotalPages(totalPages *int) {
+	c.TotalPages = totalPages
+	c.require(cursorPagesFieldTotalPages)
+}
+
 func (c *CursorPages) UnmarshalJSON(data []byte) error {
 	type embed CursorPages
 	var unmarshaler = struct {
@@ -135,7 +203,8 @@ func (c *CursorPages) MarshalJSON() ([]byte, error) {
 		embed: embed(*c),
 		Type:  "pages",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (c *CursorPages) String() string {
@@ -150,9 +219,17 @@ func (c *CursorPages) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	multipleFilterSearchRequestFieldOperator = big.NewInt(1 << 0)
+	multipleFilterSearchRequestFieldValue    = big.NewInt(1 << 1)
+)
+
 type MultipleFilterSearchRequest struct {
 	Operator *MultipleFilterSearchRequestOperator `json:"operator,omitempty" url:"operator,omitempty"`
 	Value    *MultipleFilterSearchRequestValue    `json:"value,omitempty" url:"value,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -176,6 +253,23 @@ func (m *MultipleFilterSearchRequest) GetExtraProperties() map[string]interface{
 	return m.extraProperties
 }
 
+func (m *MultipleFilterSearchRequest) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MultipleFilterSearchRequest) SetOperator(operator *MultipleFilterSearchRequestOperator) {
+	m.Operator = operator
+	m.require(multipleFilterSearchRequestFieldOperator)
+}
+
+func (m *MultipleFilterSearchRequest) SetValue(value *MultipleFilterSearchRequestValue) {
+	m.Value = value
+	m.require(multipleFilterSearchRequestFieldValue)
+}
+
 func (m *MultipleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler MultipleFilterSearchRequest
 	var value unmarshaler
@@ -190,6 +284,17 @@ func (m *MultipleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *MultipleFilterSearchRequest) MarshalJSON() ([]byte, error) {
+	type embed MultipleFilterSearchRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *MultipleFilterSearchRequest) String() string {
@@ -288,11 +393,20 @@ func (m *MultipleFilterSearchRequestValue) Accept(visitor MultipleFilterSearchRe
 	return fmt.Errorf("type %T does not include a non-empty union type", m)
 }
 
+var (
+	paginatedConversationResponseFieldConversations = big.NewInt(1 << 0)
+	paginatedConversationResponseFieldPages         = big.NewInt(1 << 1)
+	paginatedConversationResponseFieldTotalCount    = big.NewInt(1 << 2)
+)
+
 type PaginatedConversationResponse struct {
 	Conversations []*Conversation `json:"conversations" url:"conversations"`
 	Pages         *CursorPages    `json:"pages,omitempty" url:"pages,omitempty"`
 	TotalCount    int             `json:"total_count" url:"total_count"`
-	type_         string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	type_          string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -325,6 +439,28 @@ func (p *PaginatedConversationResponse) Type() string {
 
 func (p *PaginatedConversationResponse) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PaginatedConversationResponse) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PaginatedConversationResponse) SetConversations(conversations []*Conversation) {
+	p.Conversations = conversations
+	p.require(paginatedConversationResponseFieldConversations)
+}
+
+func (p *PaginatedConversationResponse) SetPages(pages *CursorPages) {
+	p.Pages = pages
+	p.require(paginatedConversationResponseFieldPages)
+}
+
+func (p *PaginatedConversationResponse) SetTotalCount(totalCount int) {
+	p.TotalCount = totalCount
+	p.require(paginatedConversationResponseFieldTotalCount)
 }
 
 func (p *PaginatedConversationResponse) UnmarshalJSON(data []byte) error {
@@ -361,7 +497,8 @@ func (p *PaginatedConversationResponse) MarshalJSON() ([]byte, error) {
 		embed: embed(*p),
 		Type:  "conversation.list",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *PaginatedConversationResponse) String() string {
@@ -376,9 +513,17 @@ func (p *PaginatedConversationResponse) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	searchRequestFieldPagination = big.NewInt(1 << 0)
+	searchRequestFieldQuery      = big.NewInt(1 << 1)
+)
+
 type SearchRequest struct {
 	Pagination *StartingAfterPaging `json:"pagination,omitempty" url:"pagination,omitempty"`
 	Query      *SearchRequestQuery  `json:"query" url:"query"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -402,6 +547,23 @@ func (s *SearchRequest) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SearchRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchRequest) SetPagination(pagination *StartingAfterPaging) {
+	s.Pagination = pagination
+	s.require(searchRequestFieldPagination)
+}
+
+func (s *SearchRequest) SetQuery(query *SearchRequestQuery) {
+	s.Query = query
+	s.require(searchRequestFieldQuery)
+}
+
 func (s *SearchRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler SearchRequest
 	var value unmarshaler
@@ -416,6 +578,17 @@ func (s *SearchRequest) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *SearchRequest) MarshalJSON() ([]byte, error) {
+	type embed SearchRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SearchRequest) String() string {
@@ -492,10 +665,19 @@ func (s *SearchRequestQuery) Accept(visitor SearchRequestQueryVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", s)
 }
 
+var (
+	singleFilterSearchRequestFieldField    = big.NewInt(1 << 0)
+	singleFilterSearchRequestFieldOperator = big.NewInt(1 << 1)
+	singleFilterSearchRequestFieldValue    = big.NewInt(1 << 2)
+)
+
 type SingleFilterSearchRequest struct {
 	Field    *string                            `json:"field,omitempty" url:"field,omitempty"`
 	Operator *SingleFilterSearchRequestOperator `json:"operator,omitempty" url:"operator,omitempty"`
 	Value    *string                            `json:"value,omitempty" url:"value,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -526,6 +708,28 @@ func (s *SingleFilterSearchRequest) GetExtraProperties() map[string]interface{} 
 	return s.extraProperties
 }
 
+func (s *SingleFilterSearchRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SingleFilterSearchRequest) SetField(field *string) {
+	s.Field = field
+	s.require(singleFilterSearchRequestFieldField)
+}
+
+func (s *SingleFilterSearchRequest) SetOperator(operator *SingleFilterSearchRequestOperator) {
+	s.Operator = operator
+	s.require(singleFilterSearchRequestFieldOperator)
+}
+
+func (s *SingleFilterSearchRequest) SetValue(value *string) {
+	s.Value = value
+	s.require(singleFilterSearchRequestFieldValue)
+}
+
 func (s *SingleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler SingleFilterSearchRequest
 	var value unmarshaler
@@ -540,6 +744,17 @@ func (s *SingleFilterSearchRequest) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *SingleFilterSearchRequest) MarshalJSON() ([]byte, error) {
+	type embed SingleFilterSearchRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SingleFilterSearchRequest) String() string {
@@ -600,9 +815,17 @@ func (s SingleFilterSearchRequestOperator) Ptr() *SingleFilterSearchRequestOpera
 	return &s
 }
 
+var (
+	startingAfterPagingFieldPerPage       = big.NewInt(1 << 0)
+	startingAfterPagingFieldStartingAfter = big.NewInt(1 << 1)
+)
+
 type StartingAfterPaging struct {
 	PerPage       int     `json:"per_page" url:"per_page"`
 	StartingAfter *string `json:"starting_after,omitempty" url:"starting_after,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -626,6 +849,23 @@ func (s *StartingAfterPaging) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StartingAfterPaging) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StartingAfterPaging) SetPerPage(perPage int) {
+	s.PerPage = perPage
+	s.require(startingAfterPagingFieldPerPage)
+}
+
+func (s *StartingAfterPaging) SetStartingAfter(startingAfter *string) {
+	s.StartingAfter = startingAfter
+	s.require(startingAfterPagingFieldStartingAfter)
+}
+
 func (s *StartingAfterPaging) UnmarshalJSON(data []byte) error {
 	type unmarshaler StartingAfterPaging
 	var value unmarshaler
@@ -640,6 +880,17 @@ func (s *StartingAfterPaging) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StartingAfterPaging) MarshalJSON() ([]byte, error) {
+	type embed StartingAfterPaging
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StartingAfterPaging) String() string {

--- a/seed/go-sdk/pagination/internal/explicit_fields.go
+++ b/seed/go-sdk/pagination/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/pagination/internal/explicit_fields_test.go
+++ b/seed/go-sdk/pagination/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/pagination/users.go
+++ b/seed/go-sdk/pagination/users.go
@@ -30,6 +30,8 @@ func (l *ListUsernamesRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsernamesRequest) SetStartingAfter(startingAfter *string) {
 	l.StartingAfter = startingAfter
 	l.require(listUsernamesRequestFieldStartingAfter)
@@ -55,6 +57,8 @@ func (l *ListUsersBodyCursorPaginationRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPagination sets the Pagination field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersBodyCursorPaginationRequest) SetPagination(pagination *WithCursor) {
 	l.Pagination = pagination
 	l.require(listUsersBodyCursorPaginationRequestFieldPagination)
@@ -80,6 +84,8 @@ func (l *ListUsersBodyOffsetPaginationRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPagination sets the Pagination field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersBodyOffsetPaginationRequest) SetPagination(pagination *WithPage) {
 	l.Pagination = pagination
 	l.require(listUsersBodyOffsetPaginationRequestFieldPagination)
@@ -113,21 +119,29 @@ func (l *ListUsersCursorPaginationRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersCursorPaginationRequest) SetPage(page *int) {
 	l.Page = page
 	l.require(listUsersCursorPaginationRequestFieldPage)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersCursorPaginationRequest) SetPerPage(perPage *int) {
 	l.PerPage = perPage
 	l.require(listUsersCursorPaginationRequestFieldPerPage)
 }
 
+// SetOrder sets the Order field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersCursorPaginationRequest) SetOrder(order *Order) {
 	l.Order = order
 	l.require(listUsersCursorPaginationRequestFieldOrder)
 }
 
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersCursorPaginationRequest) SetStartingAfter(startingAfter *string) {
 	l.StartingAfter = startingAfter
 	l.require(listUsersCursorPaginationRequestFieldStartingAfter)
@@ -161,21 +175,29 @@ func (l *ListUsersDoubleOffsetPaginationRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersDoubleOffsetPaginationRequest) SetPage(page *float64) {
 	l.Page = page
 	l.require(listUsersDoubleOffsetPaginationRequestFieldPage)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersDoubleOffsetPaginationRequest) SetPerPage(perPage *float64) {
 	l.PerPage = perPage
 	l.require(listUsersDoubleOffsetPaginationRequestFieldPerPage)
 }
 
+// SetOrder sets the Order field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersDoubleOffsetPaginationRequest) SetOrder(order *Order) {
 	l.Order = order
 	l.require(listUsersDoubleOffsetPaginationRequestFieldOrder)
 }
 
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersDoubleOffsetPaginationRequest) SetStartingAfter(startingAfter *string) {
 	l.StartingAfter = startingAfter
 	l.require(listUsersDoubleOffsetPaginationRequestFieldStartingAfter)
@@ -199,6 +221,8 @@ func (l *ListUsersExtendedRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetCursor sets the Cursor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedRequest) SetCursor(cursor *uuid.UUID) {
 	l.Cursor = cursor
 	l.require(listUsersExtendedRequestFieldCursor)
@@ -222,6 +246,8 @@ func (l *ListUsersExtendedRequestForOptionalData) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetCursor sets the Cursor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedRequestForOptionalData) SetCursor(cursor *uuid.UUID) {
 	l.Cursor = cursor
 	l.require(listUsersExtendedRequestForOptionalDataFieldCursor)
@@ -245,6 +271,8 @@ func (l *ListWithGlobalConfigRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetOffset sets the Offset field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListWithGlobalConfigRequest) SetOffset(offset *int) {
 	l.Offset = offset
 	l.require(listWithGlobalConfigRequestFieldOffset)
@@ -268,6 +296,8 @@ func (l *ListUsersMixedTypeCursorPaginationRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetCursor sets the Cursor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersMixedTypeCursorPaginationRequest) SetCursor(cursor *string) {
 	l.Cursor = cursor
 	l.require(listUsersMixedTypeCursorPaginationRequestFieldCursor)
@@ -301,21 +331,29 @@ func (l *ListUsersOffsetPaginationRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersOffsetPaginationRequest) SetPage(page *int) {
 	l.Page = page
 	l.require(listUsersOffsetPaginationRequestFieldPage)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersOffsetPaginationRequest) SetPerPage(perPage *int) {
 	l.PerPage = perPage
 	l.require(listUsersOffsetPaginationRequestFieldPerPage)
 }
 
+// SetOrder sets the Order field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersOffsetPaginationRequest) SetOrder(order *Order) {
 	l.Order = order
 	l.require(listUsersOffsetPaginationRequestFieldOrder)
 }
 
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersOffsetPaginationRequest) SetStartingAfter(startingAfter *string) {
 	l.StartingAfter = startingAfter
 	l.require(listUsersOffsetPaginationRequestFieldStartingAfter)
@@ -347,16 +385,22 @@ func (l *ListWithOffsetPaginationHasNextPageRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListWithOffsetPaginationHasNextPageRequest) SetPage(page *int) {
 	l.Page = page
 	l.require(listWithOffsetPaginationHasNextPageRequestFieldPage)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListWithOffsetPaginationHasNextPageRequest) SetLimit(limit *int) {
 	l.Limit = limit
 	l.require(listWithOffsetPaginationHasNextPageRequestFieldLimit)
 }
 
+// SetOrder sets the Order field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListWithOffsetPaginationHasNextPageRequest) SetOrder(order *Order) {
 	l.Order = order
 	l.require(listWithOffsetPaginationHasNextPageRequestFieldOrder)
@@ -388,16 +432,22 @@ func (l *ListUsersOffsetStepPaginationRequest) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersOffsetStepPaginationRequest) SetPage(page *int) {
 	l.Page = page
 	l.require(listUsersOffsetStepPaginationRequestFieldPage)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersOffsetStepPaginationRequest) SetLimit(limit *int) {
 	l.Limit = limit
 	l.require(listUsersOffsetStepPaginationRequestFieldLimit)
 }
 
+// SetOrder sets the Order field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersOffsetStepPaginationRequest) SetOrder(order *Order) {
 	l.Order = order
 	l.require(listUsersOffsetStepPaginationRequestFieldOrder)
@@ -435,6 +485,8 @@ func (u *UsernameCursor) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetCursor sets the Cursor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UsernameCursor) SetCursor(cursor *UsernamePage) {
 	u.Cursor = cursor
 	u.require(usernameCursorFieldCursor)
@@ -520,11 +572,15 @@ func (u *UsernamePage) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetAfter sets the After field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UsernamePage) SetAfter(after *string) {
 	u.After = after
 	u.require(usernamePageFieldAfter)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UsernamePage) SetData(data []string) {
 	u.Data = data
 	u.require(usernamePageFieldData)
@@ -620,16 +676,22 @@ func (l *ListUsersExtendedOptionalListResponse) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedOptionalListResponse) SetData(data *UserOptionalListContainer) {
 	l.Data = data
 	l.require(listUsersExtendedOptionalListResponseFieldData)
 }
 
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedOptionalListResponse) SetNext(next *uuid.UUID) {
 	l.Next = next
 	l.require(listUsersExtendedOptionalListResponseFieldNext)
 }
 
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedOptionalListResponse) SetTotalCount(totalCount int) {
 	l.TotalCount = totalCount
 	l.require(listUsersExtendedOptionalListResponseFieldTotalCount)
@@ -725,16 +787,22 @@ func (l *ListUsersExtendedResponse) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedResponse) SetData(data *UserListContainer) {
 	l.Data = data
 	l.require(listUsersExtendedResponseFieldData)
 }
 
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedResponse) SetNext(next *uuid.UUID) {
 	l.Next = next
 	l.require(listUsersExtendedResponseFieldNext)
 }
 
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersExtendedResponse) SetTotalCount(totalCount int) {
 	l.TotalCount = totalCount
 	l.require(listUsersExtendedResponseFieldTotalCount)
@@ -820,11 +888,15 @@ func (l *ListUsersMixedTypePaginationResponse) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersMixedTypePaginationResponse) SetNext(next string) {
 	l.Next = next
 	l.require(listUsersMixedTypePaginationResponseFieldNext)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersMixedTypePaginationResponse) SetData(data []*User) {
 	l.Data = data
 	l.require(listUsersMixedTypePaginationResponseFieldData)
@@ -929,21 +1001,29 @@ func (l *ListUsersPaginationResponse) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetHasNextPage sets the HasNextPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersPaginationResponse) SetHasNextPage(hasNextPage *bool) {
 	l.HasNextPage = hasNextPage
 	l.require(listUsersPaginationResponseFieldHasNextPage)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersPaginationResponse) SetPage(page *Page) {
 	l.Page = page
 	l.require(listUsersPaginationResponseFieldPage)
 }
 
+// SetTotalCount sets the TotalCount field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersPaginationResponse) SetTotalCount(totalCount int) {
 	l.TotalCount = totalCount
 	l.require(listUsersPaginationResponseFieldTotalCount)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *ListUsersPaginationResponse) SetData(data []*User) {
 	l.Data = data
 	l.require(listUsersPaginationResponseFieldData)
@@ -1029,11 +1109,15 @@ func (n *NextPage) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NextPage) SetPage(page int) {
 	n.Page = page
 	n.require(nextPageFieldPage)
 }
 
+// SetStartingAfter sets the StartingAfter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NextPage) SetStartingAfter(startingAfter string) {
 	n.StartingAfter = startingAfter
 	n.require(nextPageFieldStartingAfter)
@@ -1160,21 +1244,29 @@ func (p *Page) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Page) SetPage(page int) {
 	p.Page = page
 	p.require(pageFieldPage)
 }
 
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Page) SetNext(next *NextPage) {
 	p.Next = next
 	p.require(pageFieldNext)
 }
 
+// SetPerPage sets the PerPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Page) SetPerPage(perPage int) {
 	p.PerPage = perPage
 	p.require(pageFieldPerPage)
 }
 
+// SetTotalPage sets the TotalPage field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Page) SetTotalPage(totalPage int) {
 	p.TotalPage = totalPage
 	p.require(pageFieldTotalPage)
@@ -1260,11 +1352,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id int) {
 	u.Id = id
 	u.require(userFieldId)
@@ -1341,6 +1437,8 @@ func (u *UserListContainer) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserListContainer) SetUsers(users []*User) {
 	u.Users = users
 	u.require(userListContainerFieldUsers)
@@ -1417,6 +1515,8 @@ func (u *UserOptionalListContainer) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetUsers sets the Users field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserOptionalListContainer) SetUsers(users []*User) {
 	u.Users = users
 	u.require(userOptionalListContainerFieldUsers)
@@ -1502,11 +1602,15 @@ func (u *UserOptionalListPage) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserOptionalListPage) SetData(data *UserOptionalListContainer) {
 	u.Data = data
 	u.require(userOptionalListPageFieldData)
 }
 
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserOptionalListPage) SetNext(next *uuid.UUID) {
 	u.Next = next
 	u.require(userOptionalListPageFieldNext)
@@ -1592,11 +1696,15 @@ func (u *UserPage) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserPage) SetData(data *UserListContainer) {
 	u.Data = data
 	u.require(userPageFieldData)
 }
 
+// SetNext sets the Next field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UserPage) SetNext(next *uuid.UUID) {
 	u.Next = next
 	u.require(userPageFieldNext)
@@ -1673,6 +1781,8 @@ func (u *UsernameContainer) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UsernameContainer) SetResults(results []string) {
 	u.Results = results
 	u.require(usernameContainerFieldResults)
@@ -1749,6 +1859,8 @@ func (w *WithCursor) require(field *big.Int) {
 	w.explicitFields.Or(w.explicitFields, field)
 }
 
+// SetCursor sets the Cursor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (w *WithCursor) SetCursor(cursor *string) {
 	w.Cursor = cursor
 	w.require(withCursorFieldCursor)
@@ -1825,6 +1937,8 @@ func (w *WithPage) require(field *big.Int) {
 	w.explicitFields.Or(w.explicitFields, field)
 }
 
+// SetPage sets the Page field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (w *WithPage) SetPage(page *int) {
 	w.Page = page
 	w.require(withPageFieldPage)

--- a/seed/go-sdk/pagination/users.go
+++ b/seed/go-sdk/pagination/users.go
@@ -7,25 +7,90 @@ import (
 	fmt "fmt"
 	uuid "github.com/google/uuid"
 	internal "github.com/pagination/fern/internal"
+	big "math/big"
+)
+
+var (
+	listUsernamesRequestFieldStartingAfter = big.NewInt(1 << 0)
 )
 
 type ListUsernamesRequest struct {
 	// The cursor used for pagination in order to fetch
 	// the next page of results.
 	StartingAfter *string `json:"-" url:"starting_after,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsernamesRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsernamesRequest) SetStartingAfter(startingAfter *string) {
+	l.StartingAfter = startingAfter
+	l.require(listUsernamesRequestFieldStartingAfter)
+}
+
+var (
+	listUsersBodyCursorPaginationRequestFieldPagination = big.NewInt(1 << 0)
+)
 
 type ListUsersBodyCursorPaginationRequest struct {
 	// The object that contains the cursor used for pagination
 	// in order to fetch the next page of results.
 	Pagination *WithCursor `json:"pagination,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersBodyCursorPaginationRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersBodyCursorPaginationRequest) SetPagination(pagination *WithCursor) {
+	l.Pagination = pagination
+	l.require(listUsersBodyCursorPaginationRequestFieldPagination)
+}
+
+var (
+	listUsersBodyOffsetPaginationRequestFieldPagination = big.NewInt(1 << 0)
+)
 
 type ListUsersBodyOffsetPaginationRequest struct {
 	// The object that contains the offset used for pagination
 	// in order to fetch the next page of results.
 	Pagination *WithPage `json:"pagination,omitempty" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersBodyOffsetPaginationRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersBodyOffsetPaginationRequest) SetPagination(pagination *WithPage) {
+	l.Pagination = pagination
+	l.require(listUsersBodyOffsetPaginationRequestFieldPagination)
+}
+
+var (
+	listUsersCursorPaginationRequestFieldPage          = big.NewInt(1 << 0)
+	listUsersCursorPaginationRequestFieldPerPage       = big.NewInt(1 << 1)
+	listUsersCursorPaginationRequestFieldOrder         = big.NewInt(1 << 2)
+	listUsersCursorPaginationRequestFieldStartingAfter = big.NewInt(1 << 3)
+)
 
 type ListUsersCursorPaginationRequest struct {
 	// Defaults to first page
@@ -36,7 +101,44 @@ type ListUsersCursorPaginationRequest struct {
 	// The cursor used for pagination in order to fetch
 	// the next page of results.
 	StartingAfter *string `json:"-" url:"starting_after,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersCursorPaginationRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersCursorPaginationRequest) SetPage(page *int) {
+	l.Page = page
+	l.require(listUsersCursorPaginationRequestFieldPage)
+}
+
+func (l *ListUsersCursorPaginationRequest) SetPerPage(perPage *int) {
+	l.PerPage = perPage
+	l.require(listUsersCursorPaginationRequestFieldPerPage)
+}
+
+func (l *ListUsersCursorPaginationRequest) SetOrder(order *Order) {
+	l.Order = order
+	l.require(listUsersCursorPaginationRequestFieldOrder)
+}
+
+func (l *ListUsersCursorPaginationRequest) SetStartingAfter(startingAfter *string) {
+	l.StartingAfter = startingAfter
+	l.require(listUsersCursorPaginationRequestFieldStartingAfter)
+}
+
+var (
+	listUsersDoubleOffsetPaginationRequestFieldPage          = big.NewInt(1 << 0)
+	listUsersDoubleOffsetPaginationRequestFieldPerPage       = big.NewInt(1 << 1)
+	listUsersDoubleOffsetPaginationRequestFieldOrder         = big.NewInt(1 << 2)
+	listUsersDoubleOffsetPaginationRequestFieldStartingAfter = big.NewInt(1 << 3)
+)
 
 type ListUsersDoubleOffsetPaginationRequest struct {
 	// Defaults to first page
@@ -47,23 +149,136 @@ type ListUsersDoubleOffsetPaginationRequest struct {
 	// The cursor used for pagination in order to fetch
 	// the next page of results.
 	StartingAfter *string `json:"-" url:"starting_after,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersDoubleOffsetPaginationRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersDoubleOffsetPaginationRequest) SetPage(page *float64) {
+	l.Page = page
+	l.require(listUsersDoubleOffsetPaginationRequestFieldPage)
+}
+
+func (l *ListUsersDoubleOffsetPaginationRequest) SetPerPage(perPage *float64) {
+	l.PerPage = perPage
+	l.require(listUsersDoubleOffsetPaginationRequestFieldPerPage)
+}
+
+func (l *ListUsersDoubleOffsetPaginationRequest) SetOrder(order *Order) {
+	l.Order = order
+	l.require(listUsersDoubleOffsetPaginationRequestFieldOrder)
+}
+
+func (l *ListUsersDoubleOffsetPaginationRequest) SetStartingAfter(startingAfter *string) {
+	l.StartingAfter = startingAfter
+	l.require(listUsersDoubleOffsetPaginationRequestFieldStartingAfter)
+}
+
+var (
+	listUsersExtendedRequestFieldCursor = big.NewInt(1 << 0)
+)
 
 type ListUsersExtendedRequest struct {
 	Cursor *uuid.UUID `json:"-" url:"cursor,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersExtendedRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersExtendedRequest) SetCursor(cursor *uuid.UUID) {
+	l.Cursor = cursor
+	l.require(listUsersExtendedRequestFieldCursor)
+}
+
+var (
+	listUsersExtendedRequestForOptionalDataFieldCursor = big.NewInt(1 << 0)
+)
 
 type ListUsersExtendedRequestForOptionalData struct {
 	Cursor *uuid.UUID `json:"-" url:"cursor,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersExtendedRequestForOptionalData) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersExtendedRequestForOptionalData) SetCursor(cursor *uuid.UUID) {
+	l.Cursor = cursor
+	l.require(listUsersExtendedRequestForOptionalDataFieldCursor)
+}
+
+var (
+	listWithGlobalConfigRequestFieldOffset = big.NewInt(1 << 0)
+)
 
 type ListWithGlobalConfigRequest struct {
 	Offset *int `json:"-" url:"offset,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListWithGlobalConfigRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListWithGlobalConfigRequest) SetOffset(offset *int) {
+	l.Offset = offset
+	l.require(listWithGlobalConfigRequestFieldOffset)
+}
+
+var (
+	listUsersMixedTypeCursorPaginationRequestFieldCursor = big.NewInt(1 << 0)
+)
 
 type ListUsersMixedTypeCursorPaginationRequest struct {
 	Cursor *string `json:"-" url:"cursor,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersMixedTypeCursorPaginationRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersMixedTypeCursorPaginationRequest) SetCursor(cursor *string) {
+	l.Cursor = cursor
+	l.require(listUsersMixedTypeCursorPaginationRequestFieldCursor)
+}
+
+var (
+	listUsersOffsetPaginationRequestFieldPage          = big.NewInt(1 << 0)
+	listUsersOffsetPaginationRequestFieldPerPage       = big.NewInt(1 << 1)
+	listUsersOffsetPaginationRequestFieldOrder         = big.NewInt(1 << 2)
+	listUsersOffsetPaginationRequestFieldStartingAfter = big.NewInt(1 << 3)
+)
 
 type ListUsersOffsetPaginationRequest struct {
 	// Defaults to first page
@@ -74,7 +289,43 @@ type ListUsersOffsetPaginationRequest struct {
 	// The cursor used for pagination in order to fetch
 	// the next page of results.
 	StartingAfter *string `json:"-" url:"starting_after,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersOffsetPaginationRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersOffsetPaginationRequest) SetPage(page *int) {
+	l.Page = page
+	l.require(listUsersOffsetPaginationRequestFieldPage)
+}
+
+func (l *ListUsersOffsetPaginationRequest) SetPerPage(perPage *int) {
+	l.PerPage = perPage
+	l.require(listUsersOffsetPaginationRequestFieldPerPage)
+}
+
+func (l *ListUsersOffsetPaginationRequest) SetOrder(order *Order) {
+	l.Order = order
+	l.require(listUsersOffsetPaginationRequestFieldOrder)
+}
+
+func (l *ListUsersOffsetPaginationRequest) SetStartingAfter(startingAfter *string) {
+	l.StartingAfter = startingAfter
+	l.require(listUsersOffsetPaginationRequestFieldStartingAfter)
+}
+
+var (
+	listWithOffsetPaginationHasNextPageRequestFieldPage  = big.NewInt(1 << 0)
+	listWithOffsetPaginationHasNextPageRequestFieldLimit = big.NewInt(1 << 1)
+	listWithOffsetPaginationHasNextPageRequestFieldOrder = big.NewInt(1 << 2)
+)
 
 type ListWithOffsetPaginationHasNextPageRequest struct {
 	// Defaults to first page
@@ -84,7 +335,38 @@ type ListWithOffsetPaginationHasNextPageRequest struct {
 	// paginated endpoint.
 	Limit *int   `json:"-" url:"limit,omitempty"`
 	Order *Order `json:"-" url:"order,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListWithOffsetPaginationHasNextPageRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListWithOffsetPaginationHasNextPageRequest) SetPage(page *int) {
+	l.Page = page
+	l.require(listWithOffsetPaginationHasNextPageRequestFieldPage)
+}
+
+func (l *ListWithOffsetPaginationHasNextPageRequest) SetLimit(limit *int) {
+	l.Limit = limit
+	l.require(listWithOffsetPaginationHasNextPageRequestFieldLimit)
+}
+
+func (l *ListWithOffsetPaginationHasNextPageRequest) SetOrder(order *Order) {
+	l.Order = order
+	l.require(listWithOffsetPaginationHasNextPageRequestFieldOrder)
+}
+
+var (
+	listUsersOffsetStepPaginationRequestFieldPage  = big.NewInt(1 << 0)
+	listUsersOffsetStepPaginationRequestFieldLimit = big.NewInt(1 << 1)
+	listUsersOffsetStepPaginationRequestFieldOrder = big.NewInt(1 << 2)
+)
 
 type ListUsersOffsetStepPaginationRequest struct {
 	// Defaults to first page
@@ -94,10 +376,42 @@ type ListUsersOffsetStepPaginationRequest struct {
 	// paginated endpoint.
 	Limit *int   `json:"-" url:"limit,omitempty"`
 	Order *Order `json:"-" url:"order,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (l *ListUsersOffsetStepPaginationRequest) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersOffsetStepPaginationRequest) SetPage(page *int) {
+	l.Page = page
+	l.require(listUsersOffsetStepPaginationRequestFieldPage)
+}
+
+func (l *ListUsersOffsetStepPaginationRequest) SetLimit(limit *int) {
+	l.Limit = limit
+	l.require(listUsersOffsetStepPaginationRequestFieldLimit)
+}
+
+func (l *ListUsersOffsetStepPaginationRequest) SetOrder(order *Order) {
+	l.Order = order
+	l.require(listUsersOffsetStepPaginationRequestFieldOrder)
+}
+
+var (
+	usernameCursorFieldCursor = big.NewInt(1 << 0)
+)
 
 type UsernameCursor struct {
 	Cursor *UsernamePage `json:"cursor" url:"cursor"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -112,6 +426,18 @@ func (u *UsernameCursor) GetCursor() *UsernamePage {
 
 func (u *UsernameCursor) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UsernameCursor) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UsernameCursor) SetCursor(cursor *UsernamePage) {
+	u.Cursor = cursor
+	u.require(usernameCursorFieldCursor)
 }
 
 func (u *UsernameCursor) UnmarshalJSON(data []byte) error {
@@ -130,6 +456,17 @@ func (u *UsernameCursor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UsernameCursor) MarshalJSON() ([]byte, error) {
+	type embed UsernameCursor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UsernameCursor) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -142,9 +479,17 @@ func (u *UsernameCursor) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	usernamePageFieldAfter = big.NewInt(1 << 0)
+	usernamePageFieldData  = big.NewInt(1 << 1)
+)
+
 type UsernamePage struct {
 	After *string  `json:"after,omitempty" url:"after,omitempty"`
 	Data  []string `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -168,6 +513,23 @@ func (u *UsernamePage) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UsernamePage) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UsernamePage) SetAfter(after *string) {
+	u.After = after
+	u.require(usernamePageFieldAfter)
+}
+
+func (u *UsernamePage) SetData(data []string) {
+	u.Data = data
+	u.require(usernamePageFieldData)
+}
+
 func (u *UsernamePage) UnmarshalJSON(data []byte) error {
 	type unmarshaler UsernamePage
 	var value unmarshaler
@@ -184,6 +546,17 @@ func (u *UsernamePage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UsernamePage) MarshalJSON() ([]byte, error) {
+	type embed UsernamePage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UsernamePage) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -196,11 +569,20 @@ func (u *UsernamePage) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	listUsersExtendedOptionalListResponseFieldData       = big.NewInt(1 << 0)
+	listUsersExtendedOptionalListResponseFieldNext       = big.NewInt(1 << 1)
+	listUsersExtendedOptionalListResponseFieldTotalCount = big.NewInt(1 << 2)
+)
+
 type ListUsersExtendedOptionalListResponse struct {
 	Data *UserOptionalListContainer `json:"data" url:"data"`
 	Next *uuid.UUID                 `json:"next,omitempty" url:"next,omitempty"`
 	// The totall number of /users
 	TotalCount int `json:"total_count" url:"total_count"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -231,6 +613,28 @@ func (l *ListUsersExtendedOptionalListResponse) GetExtraProperties() map[string]
 	return l.extraProperties
 }
 
+func (l *ListUsersExtendedOptionalListResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersExtendedOptionalListResponse) SetData(data *UserOptionalListContainer) {
+	l.Data = data
+	l.require(listUsersExtendedOptionalListResponseFieldData)
+}
+
+func (l *ListUsersExtendedOptionalListResponse) SetNext(next *uuid.UUID) {
+	l.Next = next
+	l.require(listUsersExtendedOptionalListResponseFieldNext)
+}
+
+func (l *ListUsersExtendedOptionalListResponse) SetTotalCount(totalCount int) {
+	l.TotalCount = totalCount
+	l.require(listUsersExtendedOptionalListResponseFieldTotalCount)
+}
+
 func (l *ListUsersExtendedOptionalListResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersExtendedOptionalListResponse
 	var value unmarshaler
@@ -247,6 +651,17 @@ func (l *ListUsersExtendedOptionalListResponse) UnmarshalJSON(data []byte) error
 	return nil
 }
 
+func (l *ListUsersExtendedOptionalListResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersExtendedOptionalListResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersExtendedOptionalListResponse) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -259,11 +674,20 @@ func (l *ListUsersExtendedOptionalListResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	listUsersExtendedResponseFieldData       = big.NewInt(1 << 0)
+	listUsersExtendedResponseFieldNext       = big.NewInt(1 << 1)
+	listUsersExtendedResponseFieldTotalCount = big.NewInt(1 << 2)
+)
+
 type ListUsersExtendedResponse struct {
 	Data *UserListContainer `json:"data" url:"data"`
 	Next *uuid.UUID         `json:"next,omitempty" url:"next,omitempty"`
 	// The totall number of /users
 	TotalCount int `json:"total_count" url:"total_count"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -294,6 +718,28 @@ func (l *ListUsersExtendedResponse) GetExtraProperties() map[string]interface{} 
 	return l.extraProperties
 }
 
+func (l *ListUsersExtendedResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersExtendedResponse) SetData(data *UserListContainer) {
+	l.Data = data
+	l.require(listUsersExtendedResponseFieldData)
+}
+
+func (l *ListUsersExtendedResponse) SetNext(next *uuid.UUID) {
+	l.Next = next
+	l.require(listUsersExtendedResponseFieldNext)
+}
+
+func (l *ListUsersExtendedResponse) SetTotalCount(totalCount int) {
+	l.TotalCount = totalCount
+	l.require(listUsersExtendedResponseFieldTotalCount)
+}
+
 func (l *ListUsersExtendedResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersExtendedResponse
 	var value unmarshaler
@@ -310,6 +756,17 @@ func (l *ListUsersExtendedResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *ListUsersExtendedResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersExtendedResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersExtendedResponse) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -322,9 +779,17 @@ func (l *ListUsersExtendedResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	listUsersMixedTypePaginationResponseFieldNext = big.NewInt(1 << 0)
+	listUsersMixedTypePaginationResponseFieldData = big.NewInt(1 << 1)
+)
+
 type ListUsersMixedTypePaginationResponse struct {
 	Next string  `json:"next" url:"next"`
 	Data []*User `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -348,6 +813,23 @@ func (l *ListUsersMixedTypePaginationResponse) GetExtraProperties() map[string]i
 	return l.extraProperties
 }
 
+func (l *ListUsersMixedTypePaginationResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersMixedTypePaginationResponse) SetNext(next string) {
+	l.Next = next
+	l.require(listUsersMixedTypePaginationResponseFieldNext)
+}
+
+func (l *ListUsersMixedTypePaginationResponse) SetData(data []*User) {
+	l.Data = data
+	l.require(listUsersMixedTypePaginationResponseFieldData)
+}
+
 func (l *ListUsersMixedTypePaginationResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersMixedTypePaginationResponse
 	var value unmarshaler
@@ -364,6 +846,17 @@ func (l *ListUsersMixedTypePaginationResponse) UnmarshalJSON(data []byte) error 
 	return nil
 }
 
+func (l *ListUsersMixedTypePaginationResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersMixedTypePaginationResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersMixedTypePaginationResponse) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -376,12 +869,22 @@ func (l *ListUsersMixedTypePaginationResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	listUsersPaginationResponseFieldHasNextPage = big.NewInt(1 << 0)
+	listUsersPaginationResponseFieldPage        = big.NewInt(1 << 1)
+	listUsersPaginationResponseFieldTotalCount  = big.NewInt(1 << 2)
+	listUsersPaginationResponseFieldData        = big.NewInt(1 << 3)
+)
+
 type ListUsersPaginationResponse struct {
 	HasNextPage *bool `json:"hasNextPage,omitempty" url:"hasNextPage,omitempty"`
 	Page        *Page `json:"page,omitempty" url:"page,omitempty"`
 	// The totall number of /users
 	TotalCount int     `json:"total_count" url:"total_count"`
 	Data       []*User `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -419,6 +922,33 @@ func (l *ListUsersPaginationResponse) GetExtraProperties() map[string]interface{
 	return l.extraProperties
 }
 
+func (l *ListUsersPaginationResponse) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *ListUsersPaginationResponse) SetHasNextPage(hasNextPage *bool) {
+	l.HasNextPage = hasNextPage
+	l.require(listUsersPaginationResponseFieldHasNextPage)
+}
+
+func (l *ListUsersPaginationResponse) SetPage(page *Page) {
+	l.Page = page
+	l.require(listUsersPaginationResponseFieldPage)
+}
+
+func (l *ListUsersPaginationResponse) SetTotalCount(totalCount int) {
+	l.TotalCount = totalCount
+	l.require(listUsersPaginationResponseFieldTotalCount)
+}
+
+func (l *ListUsersPaginationResponse) SetData(data []*User) {
+	l.Data = data
+	l.require(listUsersPaginationResponseFieldData)
+}
+
 func (l *ListUsersPaginationResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler ListUsersPaginationResponse
 	var value unmarshaler
@@ -435,6 +965,17 @@ func (l *ListUsersPaginationResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *ListUsersPaginationResponse) MarshalJSON() ([]byte, error) {
+	type embed ListUsersPaginationResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *ListUsersPaginationResponse) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -447,9 +988,17 @@ func (l *ListUsersPaginationResponse) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	nextPageFieldPage          = big.NewInt(1 << 0)
+	nextPageFieldStartingAfter = big.NewInt(1 << 1)
+)
+
 type NextPage struct {
 	Page          int    `json:"page" url:"page"`
 	StartingAfter string `json:"starting_after" url:"starting_after"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -473,6 +1022,23 @@ func (n *NextPage) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NextPage) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NextPage) SetPage(page int) {
+	n.Page = page
+	n.require(nextPageFieldPage)
+}
+
+func (n *NextPage) SetStartingAfter(startingAfter string) {
+	n.StartingAfter = startingAfter
+	n.require(nextPageFieldStartingAfter)
+}
+
 func (n *NextPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler NextPage
 	var value unmarshaler
@@ -487,6 +1053,17 @@ func (n *NextPage) UnmarshalJSON(data []byte) error {
 	n.extraProperties = extraProperties
 	n.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (n *NextPage) MarshalJSON() ([]byte, error) {
+	type embed NextPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (n *NextPage) String() string {
@@ -523,12 +1100,22 @@ func (o Order) Ptr() *Order {
 	return &o
 }
 
+var (
+	pageFieldPage      = big.NewInt(1 << 0)
+	pageFieldNext      = big.NewInt(1 << 1)
+	pageFieldPerPage   = big.NewInt(1 << 2)
+	pageFieldTotalPage = big.NewInt(1 << 3)
+)
+
 type Page struct {
 	// The current page
 	Page      int       `json:"page" url:"page"`
 	Next      *NextPage `json:"next,omitempty" url:"next,omitempty"`
 	PerPage   int       `json:"per_page" url:"per_page"`
 	TotalPage int       `json:"total_page" url:"total_page"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -566,6 +1153,33 @@ func (p *Page) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Page) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *Page) SetPage(page int) {
+	p.Page = page
+	p.require(pageFieldPage)
+}
+
+func (p *Page) SetNext(next *NextPage) {
+	p.Next = next
+	p.require(pageFieldNext)
+}
+
+func (p *Page) SetPerPage(perPage int) {
+	p.PerPage = perPage
+	p.require(pageFieldPerPage)
+}
+
+func (p *Page) SetTotalPage(totalPage int) {
+	p.TotalPage = totalPage
+	p.require(pageFieldTotalPage)
+}
+
 func (p *Page) UnmarshalJSON(data []byte) error {
 	type unmarshaler Page
 	var value unmarshaler
@@ -582,6 +1196,17 @@ func (p *Page) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *Page) MarshalJSON() ([]byte, error) {
+	type embed Page
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *Page) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -594,9 +1219,17 @@ func (p *Page) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldId   = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name string `json:"name" url:"name"`
 	Id   int    `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -620,6 +1253,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetId(id int) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -636,6 +1286,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -648,8 +1309,15 @@ func (u *User) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userListContainerFieldUsers = big.NewInt(1 << 0)
+)
+
 type UserListContainer struct {
 	Users []*User `json:"users" url:"users"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -664,6 +1332,18 @@ func (u *UserListContainer) GetUsers() []*User {
 
 func (u *UserListContainer) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UserListContainer) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UserListContainer) SetUsers(users []*User) {
+	u.Users = users
+	u.require(userListContainerFieldUsers)
 }
 
 func (u *UserListContainer) UnmarshalJSON(data []byte) error {
@@ -682,6 +1362,17 @@ func (u *UserListContainer) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserListContainer) MarshalJSON() ([]byte, error) {
+	type embed UserListContainer
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserListContainer) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -694,8 +1385,15 @@ func (u *UserListContainer) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userOptionalListContainerFieldUsers = big.NewInt(1 << 0)
+)
+
 type UserOptionalListContainer struct {
 	Users []*User `json:"users,omitempty" url:"users,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -710,6 +1408,18 @@ func (u *UserOptionalListContainer) GetUsers() []*User {
 
 func (u *UserOptionalListContainer) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UserOptionalListContainer) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UserOptionalListContainer) SetUsers(users []*User) {
+	u.Users = users
+	u.require(userOptionalListContainerFieldUsers)
 }
 
 func (u *UserOptionalListContainer) UnmarshalJSON(data []byte) error {
@@ -728,6 +1438,17 @@ func (u *UserOptionalListContainer) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserOptionalListContainer) MarshalJSON() ([]byte, error) {
+	type embed UserOptionalListContainer
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserOptionalListContainer) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -740,9 +1461,17 @@ func (u *UserOptionalListContainer) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userOptionalListPageFieldData = big.NewInt(1 << 0)
+	userOptionalListPageFieldNext = big.NewInt(1 << 1)
+)
+
 type UserOptionalListPage struct {
 	Data *UserOptionalListContainer `json:"data" url:"data"`
 	Next *uuid.UUID                 `json:"next,omitempty" url:"next,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -766,6 +1495,23 @@ func (u *UserOptionalListPage) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserOptionalListPage) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UserOptionalListPage) SetData(data *UserOptionalListContainer) {
+	u.Data = data
+	u.require(userOptionalListPageFieldData)
+}
+
+func (u *UserOptionalListPage) SetNext(next *uuid.UUID) {
+	u.Next = next
+	u.require(userOptionalListPageFieldNext)
+}
+
 func (u *UserOptionalListPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler UserOptionalListPage
 	var value unmarshaler
@@ -782,6 +1528,17 @@ func (u *UserOptionalListPage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserOptionalListPage) MarshalJSON() ([]byte, error) {
+	type embed UserOptionalListPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserOptionalListPage) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -794,9 +1551,17 @@ func (u *UserOptionalListPage) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	userPageFieldData = big.NewInt(1 << 0)
+	userPageFieldNext = big.NewInt(1 << 1)
+)
+
 type UserPage struct {
 	Data *UserListContainer `json:"data" url:"data"`
 	Next *uuid.UUID         `json:"next,omitempty" url:"next,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -820,6 +1585,23 @@ func (u *UserPage) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *UserPage) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UserPage) SetData(data *UserListContainer) {
+	u.Data = data
+	u.require(userPageFieldData)
+}
+
+func (u *UserPage) SetNext(next *uuid.UUID) {
+	u.Next = next
+	u.require(userPageFieldNext)
+}
+
 func (u *UserPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler UserPage
 	var value unmarshaler
@@ -836,6 +1618,17 @@ func (u *UserPage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserPage) MarshalJSON() ([]byte, error) {
+	type embed UserPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UserPage) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -848,8 +1641,15 @@ func (u *UserPage) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	usernameContainerFieldResults = big.NewInt(1 << 0)
+)
+
 type UsernameContainer struct {
 	Results []string `json:"results" url:"results"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -864,6 +1664,18 @@ func (u *UsernameContainer) GetResults() []string {
 
 func (u *UsernameContainer) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UsernameContainer) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UsernameContainer) SetResults(results []string) {
+	u.Results = results
+	u.require(usernameContainerFieldResults)
 }
 
 func (u *UsernameContainer) UnmarshalJSON(data []byte) error {
@@ -882,6 +1694,17 @@ func (u *UsernameContainer) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UsernameContainer) MarshalJSON() ([]byte, error) {
+	type embed UsernameContainer
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UsernameContainer) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -894,8 +1717,15 @@ func (u *UsernameContainer) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	withCursorFieldCursor = big.NewInt(1 << 0)
+)
+
 type WithCursor struct {
 	Cursor *string `json:"cursor,omitempty" url:"cursor,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -910,6 +1740,18 @@ func (w *WithCursor) GetCursor() *string {
 
 func (w *WithCursor) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
+}
+
+func (w *WithCursor) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+func (w *WithCursor) SetCursor(cursor *string) {
+	w.Cursor = cursor
+	w.require(withCursorFieldCursor)
 }
 
 func (w *WithCursor) UnmarshalJSON(data []byte) error {
@@ -928,6 +1770,17 @@ func (w *WithCursor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (w *WithCursor) MarshalJSON() ([]byte, error) {
+	type embed WithCursor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (w *WithCursor) String() string {
 	if len(w.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -940,8 +1793,15 @@ func (w *WithCursor) String() string {
 	return fmt.Sprintf("%#v", w)
 }
 
+var (
+	withPageFieldPage = big.NewInt(1 << 0)
+)
+
 type WithPage struct {
 	Page *int `json:"page,omitempty" url:"page,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -958,6 +1818,18 @@ func (w *WithPage) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
 }
 
+func (w *WithPage) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+func (w *WithPage) SetPage(page *int) {
+	w.Page = page
+	w.require(withPageFieldPage)
+}
+
 func (w *WithPage) UnmarshalJSON(data []byte) error {
 	type unmarshaler WithPage
 	var value unmarshaler
@@ -972,6 +1844,17 @@ func (w *WithPage) UnmarshalJSON(data []byte) error {
 	w.extraProperties = extraProperties
 	w.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (w *WithPage) MarshalJSON() ([]byte, error) {
+	type embed WithPage
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (w *WithPage) String() string {

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/path-parameters/no-custom-config/organizations.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/organizations.go
@@ -31,16 +31,22 @@ func (g *GetOrganizationUserRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetOrganizationUserRequest) SetTenantId(tenantId string) {
 	g.TenantId = tenantId
 	g.require(getOrganizationUserRequestFieldTenantId)
 }
 
+// SetOrganizationId sets the OrganizationId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetOrganizationUserRequest) SetOrganizationId(organizationId string) {
 	g.OrganizationId = organizationId
 	g.require(getOrganizationUserRequestFieldOrganizationId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetOrganizationUserRequest) SetUserId(userId string) {
 	g.UserId = userId
 	g.require(getOrganizationUserRequestFieldUserId)
@@ -64,6 +70,8 @@ func (s *SearchOrganizationsRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchOrganizationsRequest) SetLimit(limit *int) {
 	s.Limit = limit
 	s.require(searchOrganizationsRequestFieldLimit)
@@ -110,11 +118,15 @@ func (o *Organization) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetName(name string) {
 	o.Name = name
 	o.require(organizationFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetTags(tags []string) {
 	o.Tags = tags
 	o.require(organizationFieldTags)

--- a/seed/go-sdk/path-parameters/no-custom-config/user.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/user.go
@@ -29,11 +29,15 @@ func (g *GetUsersRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetTenantId(tenantId string) {
 	g.TenantId = tenantId
 	g.require(getUsersRequestFieldTenantId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetUserId(userId string) {
 	g.UserId = userId
 	g.require(getUsersRequestFieldUserId)
@@ -61,16 +65,22 @@ func (s *SearchUsersRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetTenantId(tenantId string) {
 	s.TenantId = tenantId
 	s.require(searchUsersRequestFieldTenantId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetUserId(userId string) {
 	s.UserId = userId
 	s.require(searchUsersRequestFieldUserId)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetLimit(limit *int) {
 	s.Limit = limit
 	s.require(searchUsersRequestFieldLimit)
@@ -117,11 +127,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)
@@ -187,11 +201,15 @@ func (u *UpdateUserRequest) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetTenantId(tenantId string) {
 	u.TenantId = tenantId
 	u.require(updateUserRequestFieldTenantId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetUserId(userId string) {
 	u.UserId = userId
 	u.require(updateUserRequestFieldUserId)

--- a/seed/go-sdk/path-parameters/no-custom-config/user.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/user.go
@@ -6,22 +6,87 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/path-parameters/fern/internal"
+	big "math/big"
+)
+
+var (
+	getUsersRequestFieldTenantId = big.NewInt(1 << 0)
+	getUsersRequestFieldUserId   = big.NewInt(1 << 1)
 )
 
 type GetUsersRequest struct {
 	TenantId string `json:"-" url:"-"`
 	UserId   string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetUsersRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetUsersRequest) SetTenantId(tenantId string) {
+	g.TenantId = tenantId
+	g.require(getUsersRequestFieldTenantId)
+}
+
+func (g *GetUsersRequest) SetUserId(userId string) {
+	g.UserId = userId
+	g.require(getUsersRequestFieldUserId)
+}
+
+var (
+	searchUsersRequestFieldTenantId = big.NewInt(1 << 0)
+	searchUsersRequestFieldUserId   = big.NewInt(1 << 1)
+	searchUsersRequestFieldLimit    = big.NewInt(1 << 2)
+)
 
 type SearchUsersRequest struct {
 	TenantId string `json:"-" url:"-"`
 	UserId   string `json:"-" url:"-"`
 	Limit    *int   `json:"-" url:"limit,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *SearchUsersRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchUsersRequest) SetTenantId(tenantId string) {
+	s.TenantId = tenantId
+	s.require(searchUsersRequestFieldTenantId)
+}
+
+func (s *SearchUsersRequest) SetUserId(userId string) {
+	s.UserId = userId
+	s.require(searchUsersRequestFieldUserId)
+}
+
+func (s *SearchUsersRequest) SetLimit(limit *int) {
+	s.Limit = limit
+	s.require(searchUsersRequestFieldLimit)
+}
+
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
 
 type User struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags" url:"tags"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -45,6 +110,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -61,6 +143,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -73,10 +166,35 @@ func (u *User) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	updateUserRequestFieldTenantId = big.NewInt(1 << 0)
+	updateUserRequestFieldUserId   = big.NewInt(1 << 1)
+)
+
 type UpdateUserRequest struct {
 	TenantId string `json:"-" url:"-"`
 	UserId   string `json:"-" url:"-"`
 	Body     *User  `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (u *UpdateUserRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UpdateUserRequest) SetTenantId(tenantId string) {
+	u.TenantId = tenantId
+	u.require(updateUserRequestFieldTenantId)
+}
+
+func (u *UpdateUserRequest) SetUserId(userId string) {
+	u.UserId = userId
+	u.require(updateUserRequestFieldUserId)
 }
 
 func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {

--- a/seed/go-sdk/path-parameters/package-name/internal/explicit_fields.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/path-parameters/package-name/internal/explicit_fields_test.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/path-parameters/package-name/organizations.go
+++ b/seed/go-sdk/path-parameters/package-name/organizations.go
@@ -31,16 +31,22 @@ func (g *GetOrganizationUserRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetOrganizationUserRequest) SetTenantId(tenantId string) {
 	g.TenantId = tenantId
 	g.require(getOrganizationUserRequestFieldTenantId)
 }
 
+// SetOrganizationId sets the OrganizationId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetOrganizationUserRequest) SetOrganizationId(organizationId string) {
 	g.OrganizationId = organizationId
 	g.require(getOrganizationUserRequestFieldOrganizationId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetOrganizationUserRequest) SetUserId(userId string) {
 	g.UserId = userId
 	g.require(getOrganizationUserRequestFieldUserId)
@@ -64,6 +70,8 @@ func (s *SearchOrganizationsRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchOrganizationsRequest) SetLimit(limit *int) {
 	s.Limit = limit
 	s.require(searchOrganizationsRequestFieldLimit)
@@ -110,11 +118,15 @@ func (o *Organization) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetName(name string) {
 	o.Name = name
 	o.require(organizationFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetTags(tags []string) {
 	o.Tags = tags
 	o.require(organizationFieldTags)

--- a/seed/go-sdk/path-parameters/package-name/organizations.go
+++ b/seed/go-sdk/path-parameters/package-name/organizations.go
@@ -6,21 +6,80 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/fern-api/path-parameters-go/internal"
+	big "math/big"
+)
+
+var (
+	getOrganizationUserRequestFieldTenantId       = big.NewInt(1 << 0)
+	getOrganizationUserRequestFieldOrganizationId = big.NewInt(1 << 1)
+	getOrganizationUserRequestFieldUserId         = big.NewInt(1 << 2)
 )
 
 type GetOrganizationUserRequest struct {
 	TenantId       string `json:"-" url:"-"`
 	OrganizationId string `json:"-" url:"-"`
 	UserId         string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetOrganizationUserRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetOrganizationUserRequest) SetTenantId(tenantId string) {
+	g.TenantId = tenantId
+	g.require(getOrganizationUserRequestFieldTenantId)
+}
+
+func (g *GetOrganizationUserRequest) SetOrganizationId(organizationId string) {
+	g.OrganizationId = organizationId
+	g.require(getOrganizationUserRequestFieldOrganizationId)
+}
+
+func (g *GetOrganizationUserRequest) SetUserId(userId string) {
+	g.UserId = userId
+	g.require(getOrganizationUserRequestFieldUserId)
+}
+
+var (
+	searchOrganizationsRequestFieldLimit = big.NewInt(1 << 0)
+)
 
 type SearchOrganizationsRequest struct {
 	Limit *int `json:"-" url:"limit,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *SearchOrganizationsRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchOrganizationsRequest) SetLimit(limit *int) {
+	s.Limit = limit
+	s.require(searchOrganizationsRequestFieldLimit)
+}
+
+var (
+	organizationFieldName = big.NewInt(1 << 0)
+	organizationFieldTags = big.NewInt(1 << 1)
+)
 
 type Organization struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags" url:"tags"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -44,6 +103,23 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
+func (o *Organization) SetTags(tags []string) {
+	o.Tags = tags
+	o.require(organizationFieldTags)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -58,6 +134,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *Organization) String() string {

--- a/seed/go-sdk/path-parameters/package-name/user.go
+++ b/seed/go-sdk/path-parameters/package-name/user.go
@@ -29,11 +29,15 @@ func (g *GetUsersRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetTenantId(tenantId string) {
 	g.TenantId = tenantId
 	g.require(getUsersRequestFieldTenantId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetUserId(userId string) {
 	g.UserId = userId
 	g.require(getUsersRequestFieldUserId)
@@ -61,16 +65,22 @@ func (s *SearchUsersRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetTenantId(tenantId string) {
 	s.TenantId = tenantId
 	s.require(searchUsersRequestFieldTenantId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetUserId(userId string) {
 	s.UserId = userId
 	s.require(searchUsersRequestFieldUserId)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetLimit(limit *int) {
 	s.Limit = limit
 	s.require(searchUsersRequestFieldLimit)
@@ -117,11 +127,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)
@@ -187,11 +201,15 @@ func (u *UpdateUserRequest) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetTenantId sets the TenantId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetTenantId(tenantId string) {
 	u.TenantId = tenantId
 	u.require(updateUserRequestFieldTenantId)
 }
 
+// SetUserId sets the UserId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UpdateUserRequest) SetUserId(userId string) {
 	u.UserId = userId
 	u.require(updateUserRequestFieldUserId)

--- a/seed/go-sdk/path-parameters/package-name/user.go
+++ b/seed/go-sdk/path-parameters/package-name/user.go
@@ -6,22 +6,87 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/fern-api/path-parameters-go/internal"
+	big "math/big"
+)
+
+var (
+	getUsersRequestFieldTenantId = big.NewInt(1 << 0)
+	getUsersRequestFieldUserId   = big.NewInt(1 << 1)
 )
 
 type GetUsersRequest struct {
 	TenantId string `json:"-" url:"-"`
 	UserId   string `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetUsersRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetUsersRequest) SetTenantId(tenantId string) {
+	g.TenantId = tenantId
+	g.require(getUsersRequestFieldTenantId)
+}
+
+func (g *GetUsersRequest) SetUserId(userId string) {
+	g.UserId = userId
+	g.require(getUsersRequestFieldUserId)
+}
+
+var (
+	searchUsersRequestFieldTenantId = big.NewInt(1 << 0)
+	searchUsersRequestFieldUserId   = big.NewInt(1 << 1)
+	searchUsersRequestFieldLimit    = big.NewInt(1 << 2)
+)
 
 type SearchUsersRequest struct {
 	TenantId string `json:"-" url:"-"`
 	UserId   string `json:"-" url:"-"`
 	Limit    *int   `json:"-" url:"limit,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *SearchUsersRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchUsersRequest) SetTenantId(tenantId string) {
+	s.TenantId = tenantId
+	s.require(searchUsersRequestFieldTenantId)
+}
+
+func (s *SearchUsersRequest) SetUserId(userId string) {
+	s.UserId = userId
+	s.require(searchUsersRequestFieldUserId)
+}
+
+func (s *SearchUsersRequest) SetLimit(limit *int) {
+	s.Limit = limit
+	s.require(searchUsersRequestFieldLimit)
+}
+
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
 
 type User struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags" url:"tags"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -45,6 +110,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -61,6 +143,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *User) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -73,10 +166,35 @@ func (u *User) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	updateUserRequestFieldTenantId = big.NewInt(1 << 0)
+	updateUserRequestFieldUserId   = big.NewInt(1 << 1)
+)
+
 type UpdateUserRequest struct {
 	TenantId string `json:"-" url:"-"`
 	UserId   string `json:"-" url:"-"`
 	Body     *User  `json:"-" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+}
+
+func (u *UpdateUserRequest) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UpdateUserRequest) SetTenantId(tenantId string) {
+	u.TenantId = tenantId
+	u.require(updateUserRequestFieldTenantId)
+}
+
+func (u *UpdateUserRequest) SetUserId(userId string) {
+	u.UserId = userId
+	u.require(updateUserRequestFieldUserId)
 }
 
 func (u *UpdateUserRequest) UnmarshalJSON(data []byte) error {

--- a/seed/go-sdk/path-parameters/v0/internal/explicit_fields.go
+++ b/seed/go-sdk/path-parameters/v0/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/path-parameters/v0/internal/explicit_fields_test.go
+++ b/seed/go-sdk/path-parameters/v0/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/path-parameters/v0/organizations.go
+++ b/seed/go-sdk/path-parameters/v0/organizations.go
@@ -6,15 +6,43 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/path-parameters/fern/internal"
+	big "math/big"
+)
+
+var (
+	searchOrganizationsRequestFieldLimit = big.NewInt(1 << 0)
 )
 
 type SearchOrganizationsRequest struct {
 	Limit *int `json:"-" url:"limit,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *SearchOrganizationsRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchOrganizationsRequest) SetLimit(limit *int) {
+	s.Limit = limit
+	s.require(searchOrganizationsRequestFieldLimit)
+}
+
+var (
+	organizationFieldName = big.NewInt(1 << 0)
+	organizationFieldTags = big.NewInt(1 << 1)
+)
 
 type Organization struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags,omitempty" url:"tags,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -38,6 +66,23 @@ func (o *Organization) GetExtraProperties() map[string]interface{} {
 	return o.extraProperties
 }
 
+func (o *Organization) require(field *big.Int) {
+	if o.explicitFields == nil {
+		o.explicitFields = big.NewInt(0)
+	}
+	o.explicitFields.Or(o.explicitFields, field)
+}
+
+func (o *Organization) SetName(name string) {
+	o.Name = name
+	o.require(organizationFieldName)
+}
+
+func (o *Organization) SetTags(tags []string) {
+	o.Tags = tags
+	o.require(organizationFieldTags)
+}
+
 func (o *Organization) UnmarshalJSON(data []byte) error {
 	type unmarshaler Organization
 	var value unmarshaler
@@ -52,6 +97,17 @@ func (o *Organization) UnmarshalJSON(data []byte) error {
 	o.extraProperties = extraProperties
 	o.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (o *Organization) MarshalJSON() ([]byte, error) {
+	type embed Organization
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*o),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, o.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (o *Organization) String() string {

--- a/seed/go-sdk/path-parameters/v0/organizations.go
+++ b/seed/go-sdk/path-parameters/v0/organizations.go
@@ -27,6 +27,8 @@ func (s *SearchOrganizationsRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchOrganizationsRequest) SetLimit(limit *int) {
 	s.Limit = limit
 	s.require(searchOrganizationsRequestFieldLimit)
@@ -73,11 +75,15 @@ func (o *Organization) require(field *big.Int) {
 	o.explicitFields.Or(o.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetName(name string) {
 	o.Name = name
 	o.require(organizationFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (o *Organization) SetTags(tags []string) {
 	o.Tags = tags
 	o.require(organizationFieldTags)

--- a/seed/go-sdk/path-parameters/v0/user.go
+++ b/seed/go-sdk/path-parameters/v0/user.go
@@ -27,6 +27,8 @@ func (s *SearchUsersRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchUsersRequest) SetLimit(limit *int) {
 	s.Limit = limit
 	s.require(searchUsersRequestFieldLimit)
@@ -73,11 +75,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)

--- a/seed/go-sdk/plain-text/internal/explicit_fields.go
+++ b/seed/go-sdk/plain-text/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/plain-text/internal/explicit_fields_test.go
+++ b/seed/go-sdk/plain-text/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/public-object/internal/explicit_fields.go
+++ b/seed/go-sdk/public-object/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/public-object/internal/explicit_fields_test.go
+++ b/seed/go-sdk/public-object/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/explicit_fields.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/explicit_fields_test.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/query-parameters-openapi-as-objects/types.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/types.go
@@ -58,81 +58,113 @@ func (s *SearchRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetLimit(limit int) {
 	s.Limit = limit
 	s.require(searchRequestFieldLimit)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetId(id string) {
 	s.Id = id
 	s.require(searchRequestFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetDate(date string) {
 	s.Date = date
 	s.require(searchRequestFieldDate)
 }
 
+// SetDeadline sets the Deadline field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetDeadline(deadline time.Time) {
 	s.Deadline = deadline
 	s.require(searchRequestFieldDeadline)
 }
 
+// SetBytes sets the Bytes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetBytes(bytes string) {
 	s.Bytes = bytes
 	s.require(searchRequestFieldBytes)
 }
 
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetUser(user *User) {
 	s.User = user
 	s.require(searchRequestFieldUser)
 }
 
+// SetUserList sets the UserList field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetUserList(userList []*User) {
 	s.UserList = userList
 	s.require(searchRequestFieldUserList)
 }
 
+// SetOptionalDeadline sets the OptionalDeadline field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetOptionalDeadline(optionalDeadline *time.Time) {
 	s.OptionalDeadline = optionalDeadline
 	s.require(searchRequestFieldOptionalDeadline)
 }
 
+// SetKeyValue sets the KeyValue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetKeyValue(keyValue map[string]*string) {
 	s.KeyValue = keyValue
 	s.require(searchRequestFieldKeyValue)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetOptionalString(optionalString *string) {
 	s.OptionalString = optionalString
 	s.require(searchRequestFieldOptionalString)
 }
 
+// SetNestedUser sets the NestedUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetNestedUser(nestedUser *NestedUser) {
 	s.NestedUser = nestedUser
 	s.require(searchRequestFieldNestedUser)
 }
 
+// SetOptionalUser sets the OptionalUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetOptionalUser(optionalUser *User) {
 	s.OptionalUser = optionalUser
 	s.require(searchRequestFieldOptionalUser)
 }
 
+// SetExcludeUser sets the ExcludeUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetExcludeUser(excludeUser []*User) {
 	s.ExcludeUser = excludeUser
 	s.require(searchRequestFieldExcludeUser)
 }
 
+// SetFilter sets the Filter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetFilter(filter []*string) {
 	s.Filter = filter
 	s.require(searchRequestFieldFilter)
 }
 
+// SetNeighbor sets the Neighbor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetNeighbor(neighbor *SearchRequestNeighbor) {
 	s.Neighbor = neighbor
 	s.require(searchRequestFieldNeighbor)
 }
 
+// SetNeighborRequired sets the NeighborRequired field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetNeighborRequired(neighborRequired *SearchRequestNeighborRequired) {
 	s.NeighborRequired = neighborRequired
 	s.require(searchRequestFieldNeighborRequired)
@@ -179,11 +211,15 @@ func (n *NestedUser) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetName(name *string) {
 	n.Name = name
 	n.require(nestedUserFieldName)
 }
 
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetUser(user *User) {
 	n.User = user
 	n.require(nestedUserFieldUser)
@@ -468,6 +504,8 @@ func (s *SearchResponse) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResponse) SetResults(results []string) {
 	s.Results = results
 	s.require(searchResponseFieldResults)
@@ -553,11 +591,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name *string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)

--- a/seed/go-sdk/query-parameters-openapi/internal/explicit_fields.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/query-parameters-openapi/internal/explicit_fields_test.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/query-parameters-openapi/types.go
+++ b/seed/go-sdk/query-parameters-openapi/types.go
@@ -58,81 +58,113 @@ func (s *SearchRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetLimit(limit int) {
 	s.Limit = limit
 	s.require(searchRequestFieldLimit)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetId(id string) {
 	s.Id = id
 	s.require(searchRequestFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetDate(date string) {
 	s.Date = date
 	s.require(searchRequestFieldDate)
 }
 
+// SetDeadline sets the Deadline field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetDeadline(deadline time.Time) {
 	s.Deadline = deadline
 	s.require(searchRequestFieldDeadline)
 }
 
+// SetBytes sets the Bytes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetBytes(bytes string) {
 	s.Bytes = bytes
 	s.require(searchRequestFieldBytes)
 }
 
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetUser(user *User) {
 	s.User = user
 	s.require(searchRequestFieldUser)
 }
 
+// SetUserList sets the UserList field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetUserList(userList []*User) {
 	s.UserList = userList
 	s.require(searchRequestFieldUserList)
 }
 
+// SetOptionalDeadline sets the OptionalDeadline field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetOptionalDeadline(optionalDeadline *time.Time) {
 	s.OptionalDeadline = optionalDeadline
 	s.require(searchRequestFieldOptionalDeadline)
 }
 
+// SetKeyValue sets the KeyValue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetKeyValue(keyValue map[string]*string) {
 	s.KeyValue = keyValue
 	s.require(searchRequestFieldKeyValue)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetOptionalString(optionalString *string) {
 	s.OptionalString = optionalString
 	s.require(searchRequestFieldOptionalString)
 }
 
+// SetNestedUser sets the NestedUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetNestedUser(nestedUser *NestedUser) {
 	s.NestedUser = nestedUser
 	s.require(searchRequestFieldNestedUser)
 }
 
+// SetOptionalUser sets the OptionalUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetOptionalUser(optionalUser *User) {
 	s.OptionalUser = optionalUser
 	s.require(searchRequestFieldOptionalUser)
 }
 
+// SetExcludeUser sets the ExcludeUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetExcludeUser(excludeUser []*User) {
 	s.ExcludeUser = excludeUser
 	s.require(searchRequestFieldExcludeUser)
 }
 
+// SetFilter sets the Filter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetFilter(filter []*string) {
 	s.Filter = filter
 	s.require(searchRequestFieldFilter)
 }
 
+// SetNeighbor sets the Neighbor field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetNeighbor(neighbor *User) {
 	s.Neighbor = neighbor
 	s.require(searchRequestFieldNeighbor)
 }
 
+// SetNeighborRequired sets the NeighborRequired field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchRequest) SetNeighborRequired(neighborRequired *SearchRequestNeighborRequired) {
 	s.NeighborRequired = neighborRequired
 	s.require(searchRequestFieldNeighborRequired)
@@ -179,11 +211,15 @@ func (n *NestedUser) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetName(name *string) {
 	n.Name = name
 	n.require(nestedUserFieldName)
 }
 
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetUser(user *User) {
 	n.User = user
 	n.require(nestedUserFieldUser)
@@ -364,6 +400,8 @@ func (s *SearchResponse) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetResults sets the Results field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SearchResponse) SetResults(results []string) {
 	s.Results = results
 	s.require(searchResponseFieldResults)
@@ -449,11 +487,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name *string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)

--- a/seed/go-sdk/query-parameters-openapi/types.go
+++ b/seed/go-sdk/query-parameters-openapi/types.go
@@ -6,7 +6,27 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/query-parameters-openapi/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	searchRequestFieldLimit            = big.NewInt(1 << 0)
+	searchRequestFieldId               = big.NewInt(1 << 1)
+	searchRequestFieldDate             = big.NewInt(1 << 2)
+	searchRequestFieldDeadline         = big.NewInt(1 << 3)
+	searchRequestFieldBytes            = big.NewInt(1 << 4)
+	searchRequestFieldUser             = big.NewInt(1 << 5)
+	searchRequestFieldUserList         = big.NewInt(1 << 6)
+	searchRequestFieldOptionalDeadline = big.NewInt(1 << 7)
+	searchRequestFieldKeyValue         = big.NewInt(1 << 8)
+	searchRequestFieldOptionalString   = big.NewInt(1 << 9)
+	searchRequestFieldNestedUser       = big.NewInt(1 << 10)
+	searchRequestFieldOptionalUser     = big.NewInt(1 << 11)
+	searchRequestFieldExcludeUser      = big.NewInt(1 << 12)
+	searchRequestFieldFilter           = big.NewInt(1 << 13)
+	searchRequestFieldNeighbor         = big.NewInt(1 << 14)
+	searchRequestFieldNeighborRequired = big.NewInt(1 << 15)
 )
 
 type SearchRequest struct {
@@ -26,11 +46,109 @@ type SearchRequest struct {
 	Filter           []*string                      `json:"-" url:"filter,omitempty"`
 	Neighbor         *User                          `json:"-" url:"neighbor,omitempty"`
 	NeighborRequired *SearchRequestNeighborRequired `json:"-" url:"neighborRequired"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *SearchRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchRequest) SetLimit(limit int) {
+	s.Limit = limit
+	s.require(searchRequestFieldLimit)
+}
+
+func (s *SearchRequest) SetId(id string) {
+	s.Id = id
+	s.require(searchRequestFieldId)
+}
+
+func (s *SearchRequest) SetDate(date string) {
+	s.Date = date
+	s.require(searchRequestFieldDate)
+}
+
+func (s *SearchRequest) SetDeadline(deadline time.Time) {
+	s.Deadline = deadline
+	s.require(searchRequestFieldDeadline)
+}
+
+func (s *SearchRequest) SetBytes(bytes string) {
+	s.Bytes = bytes
+	s.require(searchRequestFieldBytes)
+}
+
+func (s *SearchRequest) SetUser(user *User) {
+	s.User = user
+	s.require(searchRequestFieldUser)
+}
+
+func (s *SearchRequest) SetUserList(userList []*User) {
+	s.UserList = userList
+	s.require(searchRequestFieldUserList)
+}
+
+func (s *SearchRequest) SetOptionalDeadline(optionalDeadline *time.Time) {
+	s.OptionalDeadline = optionalDeadline
+	s.require(searchRequestFieldOptionalDeadline)
+}
+
+func (s *SearchRequest) SetKeyValue(keyValue map[string]*string) {
+	s.KeyValue = keyValue
+	s.require(searchRequestFieldKeyValue)
+}
+
+func (s *SearchRequest) SetOptionalString(optionalString *string) {
+	s.OptionalString = optionalString
+	s.require(searchRequestFieldOptionalString)
+}
+
+func (s *SearchRequest) SetNestedUser(nestedUser *NestedUser) {
+	s.NestedUser = nestedUser
+	s.require(searchRequestFieldNestedUser)
+}
+
+func (s *SearchRequest) SetOptionalUser(optionalUser *User) {
+	s.OptionalUser = optionalUser
+	s.require(searchRequestFieldOptionalUser)
+}
+
+func (s *SearchRequest) SetExcludeUser(excludeUser []*User) {
+	s.ExcludeUser = excludeUser
+	s.require(searchRequestFieldExcludeUser)
+}
+
+func (s *SearchRequest) SetFilter(filter []*string) {
+	s.Filter = filter
+	s.require(searchRequestFieldFilter)
+}
+
+func (s *SearchRequest) SetNeighbor(neighbor *User) {
+	s.Neighbor = neighbor
+	s.require(searchRequestFieldNeighbor)
+}
+
+func (s *SearchRequest) SetNeighborRequired(neighborRequired *SearchRequestNeighborRequired) {
+	s.NeighborRequired = neighborRequired
+	s.require(searchRequestFieldNeighborRequired)
+}
+
+var (
+	nestedUserFieldName = big.NewInt(1 << 0)
+	nestedUserFieldUser = big.NewInt(1 << 1)
+)
 
 type NestedUser struct {
 	Name *string `json:"name,omitempty" url:"name,omitempty"`
 	User *User   `json:"user,omitempty" url:"user,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -54,6 +172,23 @@ func (n *NestedUser) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedUser) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NestedUser) SetName(name *string) {
+	n.Name = name
+	n.require(nestedUserFieldName)
+}
+
+func (n *NestedUser) SetUser(user *User) {
+	n.User = user
+	n.require(nestedUserFieldUser)
+}
+
 func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedUser
 	var value unmarshaler
@@ -68,6 +203,17 @@ func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	n.extraProperties = extraProperties
 	n.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (n *NestedUser) MarshalJSON() ([]byte, error) {
+	type embed NestedUser
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (n *NestedUser) String() string {
@@ -186,8 +332,15 @@ func (s *SearchRequestNeighborRequired) Accept(visitor SearchRequestNeighborRequ
 	return fmt.Errorf("type %T does not include a non-empty union type", s)
 }
 
+var (
+	searchResponseFieldResults = big.NewInt(1 << 0)
+)
+
 type SearchResponse struct {
 	Results []string `json:"results,omitempty" url:"results,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -202,6 +355,18 @@ func (s *SearchResponse) GetResults() []string {
 
 func (s *SearchResponse) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
+}
+
+func (s *SearchResponse) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SearchResponse) SetResults(results []string) {
+	s.Results = results
+	s.require(searchResponseFieldResults)
 }
 
 func (s *SearchResponse) UnmarshalJSON(data []byte) error {
@@ -220,6 +385,17 @@ func (s *SearchResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SearchResponse) MarshalJSON() ([]byte, error) {
+	type embed SearchResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SearchResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -232,9 +408,17 @@ func (s *SearchResponse) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name *string  `json:"name,omitempty" url:"name,omitempty"`
 	Tags []string `json:"tags,omitempty" url:"tags,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -258,6 +442,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name *string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -272,6 +473,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/query-parameters/internal/explicit_fields.go
+++ b/seed/go-sdk/query-parameters/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/query-parameters/internal/explicit_fields_test.go
+++ b/seed/go-sdk/query-parameters/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/query-parameters/user.go
+++ b/seed/go-sdk/query-parameters/user.go
@@ -55,71 +55,99 @@ func (g *GetUsersRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetLimit sets the Limit field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetLimit(limit int) {
 	g.Limit = limit
 	g.require(getUsersRequestFieldLimit)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetId(id uuid.UUID) {
 	g.Id = id
 	g.require(getUsersRequestFieldId)
 }
 
+// SetDate sets the Date field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetDate(date time.Time) {
 	g.Date = date
 	g.require(getUsersRequestFieldDate)
 }
 
+// SetDeadline sets the Deadline field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetDeadline(deadline time.Time) {
 	g.Deadline = deadline
 	g.require(getUsersRequestFieldDeadline)
 }
 
+// SetBytes sets the Bytes field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetBytes(bytes []byte) {
 	g.Bytes = bytes
 	g.require(getUsersRequestFieldBytes)
 }
 
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetUser(user *User) {
 	g.User = user
 	g.require(getUsersRequestFieldUser)
 }
 
+// SetUserList sets the UserList field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetUserList(userList []*User) {
 	g.UserList = userList
 	g.require(getUsersRequestFieldUserList)
 }
 
+// SetOptionalDeadline sets the OptionalDeadline field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetOptionalDeadline(optionalDeadline *time.Time) {
 	g.OptionalDeadline = optionalDeadline
 	g.require(getUsersRequestFieldOptionalDeadline)
 }
 
+// SetKeyValue sets the KeyValue field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetKeyValue(keyValue map[string]string) {
 	g.KeyValue = keyValue
 	g.require(getUsersRequestFieldKeyValue)
 }
 
+// SetOptionalString sets the OptionalString field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetOptionalString(optionalString *string) {
 	g.OptionalString = optionalString
 	g.require(getUsersRequestFieldOptionalString)
 }
 
+// SetNestedUser sets the NestedUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetNestedUser(nestedUser *NestedUser) {
 	g.NestedUser = nestedUser
 	g.require(getUsersRequestFieldNestedUser)
 }
 
+// SetOptionalUser sets the OptionalUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetOptionalUser(optionalUser *User) {
 	g.OptionalUser = optionalUser
 	g.require(getUsersRequestFieldOptionalUser)
 }
 
+// SetExcludeUser sets the ExcludeUser field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetExcludeUser(excludeUser []*User) {
 	g.ExcludeUser = excludeUser
 	g.require(getUsersRequestFieldExcludeUser)
 }
 
+// SetFilter sets the Filter field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetUsersRequest) SetFilter(filter []string) {
 	g.Filter = filter
 	g.require(getUsersRequestFieldFilter)
@@ -166,11 +194,15 @@ func (n *NestedUser) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetName(name string) {
 	n.Name = name
 	n.require(nestedUserFieldName)
 }
 
+// SetUser sets the User field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NestedUser) SetUser(user *User) {
 	n.User = user
 	n.require(nestedUserFieldUser)
@@ -256,11 +288,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetTags sets the Tags field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetTags(tags []string) {
 	u.Tags = tags
 	u.require(userFieldTags)

--- a/seed/go-sdk/query-parameters/user.go
+++ b/seed/go-sdk/query-parameters/user.go
@@ -7,7 +7,25 @@ import (
 	fmt "fmt"
 	uuid "github.com/google/uuid"
 	internal "github.com/query-parameters/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	getUsersRequestFieldLimit            = big.NewInt(1 << 0)
+	getUsersRequestFieldId               = big.NewInt(1 << 1)
+	getUsersRequestFieldDate             = big.NewInt(1 << 2)
+	getUsersRequestFieldDeadline         = big.NewInt(1 << 3)
+	getUsersRequestFieldBytes            = big.NewInt(1 << 4)
+	getUsersRequestFieldUser             = big.NewInt(1 << 5)
+	getUsersRequestFieldUserList         = big.NewInt(1 << 6)
+	getUsersRequestFieldOptionalDeadline = big.NewInt(1 << 7)
+	getUsersRequestFieldKeyValue         = big.NewInt(1 << 8)
+	getUsersRequestFieldOptionalString   = big.NewInt(1 << 9)
+	getUsersRequestFieldNestedUser       = big.NewInt(1 << 10)
+	getUsersRequestFieldOptionalUser     = big.NewInt(1 << 11)
+	getUsersRequestFieldExcludeUser      = big.NewInt(1 << 12)
+	getUsersRequestFieldFilter           = big.NewInt(1 << 13)
 )
 
 type GetUsersRequest struct {
@@ -25,11 +43,99 @@ type GetUsersRequest struct {
 	OptionalUser     *User             `json:"-" url:"optionalUser,omitempty"`
 	ExcludeUser      []*User           `json:"-" url:"excludeUser"`
 	Filter           []string          `json:"-" url:"filter"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (g *GetUsersRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetUsersRequest) SetLimit(limit int) {
+	g.Limit = limit
+	g.require(getUsersRequestFieldLimit)
+}
+
+func (g *GetUsersRequest) SetId(id uuid.UUID) {
+	g.Id = id
+	g.require(getUsersRequestFieldId)
+}
+
+func (g *GetUsersRequest) SetDate(date time.Time) {
+	g.Date = date
+	g.require(getUsersRequestFieldDate)
+}
+
+func (g *GetUsersRequest) SetDeadline(deadline time.Time) {
+	g.Deadline = deadline
+	g.require(getUsersRequestFieldDeadline)
+}
+
+func (g *GetUsersRequest) SetBytes(bytes []byte) {
+	g.Bytes = bytes
+	g.require(getUsersRequestFieldBytes)
+}
+
+func (g *GetUsersRequest) SetUser(user *User) {
+	g.User = user
+	g.require(getUsersRequestFieldUser)
+}
+
+func (g *GetUsersRequest) SetUserList(userList []*User) {
+	g.UserList = userList
+	g.require(getUsersRequestFieldUserList)
+}
+
+func (g *GetUsersRequest) SetOptionalDeadline(optionalDeadline *time.Time) {
+	g.OptionalDeadline = optionalDeadline
+	g.require(getUsersRequestFieldOptionalDeadline)
+}
+
+func (g *GetUsersRequest) SetKeyValue(keyValue map[string]string) {
+	g.KeyValue = keyValue
+	g.require(getUsersRequestFieldKeyValue)
+}
+
+func (g *GetUsersRequest) SetOptionalString(optionalString *string) {
+	g.OptionalString = optionalString
+	g.require(getUsersRequestFieldOptionalString)
+}
+
+func (g *GetUsersRequest) SetNestedUser(nestedUser *NestedUser) {
+	g.NestedUser = nestedUser
+	g.require(getUsersRequestFieldNestedUser)
+}
+
+func (g *GetUsersRequest) SetOptionalUser(optionalUser *User) {
+	g.OptionalUser = optionalUser
+	g.require(getUsersRequestFieldOptionalUser)
+}
+
+func (g *GetUsersRequest) SetExcludeUser(excludeUser []*User) {
+	g.ExcludeUser = excludeUser
+	g.require(getUsersRequestFieldExcludeUser)
+}
+
+func (g *GetUsersRequest) SetFilter(filter []string) {
+	g.Filter = filter
+	g.require(getUsersRequestFieldFilter)
+}
+
+var (
+	nestedUserFieldName = big.NewInt(1 << 0)
+	nestedUserFieldUser = big.NewInt(1 << 1)
+)
 
 type NestedUser struct {
 	Name string `json:"name" url:"name"`
 	User *User  `json:"user" url:"user"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -53,6 +159,23 @@ func (n *NestedUser) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
 }
 
+func (n *NestedUser) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NestedUser) SetName(name string) {
+	n.Name = name
+	n.require(nestedUserFieldName)
+}
+
+func (n *NestedUser) SetUser(user *User) {
+	n.User = user
+	n.require(nestedUserFieldUser)
+}
+
 func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	type unmarshaler NestedUser
 	var value unmarshaler
@@ -69,6 +192,17 @@ func (n *NestedUser) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NestedUser) MarshalJSON() ([]byte, error) {
+	type embed NestedUser
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NestedUser) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -81,9 +215,17 @@ func (n *NestedUser) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	userFieldName = big.NewInt(1 << 0)
+	userFieldTags = big.NewInt(1 << 1)
+)
+
 type User struct {
 	Name string   `json:"name" url:"name"`
 	Tags []string `json:"tags" url:"tags"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -107,6 +249,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetTags(tags []string) {
+	u.Tags = tags
+	u.require(userFieldTags)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -121,6 +280,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/response-property/internal/explicit_fields.go
+++ b/seed/go-sdk/response-property/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/response-property/internal/explicit_fields_test.go
+++ b/seed/go-sdk/response-property/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/response-property/service.go
+++ b/seed/go-sdk/response-property/service.go
@@ -43,6 +43,8 @@ func (s *StringResponse) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StringResponse) SetData(data string) {
 	s.Data = data
 	s.require(stringResponseFieldData)
@@ -119,6 +121,8 @@ func (w *WithMetadata) require(field *big.Int) {
 	w.explicitFields.Or(w.explicitFields, field)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (w *WithMetadata) SetMetadata(metadata map[string]string) {
 	w.Metadata = metadata
 	w.require(withMetadataFieldMetadata)
@@ -204,11 +208,15 @@ func (m *Movie) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetId(id string) {
 	m.Id = id
 	m.require(movieFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Movie) SetName(name string) {
 	m.Name = name
 	m.require(movieFieldName)
@@ -305,16 +313,22 @@ func (r *Response) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetMetadata sets the Metadata field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetMetadata(metadata map[string]string) {
 	r.Metadata = metadata
 	r.require(responseFieldMetadata)
 }
 
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetDocs(docs string) {
 	r.Docs = docs
 	r.require(responseFieldDocs)
 }
 
+// SetData sets the Data field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Response) SetData(data *Movie) {
 	r.Data = data
 	r.require(responseFieldData)
@@ -391,6 +405,8 @@ func (w *WithDocs) require(field *big.Int) {
 	w.explicitFields.Or(w.explicitFields, field)
 }
 
+// SetDocs sets the Docs field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (w *WithDocs) SetDocs(docs string) {
 	w.Docs = docs
 	w.require(withDocsFieldDocs)

--- a/seed/go-sdk/response-property/service.go
+++ b/seed/go-sdk/response-property/service.go
@@ -6,12 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/response-property/fern/internal"
+	big "math/big"
 )
 
 type OptionalStringResponse = *StringResponse
 
+var (
+	stringResponseFieldData = big.NewInt(1 << 0)
+)
+
 type StringResponse struct {
 	Data string `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -26,6 +34,18 @@ func (s *StringResponse) GetData() string {
 
 func (s *StringResponse) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
+}
+
+func (s *StringResponse) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StringResponse) SetData(data string) {
+	s.Data = data
+	s.require(stringResponseFieldData)
 }
 
 func (s *StringResponse) UnmarshalJSON(data []byte) error {
@@ -44,6 +64,17 @@ func (s *StringResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *StringResponse) MarshalJSON() ([]byte, error) {
+	type embed StringResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *StringResponse) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -56,8 +87,15 @@ func (s *StringResponse) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	withMetadataFieldMetadata = big.NewInt(1 << 0)
+)
+
 type WithMetadata struct {
 	Metadata map[string]string `json:"metadata" url:"metadata"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -72,6 +110,18 @@ func (w *WithMetadata) GetMetadata() map[string]string {
 
 func (w *WithMetadata) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
+}
+
+func (w *WithMetadata) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+func (w *WithMetadata) SetMetadata(metadata map[string]string) {
+	w.Metadata = metadata
+	w.require(withMetadataFieldMetadata)
 }
 
 func (w *WithMetadata) UnmarshalJSON(data []byte) error {
@@ -90,6 +140,17 @@ func (w *WithMetadata) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (w *WithMetadata) MarshalJSON() ([]byte, error) {
+	type embed WithMetadata
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (w *WithMetadata) String() string {
 	if len(w.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(w.rawJSON); err == nil {
@@ -102,9 +163,17 @@ func (w *WithMetadata) String() string {
 	return fmt.Sprintf("%#v", w)
 }
 
+var (
+	movieFieldId   = big.NewInt(1 << 0)
+	movieFieldName = big.NewInt(1 << 1)
+)
+
 type Movie struct {
 	Id   string `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -128,6 +197,23 @@ func (m *Movie) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Movie) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Movie) SetId(id string) {
+	m.Id = id
+	m.require(movieFieldId)
+}
+
+func (m *Movie) SetName(name string) {
+	m.Name = name
+	m.require(movieFieldName)
+}
+
 func (m *Movie) UnmarshalJSON(data []byte) error {
 	type unmarshaler Movie
 	var value unmarshaler
@@ -144,6 +230,17 @@ func (m *Movie) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *Movie) MarshalJSON() ([]byte, error) {
+	type embed Movie
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *Movie) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -158,10 +255,19 @@ func (m *Movie) String() string {
 
 type OptionalWithDocs = *WithDocs
 
+var (
+	responseFieldMetadata = big.NewInt(1 << 0)
+	responseFieldDocs     = big.NewInt(1 << 1)
+	responseFieldData     = big.NewInt(1 << 2)
+)
+
 type Response struct {
 	Metadata map[string]string `json:"metadata" url:"metadata"`
 	Docs     string            `json:"docs" url:"docs"`
 	Data     *Movie            `json:"data" url:"data"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -192,6 +298,28 @@ func (r *Response) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *Response) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *Response) SetMetadata(metadata map[string]string) {
+	r.Metadata = metadata
+	r.require(responseFieldMetadata)
+}
+
+func (r *Response) SetDocs(docs string) {
+	r.Docs = docs
+	r.require(responseFieldDocs)
+}
+
+func (r *Response) SetData(data *Movie) {
+	r.Data = data
+	r.require(responseFieldData)
+}
+
 func (r *Response) UnmarshalJSON(data []byte) error {
 	type unmarshaler Response
 	var value unmarshaler
@@ -208,6 +336,17 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *Response) MarshalJSON() ([]byte, error) {
+	type embed Response
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *Response) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -220,8 +359,15 @@ func (r *Response) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	withDocsFieldDocs = big.NewInt(1 << 0)
+)
+
 type WithDocs struct {
 	Docs string `json:"docs" url:"docs"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -238,6 +384,18 @@ func (w *WithDocs) GetExtraProperties() map[string]interface{} {
 	return w.extraProperties
 }
 
+func (w *WithDocs) require(field *big.Int) {
+	if w.explicitFields == nil {
+		w.explicitFields = big.NewInt(0)
+	}
+	w.explicitFields.Or(w.explicitFields, field)
+}
+
+func (w *WithDocs) SetDocs(docs string) {
+	w.Docs = docs
+	w.require(withDocsFieldDocs)
+}
+
 func (w *WithDocs) UnmarshalJSON(data []byte) error {
 	type unmarshaler WithDocs
 	var value unmarshaler
@@ -252,6 +410,17 @@ func (w *WithDocs) UnmarshalJSON(data []byte) error {
 	w.extraProperties = extraProperties
 	w.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (w *WithDocs) MarshalJSON() ([]byte, error) {
+	type embed WithDocs
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*w),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, w.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (w *WithDocs) String() string {

--- a/seed/go-sdk/server-sent-event-examples/completions.go
+++ b/seed/go-sdk/server-sent-event-examples/completions.go
@@ -27,6 +27,8 @@ func (s *StreamCompletionRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamCompletionRequest) SetQuery(query string) {
 	s.Query = query
 	s.require(streamCompletionRequestFieldQuery)
@@ -73,11 +75,15 @@ func (s *StreamedCompletion) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamedCompletion) SetDelta(delta string) {
 	s.Delta = delta
 	s.require(streamedCompletionFieldDelta)
 }
 
+// SetTokens sets the Tokens field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamedCompletion) SetTokens(tokens *int) {
 	s.Tokens = tokens
 	s.require(streamedCompletionFieldTokens)

--- a/seed/go-sdk/server-sent-event-examples/completions.go
+++ b/seed/go-sdk/server-sent-event-examples/completions.go
@@ -6,15 +6,43 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/server-sent-event-examples/fern/internal"
+	big "math/big"
+)
+
+var (
+	streamCompletionRequestFieldQuery = big.NewInt(1 << 0)
 )
 
 type StreamCompletionRequest struct {
 	Query string `json:"query" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *StreamCompletionRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StreamCompletionRequest) SetQuery(query string) {
+	s.Query = query
+	s.require(streamCompletionRequestFieldQuery)
+}
+
+var (
+	streamedCompletionFieldDelta  = big.NewInt(1 << 0)
+	streamedCompletionFieldTokens = big.NewInt(1 << 1)
+)
 
 type StreamedCompletion struct {
 	Delta  string `json:"delta" url:"delta"`
 	Tokens *int   `json:"tokens,omitempty" url:"tokens,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -38,6 +66,23 @@ func (s *StreamedCompletion) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StreamedCompletion) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StreamedCompletion) SetDelta(delta string) {
+	s.Delta = delta
+	s.require(streamedCompletionFieldDelta)
+}
+
+func (s *StreamedCompletion) SetTokens(tokens *int) {
+	s.Tokens = tokens
+	s.require(streamedCompletionFieldTokens)
+}
+
 func (s *StreamedCompletion) UnmarshalJSON(data []byte) error {
 	type unmarshaler StreamedCompletion
 	var value unmarshaler
@@ -52,6 +97,17 @@ func (s *StreamedCompletion) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StreamedCompletion) MarshalJSON() ([]byte, error) {
+	type embed StreamedCompletion
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StreamedCompletion) String() string {

--- a/seed/go-sdk/server-sent-event-examples/internal/explicit_fields.go
+++ b/seed/go-sdk/server-sent-event-examples/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/server-sent-event-examples/internal/explicit_fields_test.go
+++ b/seed/go-sdk/server-sent-event-examples/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/server-sent-events/completions.go
+++ b/seed/go-sdk/server-sent-events/completions.go
@@ -27,6 +27,8 @@ func (s *StreamCompletionRequest) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetQuery sets the Query field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamCompletionRequest) SetQuery(query string) {
 	s.Query = query
 	s.require(streamCompletionRequestFieldQuery)
@@ -73,11 +75,15 @@ func (s *StreamedCompletion) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamedCompletion) SetDelta(delta string) {
 	s.Delta = delta
 	s.require(streamedCompletionFieldDelta)
 }
 
+// SetTokens sets the Tokens field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamedCompletion) SetTokens(tokens *int) {
 	s.Tokens = tokens
 	s.require(streamedCompletionFieldTokens)

--- a/seed/go-sdk/server-sent-events/completions.go
+++ b/seed/go-sdk/server-sent-events/completions.go
@@ -6,15 +6,43 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/server-sent-events/fern/internal"
+	big "math/big"
+)
+
+var (
+	streamCompletionRequestFieldQuery = big.NewInt(1 << 0)
 )
 
 type StreamCompletionRequest struct {
 	Query string `json:"query" url:"-"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
+
+func (s *StreamCompletionRequest) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StreamCompletionRequest) SetQuery(query string) {
+	s.Query = query
+	s.require(streamCompletionRequestFieldQuery)
+}
+
+var (
+	streamedCompletionFieldDelta  = big.NewInt(1 << 0)
+	streamedCompletionFieldTokens = big.NewInt(1 << 1)
+)
 
 type StreamedCompletion struct {
 	Delta  string `json:"delta" url:"delta"`
 	Tokens *int   `json:"tokens,omitempty" url:"tokens,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -38,6 +66,23 @@ func (s *StreamedCompletion) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *StreamedCompletion) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *StreamedCompletion) SetDelta(delta string) {
+	s.Delta = delta
+	s.require(streamedCompletionFieldDelta)
+}
+
+func (s *StreamedCompletion) SetTokens(tokens *int) {
+	s.Tokens = tokens
+	s.require(streamedCompletionFieldTokens)
+}
+
 func (s *StreamedCompletion) UnmarshalJSON(data []byte) error {
 	type unmarshaler StreamedCompletion
 	var value unmarshaler
@@ -52,6 +97,17 @@ func (s *StreamedCompletion) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *StreamedCompletion) MarshalJSON() ([]byte, error) {
+	type embed StreamedCompletion
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *StreamedCompletion) String() string {

--- a/seed/go-sdk/server-sent-events/internal/explicit_fields.go
+++ b/seed/go-sdk/server-sent-events/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/server-sent-events/internal/explicit_fields_test.go
+++ b/seed/go-sdk/server-sent-events/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/simple-api/internal/explicit_fields.go
+++ b/seed/go-sdk/simple-api/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/simple-api/internal/explicit_fields_test.go
+++ b/seed/go-sdk/simple-api/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/simple-api/user.go
+++ b/seed/go-sdk/simple-api/user.go
@@ -59,16 +59,22 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id string) {
 	u.Id = id
 	u.require(userFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)
 }
 
+// SetEmail sets the Email field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetEmail(email string) {
 	u.Email = email
 	u.require(userFieldEmail)

--- a/seed/go-sdk/simple-api/user.go
+++ b/seed/go-sdk/simple-api/user.go
@@ -6,12 +6,22 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/simple-api/fern/internal"
+	big "math/big"
+)
+
+var (
+	userFieldId    = big.NewInt(1 << 0)
+	userFieldName  = big.NewInt(1 << 1)
+	userFieldEmail = big.NewInt(1 << 2)
 )
 
 type User struct {
 	Id    string `json:"id" url:"id"`
 	Name  string `json:"name" url:"name"`
 	Email string `json:"email" url:"email"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -42,6 +52,28 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetId(id string) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
+func (u *User) SetEmail(email string) {
+	u.Email = email
+	u.require(userFieldEmail)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -56,6 +88,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/simple-fhir/internal/explicit_fields.go
+++ b/seed/go-sdk/simple-fhir/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/simple-fhir/internal/explicit_fields_test.go
+++ b/seed/go-sdk/simple-fhir/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/simple-fhir/types.go
+++ b/seed/go-sdk/simple-fhir/types.go
@@ -91,31 +91,43 @@ func (a *Account) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Account) SetId(id string) {
 	a.Id = id
 	a.require(accountFieldId)
 }
 
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Account) SetRelatedResources(relatedResources []*ResourceList) {
 	a.RelatedResources = relatedResources
 	a.require(accountFieldRelatedResources)
 }
 
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Account) SetMemo(memo *Memo) {
 	a.Memo = memo
 	a.require(accountFieldMemo)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Account) SetName(name string) {
 	a.Name = name
 	a.require(accountFieldName)
 }
 
+// SetPatient sets the Patient field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Account) SetPatient(patient *Patient) {
 	a.Patient = patient
 	a.require(accountFieldPatient)
 }
 
+// SetPractitioner sets the Practitioner field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *Account) SetPractitioner(practitioner *Practitioner) {
 	a.Practitioner = practitioner
 	a.require(accountFieldPractitioner)
@@ -221,16 +233,22 @@ func (b *BaseResource) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BaseResource) SetId(id string) {
 	b.Id = id
 	b.require(baseResourceFieldId)
 }
 
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BaseResource) SetRelatedResources(relatedResources []*ResourceList) {
 	b.RelatedResources = relatedResources
 	b.require(baseResourceFieldRelatedResources)
 }
 
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *BaseResource) SetMemo(memo *Memo) {
 	b.Memo = memo
 	b.require(baseResourceFieldMemo)
@@ -316,11 +334,15 @@ func (m *Memo) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetDescription sets the Description field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Memo) SetDescription(description string) {
 	m.Description = description
 	m.require(memoFieldDescription)
 }
 
+// SetAccount sets the Account field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *Memo) SetAccount(account *Account) {
 	m.Account = account
 	m.require(memoFieldAccount)
@@ -438,26 +460,36 @@ func (p *Patient) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Patient) SetId(id string) {
 	p.Id = id
 	p.require(patientFieldId)
 }
 
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Patient) SetRelatedResources(relatedResources []*ResourceList) {
 	p.RelatedResources = relatedResources
 	p.require(patientFieldRelatedResources)
 }
 
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Patient) SetMemo(memo *Memo) {
 	p.Memo = memo
 	p.require(patientFieldMemo)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Patient) SetName(name string) {
 	p.Name = name
 	p.require(patientFieldName)
 }
 
+// SetScripts sets the Scripts field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Patient) SetScripts(scripts []*Script) {
 	p.Scripts = scripts
 	p.require(patientFieldScripts)
@@ -577,21 +609,29 @@ func (p *Practitioner) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Practitioner) SetId(id string) {
 	p.Id = id
 	p.require(practitionerFieldId)
 }
 
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Practitioner) SetRelatedResources(relatedResources []*ResourceList) {
 	p.RelatedResources = relatedResources
 	p.require(practitionerFieldRelatedResources)
 }
 
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Practitioner) SetMemo(memo *Memo) {
 	p.Memo = memo
 	p.require(practitionerFieldMemo)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *Practitioner) SetName(name string) {
 	p.Name = name
 	p.require(practitionerFieldName)
@@ -815,21 +855,29 @@ func (s *Script) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *Script) SetId(id string) {
 	s.Id = id
 	s.require(scriptFieldId)
 }
 
+// SetRelatedResources sets the RelatedResources field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *Script) SetRelatedResources(relatedResources []*ResourceList) {
 	s.RelatedResources = relatedResources
 	s.require(scriptFieldRelatedResources)
 }
 
+// SetMemo sets the Memo field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *Script) SetMemo(memo *Memo) {
 	s.Memo = memo
 	s.require(scriptFieldMemo)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *Script) SetName(name string) {
 	s.Name = name
 	s.require(scriptFieldName)

--- a/seed/go-sdk/simple-fhir/types.go
+++ b/seed/go-sdk/simple-fhir/types.go
@@ -6,6 +6,16 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/simple-fhir/fern/internal"
+	big "math/big"
+)
+
+var (
+	accountFieldId               = big.NewInt(1 << 0)
+	accountFieldRelatedResources = big.NewInt(1 << 1)
+	accountFieldMemo             = big.NewInt(1 << 2)
+	accountFieldName             = big.NewInt(1 << 3)
+	accountFieldPatient          = big.NewInt(1 << 4)
+	accountFieldPractitioner     = big.NewInt(1 << 5)
 )
 
 type Account struct {
@@ -15,7 +25,10 @@ type Account struct {
 	Name             string          `json:"name" url:"name"`
 	Patient          *Patient        `json:"patient,omitempty" url:"patient,omitempty"`
 	Practitioner     *Practitioner   `json:"practitioner,omitempty" url:"practitioner,omitempty"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -71,6 +84,43 @@ func (a *Account) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *Account) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *Account) SetId(id string) {
+	a.Id = id
+	a.require(accountFieldId)
+}
+
+func (a *Account) SetRelatedResources(relatedResources []*ResourceList) {
+	a.RelatedResources = relatedResources
+	a.require(accountFieldRelatedResources)
+}
+
+func (a *Account) SetMemo(memo *Memo) {
+	a.Memo = memo
+	a.require(accountFieldMemo)
+}
+
+func (a *Account) SetName(name string) {
+	a.Name = name
+	a.require(accountFieldName)
+}
+
+func (a *Account) SetPatient(patient *Patient) {
+	a.Patient = patient
+	a.require(accountFieldPatient)
+}
+
+func (a *Account) SetPractitioner(practitioner *Practitioner) {
+	a.Practitioner = practitioner
+	a.require(accountFieldPractitioner)
+}
+
 func (a *Account) UnmarshalJSON(data []byte) error {
 	type embed Account
 	var unmarshaler = struct {
@@ -105,7 +155,8 @@ func (a *Account) MarshalJSON() ([]byte, error) {
 		embed:        embed(*a),
 		ResourceType: "Account",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *Account) String() string {
@@ -120,10 +171,19 @@ func (a *Account) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	baseResourceFieldId               = big.NewInt(1 << 0)
+	baseResourceFieldRelatedResources = big.NewInt(1 << 1)
+	baseResourceFieldMemo             = big.NewInt(1 << 2)
+)
+
 type BaseResource struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -154,6 +214,28 @@ func (b *BaseResource) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
 }
 
+func (b *BaseResource) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *BaseResource) SetId(id string) {
+	b.Id = id
+	b.require(baseResourceFieldId)
+}
+
+func (b *BaseResource) SetRelatedResources(relatedResources []*ResourceList) {
+	b.RelatedResources = relatedResources
+	b.require(baseResourceFieldRelatedResources)
+}
+
+func (b *BaseResource) SetMemo(memo *Memo) {
+	b.Memo = memo
+	b.require(baseResourceFieldMemo)
+}
+
 func (b *BaseResource) UnmarshalJSON(data []byte) error {
 	type unmarshaler BaseResource
 	var value unmarshaler
@@ -170,6 +252,17 @@ func (b *BaseResource) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (b *BaseResource) MarshalJSON() ([]byte, error) {
+	type embed BaseResource
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (b *BaseResource) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -182,9 +275,17 @@ func (b *BaseResource) String() string {
 	return fmt.Sprintf("%#v", b)
 }
 
+var (
+	memoFieldDescription = big.NewInt(1 << 0)
+	memoFieldAccount     = big.NewInt(1 << 1)
+)
+
 type Memo struct {
 	Description string   `json:"description" url:"description"`
 	Account     *Account `json:"account,omitempty" url:"account,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -208,6 +309,23 @@ func (m *Memo) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *Memo) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *Memo) SetDescription(description string) {
+	m.Description = description
+	m.require(memoFieldDescription)
+}
+
+func (m *Memo) SetAccount(account *Account) {
+	m.Account = account
+	m.require(memoFieldAccount)
+}
+
 func (m *Memo) UnmarshalJSON(data []byte) error {
 	type unmarshaler Memo
 	var value unmarshaler
@@ -224,6 +342,17 @@ func (m *Memo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *Memo) MarshalJSON() ([]byte, error) {
+	type embed Memo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *Memo) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -236,13 +365,24 @@ func (m *Memo) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	patientFieldId               = big.NewInt(1 << 0)
+	patientFieldRelatedResources = big.NewInt(1 << 1)
+	patientFieldMemo             = big.NewInt(1 << 2)
+	patientFieldName             = big.NewInt(1 << 3)
+	patientFieldScripts          = big.NewInt(1 << 4)
+)
+
 type Patient struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
 	Name             string          `json:"name" url:"name"`
 	Scripts          []*Script       `json:"scripts" url:"scripts"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -291,6 +431,38 @@ func (p *Patient) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Patient) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *Patient) SetId(id string) {
+	p.Id = id
+	p.require(patientFieldId)
+}
+
+func (p *Patient) SetRelatedResources(relatedResources []*ResourceList) {
+	p.RelatedResources = relatedResources
+	p.require(patientFieldRelatedResources)
+}
+
+func (p *Patient) SetMemo(memo *Memo) {
+	p.Memo = memo
+	p.require(patientFieldMemo)
+}
+
+func (p *Patient) SetName(name string) {
+	p.Name = name
+	p.require(patientFieldName)
+}
+
+func (p *Patient) SetScripts(scripts []*Script) {
+	p.Scripts = scripts
+	p.require(patientFieldScripts)
+}
+
 func (p *Patient) UnmarshalJSON(data []byte) error {
 	type embed Patient
 	var unmarshaler = struct {
@@ -325,7 +497,8 @@ func (p *Patient) MarshalJSON() ([]byte, error) {
 		embed:        embed(*p),
 		ResourceType: "Patient",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *Patient) String() string {
@@ -340,12 +513,22 @@ func (p *Patient) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	practitionerFieldId               = big.NewInt(1 << 0)
+	practitionerFieldRelatedResources = big.NewInt(1 << 1)
+	practitionerFieldMemo             = big.NewInt(1 << 2)
+	practitionerFieldName             = big.NewInt(1 << 3)
+)
+
 type Practitioner struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
 	Name             string          `json:"name" url:"name"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -387,6 +570,33 @@ func (p *Practitioner) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
+func (p *Practitioner) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *Practitioner) SetId(id string) {
+	p.Id = id
+	p.require(practitionerFieldId)
+}
+
+func (p *Practitioner) SetRelatedResources(relatedResources []*ResourceList) {
+	p.RelatedResources = relatedResources
+	p.require(practitionerFieldRelatedResources)
+}
+
+func (p *Practitioner) SetMemo(memo *Memo) {
+	p.Memo = memo
+	p.require(practitionerFieldMemo)
+}
+
+func (p *Practitioner) SetName(name string) {
+	p.Name = name
+	p.require(practitionerFieldName)
+}
+
 func (p *Practitioner) UnmarshalJSON(data []byte) error {
 	type embed Practitioner
 	var unmarshaler = struct {
@@ -421,7 +631,8 @@ func (p *Practitioner) MarshalJSON() ([]byte, error) {
 		embed:        embed(*p),
 		ResourceType: "Practitioner",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (p *Practitioner) String() string {
@@ -540,12 +751,22 @@ func (r *ResourceList) Accept(visitor ResourceListVisitor) error {
 	return fmt.Errorf("type %T does not include a non-empty union type", r)
 }
 
+var (
+	scriptFieldId               = big.NewInt(1 << 0)
+	scriptFieldRelatedResources = big.NewInt(1 << 1)
+	scriptFieldMemo             = big.NewInt(1 << 2)
+	scriptFieldName             = big.NewInt(1 << 3)
+)
+
 type Script struct {
 	Id               string          `json:"id" url:"id"`
 	RelatedResources []*ResourceList `json:"related_resources" url:"related_resources"`
 	Memo             *Memo           `json:"memo" url:"memo"`
 	Name             string          `json:"name" url:"name"`
-	resourceType     string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
+	resourceType   string
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -587,6 +808,33 @@ func (s *Script) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *Script) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *Script) SetId(id string) {
+	s.Id = id
+	s.require(scriptFieldId)
+}
+
+func (s *Script) SetRelatedResources(relatedResources []*ResourceList) {
+	s.RelatedResources = relatedResources
+	s.require(scriptFieldRelatedResources)
+}
+
+func (s *Script) SetMemo(memo *Memo) {
+	s.Memo = memo
+	s.require(scriptFieldMemo)
+}
+
+func (s *Script) SetName(name string) {
+	s.Name = name
+	s.require(scriptFieldName)
+}
+
 func (s *Script) UnmarshalJSON(data []byte) error {
 	type embed Script
 	var unmarshaler = struct {
@@ -621,7 +869,8 @@ func (s *Script) MarshalJSON() ([]byte, error) {
 		embed:        embed(*s),
 		ResourceType: "Script",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *Script) String() string {

--- a/seed/go-sdk/single-url-environment-default/internal/explicit_fields.go
+++ b/seed/go-sdk/single-url-environment-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/single-url-environment-default/internal/explicit_fields_test.go
+++ b/seed/go-sdk/single-url-environment-default/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/single-url-environment-no-default/internal/explicit_fields.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/single-url-environment-no-default/internal/explicit_fields_test.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/streaming/dummy.go
+++ b/seed/go-sdk/streaming/dummy.go
@@ -32,6 +32,8 @@ func (g *Generateequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetNumEvents sets the NumEvents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *Generateequest) SetNumEvents(numEvents int) {
 	g.NumEvents = numEvents
 	g.require(generateequestFieldNumEvents)
@@ -84,6 +86,8 @@ func (g *GenerateStreamRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetNumEvents sets the NumEvents field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GenerateStreamRequest) SetNumEvents(numEvents int) {
 	g.NumEvents = numEvents
 	g.require(generateStreamRequestFieldNumEvents)
@@ -154,11 +158,15 @@ func (s *StreamResponse) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamResponse) SetId(id string) {
 	s.Id = id
 	s.require(streamResponseFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *StreamResponse) SetName(name *string) {
 	s.Name = name
 	s.require(streamResponseFieldName)

--- a/seed/go-sdk/streaming/internal/explicit_fields.go
+++ b/seed/go-sdk/streaming/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/streaming/internal/explicit_fields_test.go
+++ b/seed/go-sdk/streaming/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/union.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/union.go
@@ -348,11 +348,15 @@ func (n *NamedMetadata) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NamedMetadata) SetName(name string) {
 	n.Name = name
 	n.require(namedMetadataFieldName)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NamedMetadata) SetValue(value map[string]interface{}) {
 	n.Value = value
 	n.require(namedMetadataFieldValue)
@@ -704,6 +708,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetUnion sets the Union field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetUnion(union *MetadataUnion) {
 	r.Union = union
 	r.require(requestFieldUnion)
@@ -780,6 +786,8 @@ func (t *TypeWithOptionalUnion) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetMyUnion sets the MyUnion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TypeWithOptionalUnion) SetMyUnion(myUnion *MyUnion) {
 	t.MyUnion = myUnion
 	t.require(typeWithOptionalUnionFieldMyUnion)

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/explicit_fields.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/explicit_fields_test.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/undiscriminated-unions/v0/union.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/union.go
@@ -384,11 +384,15 @@ func (n *NamedMetadata) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NamedMetadata) SetName(name string) {
 	n.Name = name
 	n.require(namedMetadataFieldName)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NamedMetadata) SetValue(value map[string]interface{}) {
 	n.Value = value
 	n.require(namedMetadataFieldValue)
@@ -780,6 +784,8 @@ func (r *Request) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetUnion sets the Union field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *Request) SetUnion(union *MetadataUnion) {
 	r.Union = union
 	r.require(requestFieldUnion)
@@ -856,6 +862,8 @@ func (t *TypeWithOptionalUnion) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetMyUnion sets the MyUnion field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TypeWithOptionalUnion) SetMyUnion(myUnion *MyUnion) {
 	t.MyUnion = myUnion
 	t.require(typeWithOptionalUnionFieldMyUnion)

--- a/seed/go-sdk/unions/no-custom-config/bigunion.go
+++ b/seed/go-sdk/unions/no-custom-config/bigunion.go
@@ -42,6 +42,8 @@ func (a *ActiveDiamond) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *ActiveDiamond) SetValue(value string) {
 	a.Value = value
 	a.require(activeDiamondFieldValue)
@@ -118,6 +120,8 @@ func (a *AttractiveScript) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *AttractiveScript) SetValue(value string) {
 	a.Value = value
 	a.require(attractiveScriptFieldValue)
@@ -989,6 +993,8 @@ func (c *CircularCard) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CircularCard) SetValue(value string) {
 	c.Value = value
 	c.require(circularCardFieldValue)
@@ -1065,6 +1071,8 @@ func (c *ColorfulCover) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ColorfulCover) SetValue(value string) {
 	c.Value = value
 	c.require(colorfulCoverFieldValue)
@@ -1141,6 +1149,8 @@ func (d *DiligentDeal) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DiligentDeal) SetValue(value string) {
 	d.Value = value
 	d.require(diligentDealFieldValue)
@@ -1217,6 +1227,8 @@ func (d *DisloyalValue) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DisloyalValue) SetValue(value string) {
 	d.Value = value
 	d.require(disloyalValueFieldValue)
@@ -1293,6 +1305,8 @@ func (d *DistinctFailure) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DistinctFailure) SetValue(value string) {
 	d.Value = value
 	d.require(distinctFailureFieldValue)
@@ -1369,6 +1383,8 @@ func (f *FalseMirror) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FalseMirror) SetValue(value string) {
 	f.Value = value
 	f.require(falseMirrorFieldValue)
@@ -1445,6 +1461,8 @@ func (f *FrozenSleep) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FrozenSleep) SetValue(value string) {
 	f.Value = value
 	f.require(frozenSleepFieldValue)
@@ -1521,6 +1539,8 @@ func (g *GaseousRoad) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GaseousRoad) SetValue(value string) {
 	g.Value = value
 	g.require(gaseousRoadFieldValue)
@@ -1597,6 +1617,8 @@ func (g *GruesomeCoach) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GruesomeCoach) SetValue(value string) {
 	g.Value = value
 	g.require(gruesomeCoachFieldValue)
@@ -1673,6 +1695,8 @@ func (h *HarmoniousPlay) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HarmoniousPlay) SetValue(value string) {
 	h.Value = value
 	h.require(harmoniousPlayFieldValue)
@@ -1749,6 +1773,8 @@ func (h *HastyPain) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HastyPain) SetValue(value string) {
 	h.Value = value
 	h.require(hastyPainFieldValue)
@@ -1825,6 +1851,8 @@ func (h *HoarseMouse) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HoarseMouse) SetValue(value string) {
 	h.Value = value
 	h.require(hoarseMouseFieldValue)
@@ -1901,6 +1929,8 @@ func (j *JumboEnd) require(field *big.Int) {
 	j.explicitFields.Or(j.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JumboEnd) SetValue(value string) {
 	j.Value = value
 	j.require(jumboEndFieldValue)
@@ -1977,6 +2007,8 @@ func (l *LimpingStep) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *LimpingStep) SetValue(value string) {
 	l.Value = value
 	l.require(limpingStepFieldValue)
@@ -2053,6 +2085,8 @@ func (m *MistySnow) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MistySnow) SetValue(value string) {
 	m.Value = value
 	m.require(mistySnowFieldValue)
@@ -2129,6 +2163,8 @@ func (n *NormalSweet) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NormalSweet) SetValue(value string) {
 	n.Value = value
 	n.require(normalSweetFieldValue)
@@ -2205,6 +2241,8 @@ func (p *PopularLimit) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PopularLimit) SetValue(value string) {
 	p.Value = value
 	p.require(popularLimitFieldValue)
@@ -2281,6 +2319,8 @@ func (p *PotableBad) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PotableBad) SetValue(value string) {
 	p.Value = value
 	p.require(potableBadFieldValue)
@@ -2357,6 +2397,8 @@ func (p *PracticalPrinciple) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PracticalPrinciple) SetValue(value string) {
 	p.Value = value
 	p.require(practicalPrincipleFieldValue)
@@ -2433,6 +2475,8 @@ func (p *PrimaryBlock) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PrimaryBlock) SetValue(value string) {
 	p.Value = value
 	p.require(primaryBlockFieldValue)
@@ -2509,6 +2553,8 @@ func (r *RotatingRatio) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RotatingRatio) SetValue(value string) {
 	r.Value = value
 	r.require(rotatingRatioFieldValue)
@@ -2585,6 +2631,8 @@ func (t *ThankfulFactor) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *ThankfulFactor) SetValue(value string) {
 	t.Value = value
 	t.require(thankfulFactorFieldValue)
@@ -2661,6 +2709,8 @@ func (t *TotalWork) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TotalWork) SetValue(value string) {
 	t.Value = value
 	t.require(totalWorkFieldValue)
@@ -2737,6 +2787,8 @@ func (t *TriangularRepair) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TriangularRepair) SetValue(value string) {
 	t.Value = value
 	t.require(triangularRepairFieldValue)
@@ -2813,6 +2865,8 @@ func (u *UniqueStress) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UniqueStress) SetValue(value string) {
 	u.Value = value
 	u.require(uniqueStressFieldValue)
@@ -2889,6 +2943,8 @@ func (u *UnwillingSmoke) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UnwillingSmoke) SetValue(value string) {
 	u.Value = value
 	u.require(unwillingSmokeFieldValue)
@@ -2965,6 +3021,8 @@ func (v *VibrantExcitement) require(field *big.Int) {
 	v.explicitFields.Or(v.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (v *VibrantExcitement) SetValue(value string) {
 	v.Value = value
 	v.require(vibrantExcitementFieldValue)

--- a/seed/go-sdk/unions/no-custom-config/bigunion.go
+++ b/seed/go-sdk/unions/no-custom-config/bigunion.go
@@ -6,11 +6,19 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/unions/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	activeDiamondFieldValue = big.NewInt(1 << 0)
 )
 
 type ActiveDiamond struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -25,6 +33,18 @@ func (a *ActiveDiamond) GetValue() string {
 
 func (a *ActiveDiamond) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
+}
+
+func (a *ActiveDiamond) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *ActiveDiamond) SetValue(value string) {
+	a.Value = value
+	a.require(activeDiamondFieldValue)
 }
 
 func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
@@ -43,6 +63,17 @@ func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *ActiveDiamond) MarshalJSON() ([]byte, error) {
+	type embed ActiveDiamond
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *ActiveDiamond) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -55,8 +86,15 @@ func (a *ActiveDiamond) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	attractiveScriptFieldValue = big.NewInt(1 << 0)
+)
+
 type AttractiveScript struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -73,6 +111,18 @@ func (a *AttractiveScript) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *AttractiveScript) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *AttractiveScript) SetValue(value string) {
+	a.Value = value
+	a.require(attractiveScriptFieldValue)
+}
+
 func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	type unmarshaler AttractiveScript
 	var value unmarshaler
@@ -87,6 +137,17 @@ func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	a.extraProperties = extraProperties
 	a.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (a *AttractiveScript) MarshalJSON() ([]byte, error) {
+	type embed AttractiveScript
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *AttractiveScript) String() string {
@@ -896,8 +957,15 @@ func (b *BigUnion) validate() error {
 	return nil
 }
 
+var (
+	circularCardFieldValue = big.NewInt(1 << 0)
+)
+
 type CircularCard struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -912,6 +980,18 @@ func (c *CircularCard) GetValue() string {
 
 func (c *CircularCard) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CircularCard) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CircularCard) SetValue(value string) {
+	c.Value = value
+	c.require(circularCardFieldValue)
 }
 
 func (c *CircularCard) UnmarshalJSON(data []byte) error {
@@ -930,6 +1010,17 @@ func (c *CircularCard) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CircularCard) MarshalJSON() ([]byte, error) {
+	type embed CircularCard
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CircularCard) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -942,8 +1033,15 @@ func (c *CircularCard) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	colorfulCoverFieldValue = big.NewInt(1 << 0)
+)
+
 type ColorfulCover struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -958,6 +1056,18 @@ func (c *ColorfulCover) GetValue() string {
 
 func (c *ColorfulCover) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *ColorfulCover) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *ColorfulCover) SetValue(value string) {
+	c.Value = value
+	c.require(colorfulCoverFieldValue)
 }
 
 func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
@@ -976,6 +1086,17 @@ func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *ColorfulCover) MarshalJSON() ([]byte, error) {
+	type embed ColorfulCover
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *ColorfulCover) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -988,8 +1109,15 @@ func (c *ColorfulCover) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	diligentDealFieldValue = big.NewInt(1 << 0)
+)
+
 type DiligentDeal struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1004,6 +1132,18 @@ func (d *DiligentDeal) GetValue() string {
 
 func (d *DiligentDeal) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DiligentDeal) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DiligentDeal) SetValue(value string) {
+	d.Value = value
+	d.require(diligentDealFieldValue)
 }
 
 func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
@@ -1022,6 +1162,17 @@ func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DiligentDeal) MarshalJSON() ([]byte, error) {
+	type embed DiligentDeal
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DiligentDeal) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1034,8 +1185,15 @@ func (d *DiligentDeal) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	disloyalValueFieldValue = big.NewInt(1 << 0)
+)
+
 type DisloyalValue struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1050,6 +1208,18 @@ func (d *DisloyalValue) GetValue() string {
 
 func (d *DisloyalValue) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DisloyalValue) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DisloyalValue) SetValue(value string) {
+	d.Value = value
+	d.require(disloyalValueFieldValue)
 }
 
 func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
@@ -1068,6 +1238,17 @@ func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DisloyalValue) MarshalJSON() ([]byte, error) {
+	type embed DisloyalValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DisloyalValue) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1080,8 +1261,15 @@ func (d *DisloyalValue) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	distinctFailureFieldValue = big.NewInt(1 << 0)
+)
+
 type DistinctFailure struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1096,6 +1284,18 @@ func (d *DistinctFailure) GetValue() string {
 
 func (d *DistinctFailure) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DistinctFailure) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DistinctFailure) SetValue(value string) {
+	d.Value = value
+	d.require(distinctFailureFieldValue)
 }
 
 func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
@@ -1114,6 +1314,17 @@ func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DistinctFailure) MarshalJSON() ([]byte, error) {
+	type embed DistinctFailure
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DistinctFailure) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1126,8 +1337,15 @@ func (d *DistinctFailure) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	falseMirrorFieldValue = big.NewInt(1 << 0)
+)
+
 type FalseMirror struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1142,6 +1360,18 @@ func (f *FalseMirror) GetValue() string {
 
 func (f *FalseMirror) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FalseMirror) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FalseMirror) SetValue(value string) {
+	f.Value = value
+	f.require(falseMirrorFieldValue)
 }
 
 func (f *FalseMirror) UnmarshalJSON(data []byte) error {
@@ -1160,6 +1390,17 @@ func (f *FalseMirror) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FalseMirror) MarshalJSON() ([]byte, error) {
+	type embed FalseMirror
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FalseMirror) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1172,8 +1413,15 @@ func (f *FalseMirror) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	frozenSleepFieldValue = big.NewInt(1 << 0)
+)
+
 type FrozenSleep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1188,6 +1436,18 @@ func (f *FrozenSleep) GetValue() string {
 
 func (f *FrozenSleep) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FrozenSleep) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FrozenSleep) SetValue(value string) {
+	f.Value = value
+	f.require(frozenSleepFieldValue)
 }
 
 func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
@@ -1206,6 +1466,17 @@ func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FrozenSleep) MarshalJSON() ([]byte, error) {
+	type embed FrozenSleep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FrozenSleep) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1218,8 +1489,15 @@ func (f *FrozenSleep) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	gaseousRoadFieldValue = big.NewInt(1 << 0)
+)
+
 type GaseousRoad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1234,6 +1512,18 @@ func (g *GaseousRoad) GetValue() string {
 
 func (g *GaseousRoad) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GaseousRoad) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GaseousRoad) SetValue(value string) {
+	g.Value = value
+	g.require(gaseousRoadFieldValue)
 }
 
 func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
@@ -1252,6 +1542,17 @@ func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GaseousRoad) MarshalJSON() ([]byte, error) {
+	type embed GaseousRoad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GaseousRoad) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1264,8 +1565,15 @@ func (g *GaseousRoad) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	gruesomeCoachFieldValue = big.NewInt(1 << 0)
+)
+
 type GruesomeCoach struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1280,6 +1588,18 @@ func (g *GruesomeCoach) GetValue() string {
 
 func (g *GruesomeCoach) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GruesomeCoach) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GruesomeCoach) SetValue(value string) {
+	g.Value = value
+	g.require(gruesomeCoachFieldValue)
 }
 
 func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
@@ -1298,6 +1618,17 @@ func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GruesomeCoach) MarshalJSON() ([]byte, error) {
+	type embed GruesomeCoach
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GruesomeCoach) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1310,8 +1641,15 @@ func (g *GruesomeCoach) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	harmoniousPlayFieldValue = big.NewInt(1 << 0)
+)
+
 type HarmoniousPlay struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1326,6 +1664,18 @@ func (h *HarmoniousPlay) GetValue() string {
 
 func (h *HarmoniousPlay) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HarmoniousPlay) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HarmoniousPlay) SetValue(value string) {
+	h.Value = value
+	h.require(harmoniousPlayFieldValue)
 }
 
 func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
@@ -1344,6 +1694,17 @@ func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HarmoniousPlay) MarshalJSON() ([]byte, error) {
+	type embed HarmoniousPlay
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HarmoniousPlay) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1356,8 +1717,15 @@ func (h *HarmoniousPlay) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hastyPainFieldValue = big.NewInt(1 << 0)
+)
+
 type HastyPain struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1372,6 +1740,18 @@ func (h *HastyPain) GetValue() string {
 
 func (h *HastyPain) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HastyPain) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HastyPain) SetValue(value string) {
+	h.Value = value
+	h.require(hastyPainFieldValue)
 }
 
 func (h *HastyPain) UnmarshalJSON(data []byte) error {
@@ -1390,6 +1770,17 @@ func (h *HastyPain) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HastyPain) MarshalJSON() ([]byte, error) {
+	type embed HastyPain
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HastyPain) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1402,8 +1793,15 @@ func (h *HastyPain) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hoarseMouseFieldValue = big.NewInt(1 << 0)
+)
+
 type HoarseMouse struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1418,6 +1816,18 @@ func (h *HoarseMouse) GetValue() string {
 
 func (h *HoarseMouse) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HoarseMouse) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HoarseMouse) SetValue(value string) {
+	h.Value = value
+	h.require(hoarseMouseFieldValue)
 }
 
 func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
@@ -1436,6 +1846,17 @@ func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HoarseMouse) MarshalJSON() ([]byte, error) {
+	type embed HoarseMouse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HoarseMouse) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1448,8 +1869,15 @@ func (h *HoarseMouse) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	jumboEndFieldValue = big.NewInt(1 << 0)
+)
+
 type JumboEnd struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1464,6 +1892,18 @@ func (j *JumboEnd) GetValue() string {
 
 func (j *JumboEnd) GetExtraProperties() map[string]interface{} {
 	return j.extraProperties
+}
+
+func (j *JumboEnd) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+func (j *JumboEnd) SetValue(value string) {
+	j.Value = value
+	j.require(jumboEndFieldValue)
 }
 
 func (j *JumboEnd) UnmarshalJSON(data []byte) error {
@@ -1482,6 +1922,17 @@ func (j *JumboEnd) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (j *JumboEnd) MarshalJSON() ([]byte, error) {
+	type embed JumboEnd
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*j),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, j.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (j *JumboEnd) String() string {
 	if len(j.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(j.rawJSON); err == nil {
@@ -1494,8 +1945,15 @@ func (j *JumboEnd) String() string {
 	return fmt.Sprintf("%#v", j)
 }
 
+var (
+	limpingStepFieldValue = big.NewInt(1 << 0)
+)
+
 type LimpingStep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1510,6 +1968,18 @@ func (l *LimpingStep) GetValue() string {
 
 func (l *LimpingStep) GetExtraProperties() map[string]interface{} {
 	return l.extraProperties
+}
+
+func (l *LimpingStep) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *LimpingStep) SetValue(value string) {
+	l.Value = value
+	l.require(limpingStepFieldValue)
 }
 
 func (l *LimpingStep) UnmarshalJSON(data []byte) error {
@@ -1528,6 +1998,17 @@ func (l *LimpingStep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *LimpingStep) MarshalJSON() ([]byte, error) {
+	type embed LimpingStep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *LimpingStep) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -1540,8 +2021,15 @@ func (l *LimpingStep) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	mistySnowFieldValue = big.NewInt(1 << 0)
+)
+
 type MistySnow struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1556,6 +2044,18 @@ func (m *MistySnow) GetValue() string {
 
 func (m *MistySnow) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MistySnow) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MistySnow) SetValue(value string) {
+	m.Value = value
+	m.require(mistySnowFieldValue)
 }
 
 func (m *MistySnow) UnmarshalJSON(data []byte) error {
@@ -1574,6 +2074,17 @@ func (m *MistySnow) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MistySnow) MarshalJSON() ([]byte, error) {
+	type embed MistySnow
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MistySnow) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -1586,8 +2097,15 @@ func (m *MistySnow) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	normalSweetFieldValue = big.NewInt(1 << 0)
+)
+
 type NormalSweet struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1602,6 +2120,18 @@ func (n *NormalSweet) GetValue() string {
 
 func (n *NormalSweet) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
+}
+
+func (n *NormalSweet) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NormalSweet) SetValue(value string) {
+	n.Value = value
+	n.require(normalSweetFieldValue)
 }
 
 func (n *NormalSweet) UnmarshalJSON(data []byte) error {
@@ -1620,6 +2150,17 @@ func (n *NormalSweet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NormalSweet) MarshalJSON() ([]byte, error) {
+	type embed NormalSweet
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NormalSweet) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1632,8 +2173,15 @@ func (n *NormalSweet) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	popularLimitFieldValue = big.NewInt(1 << 0)
+)
+
 type PopularLimit struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1648,6 +2196,18 @@ func (p *PopularLimit) GetValue() string {
 
 func (p *PopularLimit) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PopularLimit) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PopularLimit) SetValue(value string) {
+	p.Value = value
+	p.require(popularLimitFieldValue)
 }
 
 func (p *PopularLimit) UnmarshalJSON(data []byte) error {
@@ -1666,6 +2226,17 @@ func (p *PopularLimit) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PopularLimit) MarshalJSON() ([]byte, error) {
+	type embed PopularLimit
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PopularLimit) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1678,8 +2249,15 @@ func (p *PopularLimit) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	potableBadFieldValue = big.NewInt(1 << 0)
+)
+
 type PotableBad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1694,6 +2272,18 @@ func (p *PotableBad) GetValue() string {
 
 func (p *PotableBad) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PotableBad) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PotableBad) SetValue(value string) {
+	p.Value = value
+	p.require(potableBadFieldValue)
 }
 
 func (p *PotableBad) UnmarshalJSON(data []byte) error {
@@ -1712,6 +2302,17 @@ func (p *PotableBad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PotableBad) MarshalJSON() ([]byte, error) {
+	type embed PotableBad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PotableBad) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1724,8 +2325,15 @@ func (p *PotableBad) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	practicalPrincipleFieldValue = big.NewInt(1 << 0)
+)
+
 type PracticalPrinciple struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1740,6 +2348,18 @@ func (p *PracticalPrinciple) GetValue() string {
 
 func (p *PracticalPrinciple) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PracticalPrinciple) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PracticalPrinciple) SetValue(value string) {
+	p.Value = value
+	p.require(practicalPrincipleFieldValue)
 }
 
 func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
@@ -1758,6 +2378,17 @@ func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PracticalPrinciple) MarshalJSON() ([]byte, error) {
+	type embed PracticalPrinciple
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PracticalPrinciple) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1770,8 +2401,15 @@ func (p *PracticalPrinciple) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	primaryBlockFieldValue = big.NewInt(1 << 0)
+)
+
 type PrimaryBlock struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1786,6 +2424,18 @@ func (p *PrimaryBlock) GetValue() string {
 
 func (p *PrimaryBlock) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PrimaryBlock) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PrimaryBlock) SetValue(value string) {
+	p.Value = value
+	p.require(primaryBlockFieldValue)
 }
 
 func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
@@ -1804,6 +2454,17 @@ func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PrimaryBlock) MarshalJSON() ([]byte, error) {
+	type embed PrimaryBlock
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PrimaryBlock) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1816,8 +2477,15 @@ func (p *PrimaryBlock) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	rotatingRatioFieldValue = big.NewInt(1 << 0)
+)
+
 type RotatingRatio struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1832,6 +2500,18 @@ func (r *RotatingRatio) GetValue() string {
 
 func (r *RotatingRatio) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RotatingRatio) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RotatingRatio) SetValue(value string) {
+	r.Value = value
+	r.require(rotatingRatioFieldValue)
 }
 
 func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
@@ -1850,6 +2530,17 @@ func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RotatingRatio) MarshalJSON() ([]byte, error) {
+	type embed RotatingRatio
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RotatingRatio) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1862,8 +2553,15 @@ func (r *RotatingRatio) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	thankfulFactorFieldValue = big.NewInt(1 << 0)
+)
+
 type ThankfulFactor struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1878,6 +2576,18 @@ func (t *ThankfulFactor) GetValue() string {
 
 func (t *ThankfulFactor) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *ThankfulFactor) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *ThankfulFactor) SetValue(value string) {
+	t.Value = value
+	t.require(thankfulFactorFieldValue)
 }
 
 func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
@@ -1896,6 +2606,17 @@ func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *ThankfulFactor) MarshalJSON() ([]byte, error) {
+	type embed ThankfulFactor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *ThankfulFactor) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -1908,8 +2629,15 @@ func (t *ThankfulFactor) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	totalWorkFieldValue = big.NewInt(1 << 0)
+)
+
 type TotalWork struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1924,6 +2652,18 @@ func (t *TotalWork) GetValue() string {
 
 func (t *TotalWork) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TotalWork) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TotalWork) SetValue(value string) {
+	t.Value = value
+	t.require(totalWorkFieldValue)
 }
 
 func (t *TotalWork) UnmarshalJSON(data []byte) error {
@@ -1942,6 +2682,17 @@ func (t *TotalWork) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TotalWork) MarshalJSON() ([]byte, error) {
+	type embed TotalWork
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TotalWork) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -1954,8 +2705,15 @@ func (t *TotalWork) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	triangularRepairFieldValue = big.NewInt(1 << 0)
+)
+
 type TriangularRepair struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1970,6 +2728,18 @@ func (t *TriangularRepair) GetValue() string {
 
 func (t *TriangularRepair) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TriangularRepair) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TriangularRepair) SetValue(value string) {
+	t.Value = value
+	t.require(triangularRepairFieldValue)
 }
 
 func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
@@ -1988,6 +2758,17 @@ func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TriangularRepair) MarshalJSON() ([]byte, error) {
+	type embed TriangularRepair
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TriangularRepair) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2000,8 +2781,15 @@ func (t *TriangularRepair) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	uniqueStressFieldValue = big.NewInt(1 << 0)
+)
+
 type UniqueStress struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2016,6 +2804,18 @@ func (u *UniqueStress) GetValue() string {
 
 func (u *UniqueStress) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UniqueStress) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UniqueStress) SetValue(value string) {
+	u.Value = value
+	u.require(uniqueStressFieldValue)
 }
 
 func (u *UniqueStress) UnmarshalJSON(data []byte) error {
@@ -2034,6 +2834,17 @@ func (u *UniqueStress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UniqueStress) MarshalJSON() ([]byte, error) {
+	type embed UniqueStress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UniqueStress) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -2046,8 +2857,15 @@ func (u *UniqueStress) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	unwillingSmokeFieldValue = big.NewInt(1 << 0)
+)
+
 type UnwillingSmoke struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2062,6 +2880,18 @@ func (u *UnwillingSmoke) GetValue() string {
 
 func (u *UnwillingSmoke) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UnwillingSmoke) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UnwillingSmoke) SetValue(value string) {
+	u.Value = value
+	u.require(unwillingSmokeFieldValue)
 }
 
 func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
@@ -2080,6 +2910,17 @@ func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UnwillingSmoke) MarshalJSON() ([]byte, error) {
+	type embed UnwillingSmoke
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UnwillingSmoke) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -2092,8 +2933,15 @@ func (u *UnwillingSmoke) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	vibrantExcitementFieldValue = big.NewInt(1 << 0)
+)
+
 type VibrantExcitement struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2110,6 +2958,18 @@ func (v *VibrantExcitement) GetExtraProperties() map[string]interface{} {
 	return v.extraProperties
 }
 
+func (v *VibrantExcitement) require(field *big.Int) {
+	if v.explicitFields == nil {
+		v.explicitFields = big.NewInt(0)
+	}
+	v.explicitFields.Or(v.explicitFields, field)
+}
+
+func (v *VibrantExcitement) SetValue(value string) {
+	v.Value = value
+	v.require(vibrantExcitementFieldValue)
+}
+
 func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	type unmarshaler VibrantExcitement
 	var value unmarshaler
@@ -2124,6 +2984,17 @@ func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	v.extraProperties = extraProperties
 	v.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (v *VibrantExcitement) MarshalJSON() ([]byte, error) {
+	type embed VibrantExcitement
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*v),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, v.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (v *VibrantExcitement) String() string {

--- a/seed/go-sdk/unions/no-custom-config/internal/explicit_fields.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/unions/no-custom-config/internal/explicit_fields_test.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/unions/no-custom-config/types.go
+++ b/seed/go-sdk/unions/no-custom-config/types.go
@@ -42,6 +42,8 @@ func (b *Bar) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *Bar) SetName(name string) {
 	b.Name = name
 	b.require(barFieldName)
@@ -118,6 +120,8 @@ func (f *Foo) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *Foo) SetName(name string) {
 	f.Name = name
 	f.require(fooFieldName)
@@ -203,11 +207,15 @@ func (f *FooExtended) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooExtended) SetName(name string) {
 	f.Name = name
 	f.require(fooExtendedFieldName)
 }
 
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooExtended) SetAge(age int) {
 	f.Age = age
 	f.require(fooExtendedFieldAge)

--- a/seed/go-sdk/unions/no-custom-config/union.go
+++ b/seed/go-sdk/unions/no-custom-config/union.go
@@ -41,6 +41,8 @@ func (c *Circle) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetRadius sets the Radius field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Circle) SetRadius(radius float64) {
 	c.Radius = radius
 	c.require(circleFieldRadius)
@@ -117,6 +119,8 @@ func (g *GetShapeRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetShapeRequest) SetId(id string) {
 	g.Id = id
 	g.require(getShapeRequestFieldId)
@@ -320,6 +324,8 @@ func (s *Square) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *Square) SetLength(length float64) {
 	s.Length = length
 	s.require(squareFieldLength)

--- a/seed/go-sdk/unions/no-custom-config/union.go
+++ b/seed/go-sdk/unions/no-custom-config/union.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/unions/fern/internal"
+	big "math/big"
+)
+
+var (
+	circleFieldRadius = big.NewInt(1 << 0)
 )
 
 type Circle struct {
 	Radius float64 `json:"radius" url:"radius"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -24,6 +32,18 @@ func (c *Circle) GetRadius() float64 {
 
 func (c *Circle) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *Circle) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Circle) SetRadius(radius float64) {
+	c.Radius = radius
+	c.require(circleFieldRadius)
 }
 
 func (c *Circle) UnmarshalJSON(data []byte) error {
@@ -42,6 +62,17 @@ func (c *Circle) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Circle) MarshalJSON() ([]byte, error) {
+	type embed Circle
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Circle) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -54,8 +85,15 @@ func (c *Circle) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	getShapeRequestFieldId = big.NewInt(1 << 0)
+)
+
 type GetShapeRequest struct {
 	Id string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -72,6 +110,18 @@ func (g *GetShapeRequest) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
 }
 
+func (g *GetShapeRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetShapeRequest) SetId(id string) {
+	g.Id = id
+	g.require(getShapeRequestFieldId)
+}
+
 func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler GetShapeRequest
 	var value unmarshaler
@@ -86,6 +136,17 @@ func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	g.extraProperties = extraProperties
 	g.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (g *GetShapeRequest) MarshalJSON() ([]byte, error) {
+	type embed GetShapeRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (g *GetShapeRequest) String() string {
@@ -227,8 +288,15 @@ func (s *Shape) validate() error {
 	return nil
 }
 
+var (
+	squareFieldLength = big.NewInt(1 << 0)
+)
+
 type Square struct {
 	Length float64 `json:"length" url:"length"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -245,6 +313,18 @@ func (s *Square) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *Square) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *Square) SetLength(length float64) {
+	s.Length = length
+	s.require(squareFieldLength)
+}
+
 func (s *Square) UnmarshalJSON(data []byte) error {
 	type unmarshaler Square
 	var value unmarshaler
@@ -259,6 +339,17 @@ func (s *Square) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *Square) MarshalJSON() ([]byte, error) {
+	type embed Square
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *Square) String() string {

--- a/seed/go-sdk/unions/package-name/bigunion.go
+++ b/seed/go-sdk/unions/package-name/bigunion.go
@@ -42,6 +42,8 @@ func (a *ActiveDiamond) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *ActiveDiamond) SetValue(value string) {
 	a.Value = value
 	a.require(activeDiamondFieldValue)
@@ -118,6 +120,8 @@ func (a *AttractiveScript) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *AttractiveScript) SetValue(value string) {
 	a.Value = value
 	a.require(attractiveScriptFieldValue)
@@ -989,6 +993,8 @@ func (c *CircularCard) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CircularCard) SetValue(value string) {
 	c.Value = value
 	c.require(circularCardFieldValue)
@@ -1065,6 +1071,8 @@ func (c *ColorfulCover) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ColorfulCover) SetValue(value string) {
 	c.Value = value
 	c.require(colorfulCoverFieldValue)
@@ -1141,6 +1149,8 @@ func (d *DiligentDeal) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DiligentDeal) SetValue(value string) {
 	d.Value = value
 	d.require(diligentDealFieldValue)
@@ -1217,6 +1227,8 @@ func (d *DisloyalValue) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DisloyalValue) SetValue(value string) {
 	d.Value = value
 	d.require(disloyalValueFieldValue)
@@ -1293,6 +1305,8 @@ func (d *DistinctFailure) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DistinctFailure) SetValue(value string) {
 	d.Value = value
 	d.require(distinctFailureFieldValue)
@@ -1369,6 +1383,8 @@ func (f *FalseMirror) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FalseMirror) SetValue(value string) {
 	f.Value = value
 	f.require(falseMirrorFieldValue)
@@ -1445,6 +1461,8 @@ func (f *FrozenSleep) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FrozenSleep) SetValue(value string) {
 	f.Value = value
 	f.require(frozenSleepFieldValue)
@@ -1521,6 +1539,8 @@ func (g *GaseousRoad) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GaseousRoad) SetValue(value string) {
 	g.Value = value
 	g.require(gaseousRoadFieldValue)
@@ -1597,6 +1617,8 @@ func (g *GruesomeCoach) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GruesomeCoach) SetValue(value string) {
 	g.Value = value
 	g.require(gruesomeCoachFieldValue)
@@ -1673,6 +1695,8 @@ func (h *HarmoniousPlay) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HarmoniousPlay) SetValue(value string) {
 	h.Value = value
 	h.require(harmoniousPlayFieldValue)
@@ -1749,6 +1773,8 @@ func (h *HastyPain) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HastyPain) SetValue(value string) {
 	h.Value = value
 	h.require(hastyPainFieldValue)
@@ -1825,6 +1851,8 @@ func (h *HoarseMouse) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HoarseMouse) SetValue(value string) {
 	h.Value = value
 	h.require(hoarseMouseFieldValue)
@@ -1901,6 +1929,8 @@ func (j *JumboEnd) require(field *big.Int) {
 	j.explicitFields.Or(j.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JumboEnd) SetValue(value string) {
 	j.Value = value
 	j.require(jumboEndFieldValue)
@@ -1977,6 +2007,8 @@ func (l *LimpingStep) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *LimpingStep) SetValue(value string) {
 	l.Value = value
 	l.require(limpingStepFieldValue)
@@ -2053,6 +2085,8 @@ func (m *MistySnow) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MistySnow) SetValue(value string) {
 	m.Value = value
 	m.require(mistySnowFieldValue)
@@ -2129,6 +2163,8 @@ func (n *NormalSweet) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NormalSweet) SetValue(value string) {
 	n.Value = value
 	n.require(normalSweetFieldValue)
@@ -2205,6 +2241,8 @@ func (p *PopularLimit) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PopularLimit) SetValue(value string) {
 	p.Value = value
 	p.require(popularLimitFieldValue)
@@ -2281,6 +2319,8 @@ func (p *PotableBad) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PotableBad) SetValue(value string) {
 	p.Value = value
 	p.require(potableBadFieldValue)
@@ -2357,6 +2397,8 @@ func (p *PracticalPrinciple) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PracticalPrinciple) SetValue(value string) {
 	p.Value = value
 	p.require(practicalPrincipleFieldValue)
@@ -2433,6 +2475,8 @@ func (p *PrimaryBlock) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PrimaryBlock) SetValue(value string) {
 	p.Value = value
 	p.require(primaryBlockFieldValue)
@@ -2509,6 +2553,8 @@ func (r *RotatingRatio) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RotatingRatio) SetValue(value string) {
 	r.Value = value
 	r.require(rotatingRatioFieldValue)
@@ -2585,6 +2631,8 @@ func (t *ThankfulFactor) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *ThankfulFactor) SetValue(value string) {
 	t.Value = value
 	t.require(thankfulFactorFieldValue)
@@ -2661,6 +2709,8 @@ func (t *TotalWork) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TotalWork) SetValue(value string) {
 	t.Value = value
 	t.require(totalWorkFieldValue)
@@ -2737,6 +2787,8 @@ func (t *TriangularRepair) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TriangularRepair) SetValue(value string) {
 	t.Value = value
 	t.require(triangularRepairFieldValue)
@@ -2813,6 +2865,8 @@ func (u *UniqueStress) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UniqueStress) SetValue(value string) {
 	u.Value = value
 	u.require(uniqueStressFieldValue)
@@ -2889,6 +2943,8 @@ func (u *UnwillingSmoke) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UnwillingSmoke) SetValue(value string) {
 	u.Value = value
 	u.require(unwillingSmokeFieldValue)
@@ -2965,6 +3021,8 @@ func (v *VibrantExcitement) require(field *big.Int) {
 	v.explicitFields.Or(v.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (v *VibrantExcitement) SetValue(value string) {
 	v.Value = value
 	v.require(vibrantExcitementFieldValue)

--- a/seed/go-sdk/unions/package-name/bigunion.go
+++ b/seed/go-sdk/unions/package-name/bigunion.go
@@ -6,11 +6,19 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/fern-api/unions-go/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	activeDiamondFieldValue = big.NewInt(1 << 0)
 )
 
 type ActiveDiamond struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -25,6 +33,18 @@ func (a *ActiveDiamond) GetValue() string {
 
 func (a *ActiveDiamond) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
+}
+
+func (a *ActiveDiamond) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *ActiveDiamond) SetValue(value string) {
+	a.Value = value
+	a.require(activeDiamondFieldValue)
 }
 
 func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
@@ -43,6 +63,17 @@ func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *ActiveDiamond) MarshalJSON() ([]byte, error) {
+	type embed ActiveDiamond
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *ActiveDiamond) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -55,8 +86,15 @@ func (a *ActiveDiamond) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	attractiveScriptFieldValue = big.NewInt(1 << 0)
+)
+
 type AttractiveScript struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -73,6 +111,18 @@ func (a *AttractiveScript) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *AttractiveScript) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *AttractiveScript) SetValue(value string) {
+	a.Value = value
+	a.require(attractiveScriptFieldValue)
+}
+
 func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	type unmarshaler AttractiveScript
 	var value unmarshaler
@@ -87,6 +137,17 @@ func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	a.extraProperties = extraProperties
 	a.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (a *AttractiveScript) MarshalJSON() ([]byte, error) {
+	type embed AttractiveScript
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *AttractiveScript) String() string {
@@ -896,8 +957,15 @@ func (b *BigUnion) validate() error {
 	return nil
 }
 
+var (
+	circularCardFieldValue = big.NewInt(1 << 0)
+)
+
 type CircularCard struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -912,6 +980,18 @@ func (c *CircularCard) GetValue() string {
 
 func (c *CircularCard) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CircularCard) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CircularCard) SetValue(value string) {
+	c.Value = value
+	c.require(circularCardFieldValue)
 }
 
 func (c *CircularCard) UnmarshalJSON(data []byte) error {
@@ -930,6 +1010,17 @@ func (c *CircularCard) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CircularCard) MarshalJSON() ([]byte, error) {
+	type embed CircularCard
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CircularCard) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -942,8 +1033,15 @@ func (c *CircularCard) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	colorfulCoverFieldValue = big.NewInt(1 << 0)
+)
+
 type ColorfulCover struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -958,6 +1056,18 @@ func (c *ColorfulCover) GetValue() string {
 
 func (c *ColorfulCover) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *ColorfulCover) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *ColorfulCover) SetValue(value string) {
+	c.Value = value
+	c.require(colorfulCoverFieldValue)
 }
 
 func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
@@ -976,6 +1086,17 @@ func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *ColorfulCover) MarshalJSON() ([]byte, error) {
+	type embed ColorfulCover
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *ColorfulCover) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -988,8 +1109,15 @@ func (c *ColorfulCover) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	diligentDealFieldValue = big.NewInt(1 << 0)
+)
+
 type DiligentDeal struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1004,6 +1132,18 @@ func (d *DiligentDeal) GetValue() string {
 
 func (d *DiligentDeal) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DiligentDeal) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DiligentDeal) SetValue(value string) {
+	d.Value = value
+	d.require(diligentDealFieldValue)
 }
 
 func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
@@ -1022,6 +1162,17 @@ func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DiligentDeal) MarshalJSON() ([]byte, error) {
+	type embed DiligentDeal
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DiligentDeal) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1034,8 +1185,15 @@ func (d *DiligentDeal) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	disloyalValueFieldValue = big.NewInt(1 << 0)
+)
+
 type DisloyalValue struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1050,6 +1208,18 @@ func (d *DisloyalValue) GetValue() string {
 
 func (d *DisloyalValue) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DisloyalValue) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DisloyalValue) SetValue(value string) {
+	d.Value = value
+	d.require(disloyalValueFieldValue)
 }
 
 func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
@@ -1068,6 +1238,17 @@ func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DisloyalValue) MarshalJSON() ([]byte, error) {
+	type embed DisloyalValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DisloyalValue) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1080,8 +1261,15 @@ func (d *DisloyalValue) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	distinctFailureFieldValue = big.NewInt(1 << 0)
+)
+
 type DistinctFailure struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1096,6 +1284,18 @@ func (d *DistinctFailure) GetValue() string {
 
 func (d *DistinctFailure) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DistinctFailure) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DistinctFailure) SetValue(value string) {
+	d.Value = value
+	d.require(distinctFailureFieldValue)
 }
 
 func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
@@ -1114,6 +1314,17 @@ func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DistinctFailure) MarshalJSON() ([]byte, error) {
+	type embed DistinctFailure
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DistinctFailure) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1126,8 +1337,15 @@ func (d *DistinctFailure) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	falseMirrorFieldValue = big.NewInt(1 << 0)
+)
+
 type FalseMirror struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1142,6 +1360,18 @@ func (f *FalseMirror) GetValue() string {
 
 func (f *FalseMirror) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FalseMirror) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FalseMirror) SetValue(value string) {
+	f.Value = value
+	f.require(falseMirrorFieldValue)
 }
 
 func (f *FalseMirror) UnmarshalJSON(data []byte) error {
@@ -1160,6 +1390,17 @@ func (f *FalseMirror) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FalseMirror) MarshalJSON() ([]byte, error) {
+	type embed FalseMirror
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FalseMirror) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1172,8 +1413,15 @@ func (f *FalseMirror) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	frozenSleepFieldValue = big.NewInt(1 << 0)
+)
+
 type FrozenSleep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1188,6 +1436,18 @@ func (f *FrozenSleep) GetValue() string {
 
 func (f *FrozenSleep) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FrozenSleep) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FrozenSleep) SetValue(value string) {
+	f.Value = value
+	f.require(frozenSleepFieldValue)
 }
 
 func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
@@ -1206,6 +1466,17 @@ func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FrozenSleep) MarshalJSON() ([]byte, error) {
+	type embed FrozenSleep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FrozenSleep) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1218,8 +1489,15 @@ func (f *FrozenSleep) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	gaseousRoadFieldValue = big.NewInt(1 << 0)
+)
+
 type GaseousRoad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1234,6 +1512,18 @@ func (g *GaseousRoad) GetValue() string {
 
 func (g *GaseousRoad) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GaseousRoad) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GaseousRoad) SetValue(value string) {
+	g.Value = value
+	g.require(gaseousRoadFieldValue)
 }
 
 func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
@@ -1252,6 +1542,17 @@ func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GaseousRoad) MarshalJSON() ([]byte, error) {
+	type embed GaseousRoad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GaseousRoad) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1264,8 +1565,15 @@ func (g *GaseousRoad) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	gruesomeCoachFieldValue = big.NewInt(1 << 0)
+)
+
 type GruesomeCoach struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1280,6 +1588,18 @@ func (g *GruesomeCoach) GetValue() string {
 
 func (g *GruesomeCoach) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GruesomeCoach) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GruesomeCoach) SetValue(value string) {
+	g.Value = value
+	g.require(gruesomeCoachFieldValue)
 }
 
 func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
@@ -1298,6 +1618,17 @@ func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GruesomeCoach) MarshalJSON() ([]byte, error) {
+	type embed GruesomeCoach
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GruesomeCoach) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1310,8 +1641,15 @@ func (g *GruesomeCoach) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	harmoniousPlayFieldValue = big.NewInt(1 << 0)
+)
+
 type HarmoniousPlay struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1326,6 +1664,18 @@ func (h *HarmoniousPlay) GetValue() string {
 
 func (h *HarmoniousPlay) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HarmoniousPlay) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HarmoniousPlay) SetValue(value string) {
+	h.Value = value
+	h.require(harmoniousPlayFieldValue)
 }
 
 func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
@@ -1344,6 +1694,17 @@ func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HarmoniousPlay) MarshalJSON() ([]byte, error) {
+	type embed HarmoniousPlay
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HarmoniousPlay) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1356,8 +1717,15 @@ func (h *HarmoniousPlay) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hastyPainFieldValue = big.NewInt(1 << 0)
+)
+
 type HastyPain struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1372,6 +1740,18 @@ func (h *HastyPain) GetValue() string {
 
 func (h *HastyPain) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HastyPain) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HastyPain) SetValue(value string) {
+	h.Value = value
+	h.require(hastyPainFieldValue)
 }
 
 func (h *HastyPain) UnmarshalJSON(data []byte) error {
@@ -1390,6 +1770,17 @@ func (h *HastyPain) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HastyPain) MarshalJSON() ([]byte, error) {
+	type embed HastyPain
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HastyPain) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1402,8 +1793,15 @@ func (h *HastyPain) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hoarseMouseFieldValue = big.NewInt(1 << 0)
+)
+
 type HoarseMouse struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1418,6 +1816,18 @@ func (h *HoarseMouse) GetValue() string {
 
 func (h *HoarseMouse) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HoarseMouse) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HoarseMouse) SetValue(value string) {
+	h.Value = value
+	h.require(hoarseMouseFieldValue)
 }
 
 func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
@@ -1436,6 +1846,17 @@ func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HoarseMouse) MarshalJSON() ([]byte, error) {
+	type embed HoarseMouse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HoarseMouse) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1448,8 +1869,15 @@ func (h *HoarseMouse) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	jumboEndFieldValue = big.NewInt(1 << 0)
+)
+
 type JumboEnd struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1464,6 +1892,18 @@ func (j *JumboEnd) GetValue() string {
 
 func (j *JumboEnd) GetExtraProperties() map[string]interface{} {
 	return j.extraProperties
+}
+
+func (j *JumboEnd) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+func (j *JumboEnd) SetValue(value string) {
+	j.Value = value
+	j.require(jumboEndFieldValue)
 }
 
 func (j *JumboEnd) UnmarshalJSON(data []byte) error {
@@ -1482,6 +1922,17 @@ func (j *JumboEnd) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (j *JumboEnd) MarshalJSON() ([]byte, error) {
+	type embed JumboEnd
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*j),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, j.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (j *JumboEnd) String() string {
 	if len(j.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(j.rawJSON); err == nil {
@@ -1494,8 +1945,15 @@ func (j *JumboEnd) String() string {
 	return fmt.Sprintf("%#v", j)
 }
 
+var (
+	limpingStepFieldValue = big.NewInt(1 << 0)
+)
+
 type LimpingStep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1510,6 +1968,18 @@ func (l *LimpingStep) GetValue() string {
 
 func (l *LimpingStep) GetExtraProperties() map[string]interface{} {
 	return l.extraProperties
+}
+
+func (l *LimpingStep) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *LimpingStep) SetValue(value string) {
+	l.Value = value
+	l.require(limpingStepFieldValue)
 }
 
 func (l *LimpingStep) UnmarshalJSON(data []byte) error {
@@ -1528,6 +1998,17 @@ func (l *LimpingStep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *LimpingStep) MarshalJSON() ([]byte, error) {
+	type embed LimpingStep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *LimpingStep) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -1540,8 +2021,15 @@ func (l *LimpingStep) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	mistySnowFieldValue = big.NewInt(1 << 0)
+)
+
 type MistySnow struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1556,6 +2044,18 @@ func (m *MistySnow) GetValue() string {
 
 func (m *MistySnow) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MistySnow) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MistySnow) SetValue(value string) {
+	m.Value = value
+	m.require(mistySnowFieldValue)
 }
 
 func (m *MistySnow) UnmarshalJSON(data []byte) error {
@@ -1574,6 +2074,17 @@ func (m *MistySnow) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MistySnow) MarshalJSON() ([]byte, error) {
+	type embed MistySnow
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MistySnow) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -1586,8 +2097,15 @@ func (m *MistySnow) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	normalSweetFieldValue = big.NewInt(1 << 0)
+)
+
 type NormalSweet struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1602,6 +2120,18 @@ func (n *NormalSweet) GetValue() string {
 
 func (n *NormalSweet) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
+}
+
+func (n *NormalSweet) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NormalSweet) SetValue(value string) {
+	n.Value = value
+	n.require(normalSweetFieldValue)
 }
 
 func (n *NormalSweet) UnmarshalJSON(data []byte) error {
@@ -1620,6 +2150,17 @@ func (n *NormalSweet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NormalSweet) MarshalJSON() ([]byte, error) {
+	type embed NormalSweet
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NormalSweet) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1632,8 +2173,15 @@ func (n *NormalSweet) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	popularLimitFieldValue = big.NewInt(1 << 0)
+)
+
 type PopularLimit struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1648,6 +2196,18 @@ func (p *PopularLimit) GetValue() string {
 
 func (p *PopularLimit) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PopularLimit) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PopularLimit) SetValue(value string) {
+	p.Value = value
+	p.require(popularLimitFieldValue)
 }
 
 func (p *PopularLimit) UnmarshalJSON(data []byte) error {
@@ -1666,6 +2226,17 @@ func (p *PopularLimit) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PopularLimit) MarshalJSON() ([]byte, error) {
+	type embed PopularLimit
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PopularLimit) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1678,8 +2249,15 @@ func (p *PopularLimit) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	potableBadFieldValue = big.NewInt(1 << 0)
+)
+
 type PotableBad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1694,6 +2272,18 @@ func (p *PotableBad) GetValue() string {
 
 func (p *PotableBad) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PotableBad) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PotableBad) SetValue(value string) {
+	p.Value = value
+	p.require(potableBadFieldValue)
 }
 
 func (p *PotableBad) UnmarshalJSON(data []byte) error {
@@ -1712,6 +2302,17 @@ func (p *PotableBad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PotableBad) MarshalJSON() ([]byte, error) {
+	type embed PotableBad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PotableBad) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1724,8 +2325,15 @@ func (p *PotableBad) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	practicalPrincipleFieldValue = big.NewInt(1 << 0)
+)
+
 type PracticalPrinciple struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1740,6 +2348,18 @@ func (p *PracticalPrinciple) GetValue() string {
 
 func (p *PracticalPrinciple) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PracticalPrinciple) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PracticalPrinciple) SetValue(value string) {
+	p.Value = value
+	p.require(practicalPrincipleFieldValue)
 }
 
 func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
@@ -1758,6 +2378,17 @@ func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PracticalPrinciple) MarshalJSON() ([]byte, error) {
+	type embed PracticalPrinciple
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PracticalPrinciple) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1770,8 +2401,15 @@ func (p *PracticalPrinciple) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	primaryBlockFieldValue = big.NewInt(1 << 0)
+)
+
 type PrimaryBlock struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1786,6 +2424,18 @@ func (p *PrimaryBlock) GetValue() string {
 
 func (p *PrimaryBlock) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PrimaryBlock) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PrimaryBlock) SetValue(value string) {
+	p.Value = value
+	p.require(primaryBlockFieldValue)
 }
 
 func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
@@ -1804,6 +2454,17 @@ func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PrimaryBlock) MarshalJSON() ([]byte, error) {
+	type embed PrimaryBlock
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PrimaryBlock) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1816,8 +2477,15 @@ func (p *PrimaryBlock) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	rotatingRatioFieldValue = big.NewInt(1 << 0)
+)
+
 type RotatingRatio struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1832,6 +2500,18 @@ func (r *RotatingRatio) GetValue() string {
 
 func (r *RotatingRatio) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RotatingRatio) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RotatingRatio) SetValue(value string) {
+	r.Value = value
+	r.require(rotatingRatioFieldValue)
 }
 
 func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
@@ -1850,6 +2530,17 @@ func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RotatingRatio) MarshalJSON() ([]byte, error) {
+	type embed RotatingRatio
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RotatingRatio) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1862,8 +2553,15 @@ func (r *RotatingRatio) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	thankfulFactorFieldValue = big.NewInt(1 << 0)
+)
+
 type ThankfulFactor struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1878,6 +2576,18 @@ func (t *ThankfulFactor) GetValue() string {
 
 func (t *ThankfulFactor) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *ThankfulFactor) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *ThankfulFactor) SetValue(value string) {
+	t.Value = value
+	t.require(thankfulFactorFieldValue)
 }
 
 func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
@@ -1896,6 +2606,17 @@ func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *ThankfulFactor) MarshalJSON() ([]byte, error) {
+	type embed ThankfulFactor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *ThankfulFactor) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -1908,8 +2629,15 @@ func (t *ThankfulFactor) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	totalWorkFieldValue = big.NewInt(1 << 0)
+)
+
 type TotalWork struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1924,6 +2652,18 @@ func (t *TotalWork) GetValue() string {
 
 func (t *TotalWork) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TotalWork) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TotalWork) SetValue(value string) {
+	t.Value = value
+	t.require(totalWorkFieldValue)
 }
 
 func (t *TotalWork) UnmarshalJSON(data []byte) error {
@@ -1942,6 +2682,17 @@ func (t *TotalWork) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TotalWork) MarshalJSON() ([]byte, error) {
+	type embed TotalWork
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TotalWork) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -1954,8 +2705,15 @@ func (t *TotalWork) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	triangularRepairFieldValue = big.NewInt(1 << 0)
+)
+
 type TriangularRepair struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1970,6 +2728,18 @@ func (t *TriangularRepair) GetValue() string {
 
 func (t *TriangularRepair) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TriangularRepair) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TriangularRepair) SetValue(value string) {
+	t.Value = value
+	t.require(triangularRepairFieldValue)
 }
 
 func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
@@ -1988,6 +2758,17 @@ func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TriangularRepair) MarshalJSON() ([]byte, error) {
+	type embed TriangularRepair
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TriangularRepair) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2000,8 +2781,15 @@ func (t *TriangularRepair) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	uniqueStressFieldValue = big.NewInt(1 << 0)
+)
+
 type UniqueStress struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2016,6 +2804,18 @@ func (u *UniqueStress) GetValue() string {
 
 func (u *UniqueStress) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UniqueStress) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UniqueStress) SetValue(value string) {
+	u.Value = value
+	u.require(uniqueStressFieldValue)
 }
 
 func (u *UniqueStress) UnmarshalJSON(data []byte) error {
@@ -2034,6 +2834,17 @@ func (u *UniqueStress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UniqueStress) MarshalJSON() ([]byte, error) {
+	type embed UniqueStress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UniqueStress) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -2046,8 +2857,15 @@ func (u *UniqueStress) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	unwillingSmokeFieldValue = big.NewInt(1 << 0)
+)
+
 type UnwillingSmoke struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2062,6 +2880,18 @@ func (u *UnwillingSmoke) GetValue() string {
 
 func (u *UnwillingSmoke) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UnwillingSmoke) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UnwillingSmoke) SetValue(value string) {
+	u.Value = value
+	u.require(unwillingSmokeFieldValue)
 }
 
 func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
@@ -2080,6 +2910,17 @@ func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UnwillingSmoke) MarshalJSON() ([]byte, error) {
+	type embed UnwillingSmoke
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UnwillingSmoke) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -2092,8 +2933,15 @@ func (u *UnwillingSmoke) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	vibrantExcitementFieldValue = big.NewInt(1 << 0)
+)
+
 type VibrantExcitement struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2110,6 +2958,18 @@ func (v *VibrantExcitement) GetExtraProperties() map[string]interface{} {
 	return v.extraProperties
 }
 
+func (v *VibrantExcitement) require(field *big.Int) {
+	if v.explicitFields == nil {
+		v.explicitFields = big.NewInt(0)
+	}
+	v.explicitFields.Or(v.explicitFields, field)
+}
+
+func (v *VibrantExcitement) SetValue(value string) {
+	v.Value = value
+	v.require(vibrantExcitementFieldValue)
+}
+
 func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	type unmarshaler VibrantExcitement
 	var value unmarshaler
@@ -2124,6 +2984,17 @@ func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	v.extraProperties = extraProperties
 	v.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (v *VibrantExcitement) MarshalJSON() ([]byte, error) {
+	type embed VibrantExcitement
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*v),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, v.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (v *VibrantExcitement) String() string {

--- a/seed/go-sdk/unions/package-name/internal/explicit_fields.go
+++ b/seed/go-sdk/unions/package-name/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/unions/package-name/internal/explicit_fields_test.go
+++ b/seed/go-sdk/unions/package-name/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/unions/package-name/types.go
+++ b/seed/go-sdk/unions/package-name/types.go
@@ -6,11 +6,19 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/fern-api/unions-go/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	barFieldName = big.NewInt(1 << 0)
 )
 
 type Bar struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -25,6 +33,18 @@ func (b *Bar) GetName() string {
 
 func (b *Bar) GetExtraProperties() map[string]interface{} {
 	return b.extraProperties
+}
+
+func (b *Bar) require(field *big.Int) {
+	if b.explicitFields == nil {
+		b.explicitFields = big.NewInt(0)
+	}
+	b.explicitFields.Or(b.explicitFields, field)
+}
+
+func (b *Bar) SetName(name string) {
+	b.Name = name
+	b.require(barFieldName)
 }
 
 func (b *Bar) UnmarshalJSON(data []byte) error {
@@ -43,6 +63,17 @@ func (b *Bar) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (b *Bar) MarshalJSON() ([]byte, error) {
+	type embed Bar
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*b),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, b.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (b *Bar) String() string {
 	if len(b.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(b.rawJSON); err == nil {
@@ -55,8 +86,15 @@ func (b *Bar) String() string {
 	return fmt.Sprintf("%#v", b)
 }
 
+var (
+	fooFieldName = big.NewInt(1 << 0)
+)
+
 type Foo struct {
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -71,6 +109,18 @@ func (f *Foo) GetName() string {
 
 func (f *Foo) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *Foo) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *Foo) SetName(name string) {
+	f.Name = name
+	f.require(fooFieldName)
 }
 
 func (f *Foo) UnmarshalJSON(data []byte) error {
@@ -89,6 +139,17 @@ func (f *Foo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *Foo) MarshalJSON() ([]byte, error) {
+	type embed Foo
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *Foo) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -101,9 +162,17 @@ func (f *Foo) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	fooExtendedFieldName = big.NewInt(1 << 0)
+	fooExtendedFieldAge  = big.NewInt(1 << 1)
+)
+
 type FooExtended struct {
 	Name string `json:"name" url:"name"`
 	Age  int    `json:"age" url:"age"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -127,6 +196,23 @@ func (f *FooExtended) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
 }
 
+func (f *FooExtended) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FooExtended) SetName(name string) {
+	f.Name = name
+	f.require(fooExtendedFieldName)
+}
+
+func (f *FooExtended) SetAge(age int) {
+	f.Age = age
+	f.require(fooExtendedFieldAge)
+}
+
 func (f *FooExtended) UnmarshalJSON(data []byte) error {
 	type unmarshaler FooExtended
 	var value unmarshaler
@@ -141,6 +227,17 @@ func (f *FooExtended) UnmarshalJSON(data []byte) error {
 	f.extraProperties = extraProperties
 	f.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (f *FooExtended) MarshalJSON() ([]byte, error) {
+	type embed FooExtended
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (f *FooExtended) String() string {

--- a/seed/go-sdk/unions/package-name/types.go
+++ b/seed/go-sdk/unions/package-name/types.go
@@ -42,6 +42,8 @@ func (b *Bar) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *Bar) SetName(name string) {
 	b.Name = name
 	b.require(barFieldName)
@@ -118,6 +120,8 @@ func (f *Foo) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *Foo) SetName(name string) {
 	f.Name = name
 	f.require(fooFieldName)
@@ -203,11 +207,15 @@ func (f *FooExtended) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooExtended) SetName(name string) {
 	f.Name = name
 	f.require(fooExtendedFieldName)
 }
 
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooExtended) SetAge(age int) {
 	f.Age = age
 	f.require(fooExtendedFieldAge)

--- a/seed/go-sdk/unions/package-name/union.go
+++ b/seed/go-sdk/unions/package-name/union.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/fern-api/unions-go/internal"
+	big "math/big"
+)
+
+var (
+	circleFieldRadius = big.NewInt(1 << 0)
 )
 
 type Circle struct {
 	Radius float64 `json:"radius" url:"radius"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -24,6 +32,18 @@ func (c *Circle) GetRadius() float64 {
 
 func (c *Circle) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *Circle) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Circle) SetRadius(radius float64) {
+	c.Radius = radius
+	c.require(circleFieldRadius)
 }
 
 func (c *Circle) UnmarshalJSON(data []byte) error {
@@ -42,6 +62,17 @@ func (c *Circle) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Circle) MarshalJSON() ([]byte, error) {
+	type embed Circle
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Circle) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -54,8 +85,15 @@ func (c *Circle) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	getShapeRequestFieldId = big.NewInt(1 << 0)
+)
+
 type GetShapeRequest struct {
 	Id string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -72,6 +110,18 @@ func (g *GetShapeRequest) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
 }
 
+func (g *GetShapeRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetShapeRequest) SetId(id string) {
+	g.Id = id
+	g.require(getShapeRequestFieldId)
+}
+
 func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler GetShapeRequest
 	var value unmarshaler
@@ -86,6 +136,17 @@ func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	g.extraProperties = extraProperties
 	g.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (g *GetShapeRequest) MarshalJSON() ([]byte, error) {
+	type embed GetShapeRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (g *GetShapeRequest) String() string {
@@ -227,8 +288,15 @@ func (s *Shape) validate() error {
 	return nil
 }
 
+var (
+	squareFieldLength = big.NewInt(1 << 0)
+)
+
 type Square struct {
 	Length float64 `json:"length" url:"length"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -245,6 +313,18 @@ func (s *Square) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *Square) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *Square) SetLength(length float64) {
+	s.Length = length
+	s.require(squareFieldLength)
+}
+
 func (s *Square) UnmarshalJSON(data []byte) error {
 	type unmarshaler Square
 	var value unmarshaler
@@ -259,6 +339,17 @@ func (s *Square) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *Square) MarshalJSON() ([]byte, error) {
+	type embed Square
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *Square) String() string {

--- a/seed/go-sdk/unions/package-name/union.go
+++ b/seed/go-sdk/unions/package-name/union.go
@@ -41,6 +41,8 @@ func (c *Circle) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetRadius sets the Radius field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Circle) SetRadius(radius float64) {
 	c.Radius = radius
 	c.require(circleFieldRadius)
@@ -117,6 +119,8 @@ func (g *GetShapeRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetShapeRequest) SetId(id string) {
 	g.Id = id
 	g.require(getShapeRequestFieldId)
@@ -320,6 +324,8 @@ func (s *Square) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *Square) SetLength(length float64) {
 	s.Length = length
 	s.require(squareFieldLength)

--- a/seed/go-sdk/unions/v0/bigunion.go
+++ b/seed/go-sdk/unions/v0/bigunion.go
@@ -42,6 +42,8 @@ func (a *ActiveDiamond) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *ActiveDiamond) SetValue(value string) {
 	a.Value = value
 	a.require(activeDiamondFieldValue)
@@ -118,6 +120,8 @@ func (a *AttractiveScript) require(field *big.Int) {
 	a.explicitFields.Or(a.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (a *AttractiveScript) SetValue(value string) {
 	a.Value = value
 	a.require(attractiveScriptFieldValue)
@@ -1053,6 +1057,8 @@ func (c *CircularCard) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CircularCard) SetValue(value string) {
 	c.Value = value
 	c.require(circularCardFieldValue)
@@ -1129,6 +1135,8 @@ func (c *ColorfulCover) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *ColorfulCover) SetValue(value string) {
 	c.Value = value
 	c.require(colorfulCoverFieldValue)
@@ -1205,6 +1213,8 @@ func (d *DiligentDeal) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DiligentDeal) SetValue(value string) {
 	d.Value = value
 	d.require(diligentDealFieldValue)
@@ -1281,6 +1291,8 @@ func (d *DisloyalValue) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DisloyalValue) SetValue(value string) {
 	d.Value = value
 	d.require(disloyalValueFieldValue)
@@ -1357,6 +1369,8 @@ func (d *DistinctFailure) require(field *big.Int) {
 	d.explicitFields.Or(d.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (d *DistinctFailure) SetValue(value string) {
 	d.Value = value
 	d.require(distinctFailureFieldValue)
@@ -1433,6 +1447,8 @@ func (f *FalseMirror) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FalseMirror) SetValue(value string) {
 	f.Value = value
 	f.require(falseMirrorFieldValue)
@@ -1509,6 +1525,8 @@ func (f *FrozenSleep) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FrozenSleep) SetValue(value string) {
 	f.Value = value
 	f.require(frozenSleepFieldValue)
@@ -1585,6 +1603,8 @@ func (g *GaseousRoad) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GaseousRoad) SetValue(value string) {
 	g.Value = value
 	g.require(gaseousRoadFieldValue)
@@ -1661,6 +1681,8 @@ func (g *GruesomeCoach) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GruesomeCoach) SetValue(value string) {
 	g.Value = value
 	g.require(gruesomeCoachFieldValue)
@@ -1737,6 +1759,8 @@ func (h *HarmoniousPlay) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HarmoniousPlay) SetValue(value string) {
 	h.Value = value
 	h.require(harmoniousPlayFieldValue)
@@ -1813,6 +1837,8 @@ func (h *HastyPain) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HastyPain) SetValue(value string) {
 	h.Value = value
 	h.require(hastyPainFieldValue)
@@ -1889,6 +1915,8 @@ func (h *HoarseMouse) require(field *big.Int) {
 	h.explicitFields.Or(h.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (h *HoarseMouse) SetValue(value string) {
 	h.Value = value
 	h.require(hoarseMouseFieldValue)
@@ -1965,6 +1993,8 @@ func (j *JumboEnd) require(field *big.Int) {
 	j.explicitFields.Or(j.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (j *JumboEnd) SetValue(value string) {
 	j.Value = value
 	j.require(jumboEndFieldValue)
@@ -2041,6 +2071,8 @@ func (l *LimpingStep) require(field *big.Int) {
 	l.explicitFields.Or(l.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (l *LimpingStep) SetValue(value string) {
 	l.Value = value
 	l.require(limpingStepFieldValue)
@@ -2117,6 +2149,8 @@ func (m *MistySnow) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MistySnow) SetValue(value string) {
 	m.Value = value
 	m.require(mistySnowFieldValue)
@@ -2193,6 +2227,8 @@ func (n *NormalSweet) require(field *big.Int) {
 	n.explicitFields.Or(n.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (n *NormalSweet) SetValue(value string) {
 	n.Value = value
 	n.require(normalSweetFieldValue)
@@ -2269,6 +2305,8 @@ func (p *PopularLimit) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PopularLimit) SetValue(value string) {
 	p.Value = value
 	p.require(popularLimitFieldValue)
@@ -2345,6 +2383,8 @@ func (p *PotableBad) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PotableBad) SetValue(value string) {
 	p.Value = value
 	p.require(potableBadFieldValue)
@@ -2421,6 +2461,8 @@ func (p *PracticalPrinciple) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PracticalPrinciple) SetValue(value string) {
 	p.Value = value
 	p.require(practicalPrincipleFieldValue)
@@ -2497,6 +2539,8 @@ func (p *PrimaryBlock) require(field *big.Int) {
 	p.explicitFields.Or(p.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (p *PrimaryBlock) SetValue(value string) {
 	p.Value = value
 	p.require(primaryBlockFieldValue)
@@ -2573,6 +2617,8 @@ func (r *RotatingRatio) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RotatingRatio) SetValue(value string) {
 	r.Value = value
 	r.require(rotatingRatioFieldValue)
@@ -2649,6 +2695,8 @@ func (t *ThankfulFactor) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *ThankfulFactor) SetValue(value string) {
 	t.Value = value
 	t.require(thankfulFactorFieldValue)
@@ -2725,6 +2773,8 @@ func (t *TotalWork) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TotalWork) SetValue(value string) {
 	t.Value = value
 	t.require(totalWorkFieldValue)
@@ -2801,6 +2851,8 @@ func (t *TriangularRepair) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TriangularRepair) SetValue(value string) {
 	t.Value = value
 	t.require(triangularRepairFieldValue)
@@ -2877,6 +2929,8 @@ func (u *UniqueStress) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UniqueStress) SetValue(value string) {
 	u.Value = value
 	u.require(uniqueStressFieldValue)
@@ -2953,6 +3007,8 @@ func (u *UnwillingSmoke) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *UnwillingSmoke) SetValue(value string) {
 	u.Value = value
 	u.require(unwillingSmokeFieldValue)
@@ -3029,6 +3085,8 @@ func (v *VibrantExcitement) require(field *big.Int) {
 	v.explicitFields.Or(v.explicitFields, field)
 }
 
+// SetValue sets the Value field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (v *VibrantExcitement) SetValue(value string) {
 	v.Value = value
 	v.require(vibrantExcitementFieldValue)

--- a/seed/go-sdk/unions/v0/bigunion.go
+++ b/seed/go-sdk/unions/v0/bigunion.go
@@ -6,11 +6,19 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/unions/fern/internal"
+	big "math/big"
 	time "time"
+)
+
+var (
+	activeDiamondFieldValue = big.NewInt(1 << 0)
 )
 
 type ActiveDiamond struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -25,6 +33,18 @@ func (a *ActiveDiamond) GetValue() string {
 
 func (a *ActiveDiamond) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
+}
+
+func (a *ActiveDiamond) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *ActiveDiamond) SetValue(value string) {
+	a.Value = value
+	a.require(activeDiamondFieldValue)
 }
 
 func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
@@ -43,6 +63,17 @@ func (a *ActiveDiamond) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a *ActiveDiamond) MarshalJSON() ([]byte, error) {
+	type embed ActiveDiamond
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (a *ActiveDiamond) String() string {
 	if len(a.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(a.rawJSON); err == nil {
@@ -55,8 +86,15 @@ func (a *ActiveDiamond) String() string {
 	return fmt.Sprintf("%#v", a)
 }
 
+var (
+	attractiveScriptFieldValue = big.NewInt(1 << 0)
+)
+
 type AttractiveScript struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -73,6 +111,18 @@ func (a *AttractiveScript) GetExtraProperties() map[string]interface{} {
 	return a.extraProperties
 }
 
+func (a *AttractiveScript) require(field *big.Int) {
+	if a.explicitFields == nil {
+		a.explicitFields = big.NewInt(0)
+	}
+	a.explicitFields.Or(a.explicitFields, field)
+}
+
+func (a *AttractiveScript) SetValue(value string) {
+	a.Value = value
+	a.require(attractiveScriptFieldValue)
+}
+
 func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	type unmarshaler AttractiveScript
 	var value unmarshaler
@@ -87,6 +137,17 @@ func (a *AttractiveScript) UnmarshalJSON(data []byte) error {
 	a.extraProperties = extraProperties
 	a.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (a *AttractiveScript) MarshalJSON() ([]byte, error) {
+	type embed AttractiveScript
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*a),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, a.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (a *AttractiveScript) String() string {
@@ -960,8 +1021,15 @@ func (b *BigUnion) validate() error {
 	return nil
 }
 
+var (
+	circularCardFieldValue = big.NewInt(1 << 0)
+)
+
 type CircularCard struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -976,6 +1044,18 @@ func (c *CircularCard) GetValue() string {
 
 func (c *CircularCard) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *CircularCard) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *CircularCard) SetValue(value string) {
+	c.Value = value
+	c.require(circularCardFieldValue)
 }
 
 func (c *CircularCard) UnmarshalJSON(data []byte) error {
@@ -994,6 +1074,17 @@ func (c *CircularCard) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *CircularCard) MarshalJSON() ([]byte, error) {
+	type embed CircularCard
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *CircularCard) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -1006,8 +1097,15 @@ func (c *CircularCard) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	colorfulCoverFieldValue = big.NewInt(1 << 0)
+)
+
 type ColorfulCover struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1022,6 +1120,18 @@ func (c *ColorfulCover) GetValue() string {
 
 func (c *ColorfulCover) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *ColorfulCover) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *ColorfulCover) SetValue(value string) {
+	c.Value = value
+	c.require(colorfulCoverFieldValue)
 }
 
 func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
@@ -1040,6 +1150,17 @@ func (c *ColorfulCover) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *ColorfulCover) MarshalJSON() ([]byte, error) {
+	type embed ColorfulCover
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *ColorfulCover) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -1052,8 +1173,15 @@ func (c *ColorfulCover) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	diligentDealFieldValue = big.NewInt(1 << 0)
+)
+
 type DiligentDeal struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1068,6 +1196,18 @@ func (d *DiligentDeal) GetValue() string {
 
 func (d *DiligentDeal) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DiligentDeal) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DiligentDeal) SetValue(value string) {
+	d.Value = value
+	d.require(diligentDealFieldValue)
 }
 
 func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
@@ -1086,6 +1226,17 @@ func (d *DiligentDeal) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DiligentDeal) MarshalJSON() ([]byte, error) {
+	type embed DiligentDeal
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DiligentDeal) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1098,8 +1249,15 @@ func (d *DiligentDeal) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	disloyalValueFieldValue = big.NewInt(1 << 0)
+)
+
 type DisloyalValue struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1114,6 +1272,18 @@ func (d *DisloyalValue) GetValue() string {
 
 func (d *DisloyalValue) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DisloyalValue) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DisloyalValue) SetValue(value string) {
+	d.Value = value
+	d.require(disloyalValueFieldValue)
 }
 
 func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
@@ -1132,6 +1302,17 @@ func (d *DisloyalValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DisloyalValue) MarshalJSON() ([]byte, error) {
+	type embed DisloyalValue
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DisloyalValue) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1144,8 +1325,15 @@ func (d *DisloyalValue) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	distinctFailureFieldValue = big.NewInt(1 << 0)
+)
+
 type DistinctFailure struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1160,6 +1348,18 @@ func (d *DistinctFailure) GetValue() string {
 
 func (d *DistinctFailure) GetExtraProperties() map[string]interface{} {
 	return d.extraProperties
+}
+
+func (d *DistinctFailure) require(field *big.Int) {
+	if d.explicitFields == nil {
+		d.explicitFields = big.NewInt(0)
+	}
+	d.explicitFields.Or(d.explicitFields, field)
+}
+
+func (d *DistinctFailure) SetValue(value string) {
+	d.Value = value
+	d.require(distinctFailureFieldValue)
 }
 
 func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
@@ -1178,6 +1378,17 @@ func (d *DistinctFailure) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *DistinctFailure) MarshalJSON() ([]byte, error) {
+	type embed DistinctFailure
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*d),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, d.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (d *DistinctFailure) String() string {
 	if len(d.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(d.rawJSON); err == nil {
@@ -1190,8 +1401,15 @@ func (d *DistinctFailure) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+var (
+	falseMirrorFieldValue = big.NewInt(1 << 0)
+)
+
 type FalseMirror struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1206,6 +1424,18 @@ func (f *FalseMirror) GetValue() string {
 
 func (f *FalseMirror) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FalseMirror) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FalseMirror) SetValue(value string) {
+	f.Value = value
+	f.require(falseMirrorFieldValue)
 }
 
 func (f *FalseMirror) UnmarshalJSON(data []byte) error {
@@ -1224,6 +1454,17 @@ func (f *FalseMirror) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FalseMirror) MarshalJSON() ([]byte, error) {
+	type embed FalseMirror
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FalseMirror) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1236,8 +1477,15 @@ func (f *FalseMirror) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	frozenSleepFieldValue = big.NewInt(1 << 0)
+)
+
 type FrozenSleep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1252,6 +1500,18 @@ func (f *FrozenSleep) GetValue() string {
 
 func (f *FrozenSleep) GetExtraProperties() map[string]interface{} {
 	return f.extraProperties
+}
+
+func (f *FrozenSleep) require(field *big.Int) {
+	if f.explicitFields == nil {
+		f.explicitFields = big.NewInt(0)
+	}
+	f.explicitFields.Or(f.explicitFields, field)
+}
+
+func (f *FrozenSleep) SetValue(value string) {
+	f.Value = value
+	f.require(frozenSleepFieldValue)
 }
 
 func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
@@ -1270,6 +1530,17 @@ func (f *FrozenSleep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f *FrozenSleep) MarshalJSON() ([]byte, error) {
+	type embed FrozenSleep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*f),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, f.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (f *FrozenSleep) String() string {
 	if len(f.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(f.rawJSON); err == nil {
@@ -1282,8 +1553,15 @@ func (f *FrozenSleep) String() string {
 	return fmt.Sprintf("%#v", f)
 }
 
+var (
+	gaseousRoadFieldValue = big.NewInt(1 << 0)
+)
+
 type GaseousRoad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1298,6 +1576,18 @@ func (g *GaseousRoad) GetValue() string {
 
 func (g *GaseousRoad) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GaseousRoad) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GaseousRoad) SetValue(value string) {
+	g.Value = value
+	g.require(gaseousRoadFieldValue)
 }
 
 func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
@@ -1316,6 +1606,17 @@ func (g *GaseousRoad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GaseousRoad) MarshalJSON() ([]byte, error) {
+	type embed GaseousRoad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GaseousRoad) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1328,8 +1629,15 @@ func (g *GaseousRoad) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	gruesomeCoachFieldValue = big.NewInt(1 << 0)
+)
+
 type GruesomeCoach struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1344,6 +1652,18 @@ func (g *GruesomeCoach) GetValue() string {
 
 func (g *GruesomeCoach) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
+}
+
+func (g *GruesomeCoach) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GruesomeCoach) SetValue(value string) {
+	g.Value = value
+	g.require(gruesomeCoachFieldValue)
 }
 
 func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
@@ -1362,6 +1682,17 @@ func (g *GruesomeCoach) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (g *GruesomeCoach) MarshalJSON() ([]byte, error) {
+	type embed GruesomeCoach
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (g *GruesomeCoach) String() string {
 	if len(g.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(g.rawJSON); err == nil {
@@ -1374,8 +1705,15 @@ func (g *GruesomeCoach) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+var (
+	harmoniousPlayFieldValue = big.NewInt(1 << 0)
+)
+
 type HarmoniousPlay struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1390,6 +1728,18 @@ func (h *HarmoniousPlay) GetValue() string {
 
 func (h *HarmoniousPlay) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HarmoniousPlay) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HarmoniousPlay) SetValue(value string) {
+	h.Value = value
+	h.require(harmoniousPlayFieldValue)
 }
 
 func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
@@ -1408,6 +1758,17 @@ func (h *HarmoniousPlay) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HarmoniousPlay) MarshalJSON() ([]byte, error) {
+	type embed HarmoniousPlay
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HarmoniousPlay) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1420,8 +1781,15 @@ func (h *HarmoniousPlay) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hastyPainFieldValue = big.NewInt(1 << 0)
+)
+
 type HastyPain struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1436,6 +1804,18 @@ func (h *HastyPain) GetValue() string {
 
 func (h *HastyPain) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HastyPain) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HastyPain) SetValue(value string) {
+	h.Value = value
+	h.require(hastyPainFieldValue)
 }
 
 func (h *HastyPain) UnmarshalJSON(data []byte) error {
@@ -1454,6 +1834,17 @@ func (h *HastyPain) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HastyPain) MarshalJSON() ([]byte, error) {
+	type embed HastyPain
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HastyPain) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1466,8 +1857,15 @@ func (h *HastyPain) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	hoarseMouseFieldValue = big.NewInt(1 << 0)
+)
+
 type HoarseMouse struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1482,6 +1880,18 @@ func (h *HoarseMouse) GetValue() string {
 
 func (h *HoarseMouse) GetExtraProperties() map[string]interface{} {
 	return h.extraProperties
+}
+
+func (h *HoarseMouse) require(field *big.Int) {
+	if h.explicitFields == nil {
+		h.explicitFields = big.NewInt(0)
+	}
+	h.explicitFields.Or(h.explicitFields, field)
+}
+
+func (h *HoarseMouse) SetValue(value string) {
+	h.Value = value
+	h.require(hoarseMouseFieldValue)
 }
 
 func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
@@ -1500,6 +1910,17 @@ func (h *HoarseMouse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *HoarseMouse) MarshalJSON() ([]byte, error) {
+	type embed HoarseMouse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*h),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, h.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (h *HoarseMouse) String() string {
 	if len(h.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(h.rawJSON); err == nil {
@@ -1512,8 +1933,15 @@ func (h *HoarseMouse) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+var (
+	jumboEndFieldValue = big.NewInt(1 << 0)
+)
+
 type JumboEnd struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1528,6 +1956,18 @@ func (j *JumboEnd) GetValue() string {
 
 func (j *JumboEnd) GetExtraProperties() map[string]interface{} {
 	return j.extraProperties
+}
+
+func (j *JumboEnd) require(field *big.Int) {
+	if j.explicitFields == nil {
+		j.explicitFields = big.NewInt(0)
+	}
+	j.explicitFields.Or(j.explicitFields, field)
+}
+
+func (j *JumboEnd) SetValue(value string) {
+	j.Value = value
+	j.require(jumboEndFieldValue)
 }
 
 func (j *JumboEnd) UnmarshalJSON(data []byte) error {
@@ -1546,6 +1986,17 @@ func (j *JumboEnd) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (j *JumboEnd) MarshalJSON() ([]byte, error) {
+	type embed JumboEnd
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*j),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, j.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (j *JumboEnd) String() string {
 	if len(j.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(j.rawJSON); err == nil {
@@ -1558,8 +2009,15 @@ func (j *JumboEnd) String() string {
 	return fmt.Sprintf("%#v", j)
 }
 
+var (
+	limpingStepFieldValue = big.NewInt(1 << 0)
+)
+
 type LimpingStep struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1574,6 +2032,18 @@ func (l *LimpingStep) GetValue() string {
 
 func (l *LimpingStep) GetExtraProperties() map[string]interface{} {
 	return l.extraProperties
+}
+
+func (l *LimpingStep) require(field *big.Int) {
+	if l.explicitFields == nil {
+		l.explicitFields = big.NewInt(0)
+	}
+	l.explicitFields.Or(l.explicitFields, field)
+}
+
+func (l *LimpingStep) SetValue(value string) {
+	l.Value = value
+	l.require(limpingStepFieldValue)
 }
 
 func (l *LimpingStep) UnmarshalJSON(data []byte) error {
@@ -1592,6 +2062,17 @@ func (l *LimpingStep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (l *LimpingStep) MarshalJSON() ([]byte, error) {
+	type embed LimpingStep
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*l),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, l.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (l *LimpingStep) String() string {
 	if len(l.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(l.rawJSON); err == nil {
@@ -1604,8 +2085,15 @@ func (l *LimpingStep) String() string {
 	return fmt.Sprintf("%#v", l)
 }
 
+var (
+	mistySnowFieldValue = big.NewInt(1 << 0)
+)
+
 type MistySnow struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1620,6 +2108,18 @@ func (m *MistySnow) GetValue() string {
 
 func (m *MistySnow) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
+}
+
+func (m *MistySnow) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MistySnow) SetValue(value string) {
+	m.Value = value
+	m.require(mistySnowFieldValue)
 }
 
 func (m *MistySnow) UnmarshalJSON(data []byte) error {
@@ -1638,6 +2138,17 @@ func (m *MistySnow) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MistySnow) MarshalJSON() ([]byte, error) {
+	type embed MistySnow
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (m *MistySnow) String() string {
 	if len(m.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(m.rawJSON); err == nil {
@@ -1650,8 +2161,15 @@ func (m *MistySnow) String() string {
 	return fmt.Sprintf("%#v", m)
 }
 
+var (
+	normalSweetFieldValue = big.NewInt(1 << 0)
+)
+
 type NormalSweet struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1666,6 +2184,18 @@ func (n *NormalSweet) GetValue() string {
 
 func (n *NormalSweet) GetExtraProperties() map[string]interface{} {
 	return n.extraProperties
+}
+
+func (n *NormalSweet) require(field *big.Int) {
+	if n.explicitFields == nil {
+		n.explicitFields = big.NewInt(0)
+	}
+	n.explicitFields.Or(n.explicitFields, field)
+}
+
+func (n *NormalSweet) SetValue(value string) {
+	n.Value = value
+	n.require(normalSweetFieldValue)
 }
 
 func (n *NormalSweet) UnmarshalJSON(data []byte) error {
@@ -1684,6 +2214,17 @@ func (n *NormalSweet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NormalSweet) MarshalJSON() ([]byte, error) {
+	type embed NormalSweet
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*n),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, n.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (n *NormalSweet) String() string {
 	if len(n.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(n.rawJSON); err == nil {
@@ -1696,8 +2237,15 @@ func (n *NormalSweet) String() string {
 	return fmt.Sprintf("%#v", n)
 }
 
+var (
+	popularLimitFieldValue = big.NewInt(1 << 0)
+)
+
 type PopularLimit struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1712,6 +2260,18 @@ func (p *PopularLimit) GetValue() string {
 
 func (p *PopularLimit) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PopularLimit) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PopularLimit) SetValue(value string) {
+	p.Value = value
+	p.require(popularLimitFieldValue)
 }
 
 func (p *PopularLimit) UnmarshalJSON(data []byte) error {
@@ -1730,6 +2290,17 @@ func (p *PopularLimit) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PopularLimit) MarshalJSON() ([]byte, error) {
+	type embed PopularLimit
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PopularLimit) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1742,8 +2313,15 @@ func (p *PopularLimit) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	potableBadFieldValue = big.NewInt(1 << 0)
+)
+
 type PotableBad struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1758,6 +2336,18 @@ func (p *PotableBad) GetValue() string {
 
 func (p *PotableBad) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PotableBad) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PotableBad) SetValue(value string) {
+	p.Value = value
+	p.require(potableBadFieldValue)
 }
 
 func (p *PotableBad) UnmarshalJSON(data []byte) error {
@@ -1776,6 +2366,17 @@ func (p *PotableBad) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PotableBad) MarshalJSON() ([]byte, error) {
+	type embed PotableBad
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PotableBad) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1788,8 +2389,15 @@ func (p *PotableBad) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	practicalPrincipleFieldValue = big.NewInt(1 << 0)
+)
+
 type PracticalPrinciple struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1804,6 +2412,18 @@ func (p *PracticalPrinciple) GetValue() string {
 
 func (p *PracticalPrinciple) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PracticalPrinciple) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PracticalPrinciple) SetValue(value string) {
+	p.Value = value
+	p.require(practicalPrincipleFieldValue)
 }
 
 func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
@@ -1822,6 +2442,17 @@ func (p *PracticalPrinciple) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PracticalPrinciple) MarshalJSON() ([]byte, error) {
+	type embed PracticalPrinciple
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PracticalPrinciple) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1834,8 +2465,15 @@ func (p *PracticalPrinciple) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	primaryBlockFieldValue = big.NewInt(1 << 0)
+)
+
 type PrimaryBlock struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1850,6 +2488,18 @@ func (p *PrimaryBlock) GetValue() string {
 
 func (p *PrimaryBlock) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
+}
+
+func (p *PrimaryBlock) require(field *big.Int) {
+	if p.explicitFields == nil {
+		p.explicitFields = big.NewInt(0)
+	}
+	p.explicitFields.Or(p.explicitFields, field)
+}
+
+func (p *PrimaryBlock) SetValue(value string) {
+	p.Value = value
+	p.require(primaryBlockFieldValue)
 }
 
 func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
@@ -1868,6 +2518,17 @@ func (p *PrimaryBlock) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *PrimaryBlock) MarshalJSON() ([]byte, error) {
+	type embed PrimaryBlock
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*p),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, p.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (p *PrimaryBlock) String() string {
 	if len(p.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(p.rawJSON); err == nil {
@@ -1880,8 +2541,15 @@ func (p *PrimaryBlock) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
+var (
+	rotatingRatioFieldValue = big.NewInt(1 << 0)
+)
+
 type RotatingRatio struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1896,6 +2564,18 @@ func (r *RotatingRatio) GetValue() string {
 
 func (r *RotatingRatio) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *RotatingRatio) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RotatingRatio) SetValue(value string) {
+	r.Value = value
+	r.require(rotatingRatioFieldValue)
 }
 
 func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
@@ -1914,6 +2594,17 @@ func (r *RotatingRatio) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RotatingRatio) MarshalJSON() ([]byte, error) {
+	type embed RotatingRatio
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *RotatingRatio) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -1926,8 +2617,15 @@ func (r *RotatingRatio) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	thankfulFactorFieldValue = big.NewInt(1 << 0)
+)
+
 type ThankfulFactor struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1942,6 +2640,18 @@ func (t *ThankfulFactor) GetValue() string {
 
 func (t *ThankfulFactor) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *ThankfulFactor) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *ThankfulFactor) SetValue(value string) {
+	t.Value = value
+	t.require(thankfulFactorFieldValue)
 }
 
 func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
@@ -1960,6 +2670,17 @@ func (t *ThankfulFactor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *ThankfulFactor) MarshalJSON() ([]byte, error) {
+	type embed ThankfulFactor
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *ThankfulFactor) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -1972,8 +2693,15 @@ func (t *ThankfulFactor) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	totalWorkFieldValue = big.NewInt(1 << 0)
+)
+
 type TotalWork struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -1988,6 +2716,18 @@ func (t *TotalWork) GetValue() string {
 
 func (t *TotalWork) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TotalWork) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TotalWork) SetValue(value string) {
+	t.Value = value
+	t.require(totalWorkFieldValue)
 }
 
 func (t *TotalWork) UnmarshalJSON(data []byte) error {
@@ -2006,6 +2746,17 @@ func (t *TotalWork) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TotalWork) MarshalJSON() ([]byte, error) {
+	type embed TotalWork
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TotalWork) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2018,8 +2769,15 @@ func (t *TotalWork) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	triangularRepairFieldValue = big.NewInt(1 << 0)
+)
+
 type TriangularRepair struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2034,6 +2792,18 @@ func (t *TriangularRepair) GetValue() string {
 
 func (t *TriangularRepair) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
+}
+
+func (t *TriangularRepair) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TriangularRepair) SetValue(value string) {
+	t.Value = value
+	t.require(triangularRepairFieldValue)
 }
 
 func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
@@ -2052,6 +2822,17 @@ func (t *TriangularRepair) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t *TriangularRepair) MarshalJSON() ([]byte, error) {
+	type embed TriangularRepair
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (t *TriangularRepair) String() string {
 	if len(t.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(t.rawJSON); err == nil {
@@ -2064,8 +2845,15 @@ func (t *TriangularRepair) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+var (
+	uniqueStressFieldValue = big.NewInt(1 << 0)
+)
+
 type UniqueStress struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2080,6 +2868,18 @@ func (u *UniqueStress) GetValue() string {
 
 func (u *UniqueStress) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UniqueStress) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UniqueStress) SetValue(value string) {
+	u.Value = value
+	u.require(uniqueStressFieldValue)
 }
 
 func (u *UniqueStress) UnmarshalJSON(data []byte) error {
@@ -2098,6 +2898,17 @@ func (u *UniqueStress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UniqueStress) MarshalJSON() ([]byte, error) {
+	type embed UniqueStress
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UniqueStress) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -2110,8 +2921,15 @@ func (u *UniqueStress) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	unwillingSmokeFieldValue = big.NewInt(1 << 0)
+)
+
 type UnwillingSmoke struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2126,6 +2944,18 @@ func (u *UnwillingSmoke) GetValue() string {
 
 func (u *UnwillingSmoke) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
+}
+
+func (u *UnwillingSmoke) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *UnwillingSmoke) SetValue(value string) {
+	u.Value = value
+	u.require(unwillingSmokeFieldValue)
 }
 
 func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
@@ -2144,6 +2974,17 @@ func (u *UnwillingSmoke) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UnwillingSmoke) MarshalJSON() ([]byte, error) {
+	type embed UnwillingSmoke
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (u *UnwillingSmoke) String() string {
 	if len(u.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(u.rawJSON); err == nil {
@@ -2156,8 +2997,15 @@ func (u *UnwillingSmoke) String() string {
 	return fmt.Sprintf("%#v", u)
 }
 
+var (
+	vibrantExcitementFieldValue = big.NewInt(1 << 0)
+)
+
 type VibrantExcitement struct {
 	Value string `json:"value" url:"value"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -2174,6 +3022,18 @@ func (v *VibrantExcitement) GetExtraProperties() map[string]interface{} {
 	return v.extraProperties
 }
 
+func (v *VibrantExcitement) require(field *big.Int) {
+	if v.explicitFields == nil {
+		v.explicitFields = big.NewInt(0)
+	}
+	v.explicitFields.Or(v.explicitFields, field)
+}
+
+func (v *VibrantExcitement) SetValue(value string) {
+	v.Value = value
+	v.require(vibrantExcitementFieldValue)
+}
+
 func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	type unmarshaler VibrantExcitement
 	var value unmarshaler
@@ -2188,6 +3048,17 @@ func (v *VibrantExcitement) UnmarshalJSON(data []byte) error {
 	v.extraProperties = extraProperties
 	v.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (v *VibrantExcitement) MarshalJSON() ([]byte, error) {
+	type embed VibrantExcitement
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*v),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, v.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (v *VibrantExcitement) String() string {

--- a/seed/go-sdk/unions/v0/internal/explicit_fields.go
+++ b/seed/go-sdk/unions/v0/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/unions/v0/internal/explicit_fields_test.go
+++ b/seed/go-sdk/unions/v0/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/unions/v0/types.go
+++ b/seed/go-sdk/unions/v0/types.go
@@ -42,6 +42,8 @@ func (b *Bar) require(field *big.Int) {
 	b.explicitFields.Or(b.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (b *Bar) SetName(name string) {
 	b.Name = name
 	b.require(barFieldName)
@@ -118,6 +120,8 @@ func (f *Foo) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *Foo) SetName(name string) {
 	f.Name = name
 	f.require(fooFieldName)
@@ -203,11 +207,15 @@ func (f *FooExtended) require(field *big.Int) {
 	f.explicitFields.Or(f.explicitFields, field)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooExtended) SetName(name string) {
 	f.Name = name
 	f.require(fooExtendedFieldName)
 }
 
+// SetAge sets the Age field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (f *FooExtended) SetAge(age int) {
 	f.Age = age
 	f.require(fooExtendedFieldAge)

--- a/seed/go-sdk/unions/v0/union.go
+++ b/seed/go-sdk/unions/v0/union.go
@@ -41,6 +41,8 @@ func (c *Circle) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetRadius sets the Radius field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *Circle) SetRadius(radius float64) {
 	c.Radius = radius
 	c.require(circleFieldRadius)
@@ -117,6 +119,8 @@ func (g *GetShapeRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetShapeRequest) SetId(id string) {
 	g.Id = id
 	g.require(getShapeRequestFieldId)
@@ -330,6 +334,8 @@ func (s *Square) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetLength sets the Length field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *Square) SetLength(length float64) {
 	s.Length = length
 	s.require(squareFieldLength)

--- a/seed/go-sdk/unions/v0/union.go
+++ b/seed/go-sdk/unions/v0/union.go
@@ -6,10 +6,18 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/unions/fern/internal"
+	big "math/big"
+)
+
+var (
+	circleFieldRadius = big.NewInt(1 << 0)
 )
 
 type Circle struct {
 	Radius float64 `json:"radius" url:"radius"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -24,6 +32,18 @@ func (c *Circle) GetRadius() float64 {
 
 func (c *Circle) GetExtraProperties() map[string]interface{} {
 	return c.extraProperties
+}
+
+func (c *Circle) require(field *big.Int) {
+	if c.explicitFields == nil {
+		c.explicitFields = big.NewInt(0)
+	}
+	c.explicitFields.Or(c.explicitFields, field)
+}
+
+func (c *Circle) SetRadius(radius float64) {
+	c.Radius = radius
+	c.require(circleFieldRadius)
 }
 
 func (c *Circle) UnmarshalJSON(data []byte) error {
@@ -42,6 +62,17 @@ func (c *Circle) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c *Circle) MarshalJSON() ([]byte, error) {
+	type embed Circle
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*c),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, c.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (c *Circle) String() string {
 	if len(c.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(c.rawJSON); err == nil {
@@ -54,8 +85,15 @@ func (c *Circle) String() string {
 	return fmt.Sprintf("%#v", c)
 }
 
+var (
+	getShapeRequestFieldId = big.NewInt(1 << 0)
+)
+
 type GetShapeRequest struct {
 	Id string `json:"id" url:"id"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -72,6 +110,18 @@ func (g *GetShapeRequest) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
 }
 
+func (g *GetShapeRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetShapeRequest) SetId(id string) {
+	g.Id = id
+	g.require(getShapeRequestFieldId)
+}
+
 func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	type unmarshaler GetShapeRequest
 	var value unmarshaler
@@ -86,6 +136,17 @@ func (g *GetShapeRequest) UnmarshalJSON(data []byte) error {
 	g.extraProperties = extraProperties
 	g.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (g *GetShapeRequest) MarshalJSON() ([]byte, error) {
+	type embed GetShapeRequest
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*g),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (g *GetShapeRequest) String() string {
@@ -237,8 +298,15 @@ func (s *Shape) validate() error {
 	return nil
 }
 
+var (
+	squareFieldLength = big.NewInt(1 << 0)
+)
+
 type Square struct {
 	Length float64 `json:"length" url:"length"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -255,6 +323,18 @@ func (s *Square) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *Square) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *Square) SetLength(length float64) {
+	s.Length = length
+	s.require(squareFieldLength)
+}
+
 func (s *Square) UnmarshalJSON(data []byte) error {
 	type unmarshaler Square
 	var value unmarshaler
@@ -269,6 +349,17 @@ func (s *Square) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *Square) MarshalJSON() ([]byte, error) {
+	type embed Square
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *Square) String() string {

--- a/seed/go-sdk/unknown/internal/explicit_fields.go
+++ b/seed/go-sdk/unknown/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/unknown/internal/explicit_fields_test.go
+++ b/seed/go-sdk/unknown/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/unknown/unknown.go
+++ b/seed/go-sdk/unknown/unknown.go
@@ -6,12 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/unknown/fern/internal"
+	big "math/big"
 )
 
 type MyAlias = interface{}
 
+var (
+	myObjectFieldUnknown = big.NewInt(1 << 0)
+)
+
 type MyObject struct {
 	Unknown interface{} `json:"unknown" url:"unknown"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -28,6 +36,18 @@ func (m *MyObject) GetExtraProperties() map[string]interface{} {
 	return m.extraProperties
 }
 
+func (m *MyObject) require(field *big.Int) {
+	if m.explicitFields == nil {
+		m.explicitFields = big.NewInt(0)
+	}
+	m.explicitFields.Or(m.explicitFields, field)
+}
+
+func (m *MyObject) SetUnknown(unknown interface{}) {
+	m.Unknown = unknown
+	m.require(myObjectFieldUnknown)
+}
+
 func (m *MyObject) UnmarshalJSON(data []byte) error {
 	type unmarshaler MyObject
 	var value unmarshaler
@@ -42,6 +62,17 @@ func (m *MyObject) UnmarshalJSON(data []byte) error {
 	m.extraProperties = extraProperties
 	m.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (m *MyObject) MarshalJSON() ([]byte, error) {
+	type embed MyObject
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*m),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, m.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (m *MyObject) String() string {

--- a/seed/go-sdk/unknown/unknown.go
+++ b/seed/go-sdk/unknown/unknown.go
@@ -43,6 +43,8 @@ func (m *MyObject) require(field *big.Int) {
 	m.explicitFields.Or(m.explicitFields, field)
 }
 
+// SetUnknown sets the Unknown field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (m *MyObject) SetUnknown(unknown interface{}) {
 	m.Unknown = unknown
 	m.require(myObjectFieldUnknown)

--- a/seed/go-sdk/validation/internal/explicit_fields.go
+++ b/seed/go-sdk/validation/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/validation/internal/explicit_fields_test.go
+++ b/seed/go-sdk/validation/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/validation/types.go
+++ b/seed/go-sdk/validation/types.go
@@ -33,21 +33,29 @@ func (c *CreateRequest) require(field *big.Int) {
 	c.explicitFields.Or(c.explicitFields, field)
 }
 
+// SetDecimal sets the Decimal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateRequest) SetDecimal(decimal float64) {
 	c.Decimal = decimal
 	c.require(createRequestFieldDecimal)
 }
 
+// SetEven sets the Even field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateRequest) SetEven(even int) {
 	c.Even = even
 	c.require(createRequestFieldEven)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateRequest) SetName(name string) {
 	c.Name = name
 	c.require(createRequestFieldName)
 }
 
+// SetShape sets the Shape field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (c *CreateRequest) SetShape(shape Shape) {
 	c.Shape = shape
 	c.require(createRequestFieldShape)
@@ -75,16 +83,22 @@ func (g *GetRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetDecimal sets the Decimal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetRequest) SetDecimal(decimal float64) {
 	g.Decimal = decimal
 	g.require(getRequestFieldDecimal)
 }
 
+// SetEven sets the Even field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetRequest) SetEven(even int) {
 	g.Even = even
 	g.require(getRequestFieldEven)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetRequest) SetName(name string) {
 	g.Name = name
 	g.require(getRequestFieldName)
@@ -183,21 +197,29 @@ func (t *Type) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetDecimal sets the Decimal field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetDecimal(decimal float64) {
 	t.Decimal = decimal
 	t.require(typeFieldDecimal)
 }
 
+// SetEven sets the Even field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetEven(even int) {
 	t.Even = even
 	t.require(typeFieldEven)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetName(name string) {
 	t.Name = name
 	t.require(typeFieldName)
 }
 
+// SetShape sets the Shape field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *Type) SetShape(shape Shape) {
 	t.Shape = shape
 	t.require(typeFieldShape)

--- a/seed/go-sdk/variables/internal/explicit_fields.go
+++ b/seed/go-sdk/variables/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/variables/internal/explicit_fields_test.go
+++ b/seed/go-sdk/variables/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/version-no-default/internal/explicit_fields.go
+++ b/seed/go-sdk/version-no-default/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/version-no-default/internal/explicit_fields_test.go
+++ b/seed/go-sdk/version-no-default/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/version-no-default/user.go
+++ b/seed/go-sdk/version-no-default/user.go
@@ -50,11 +50,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id UserId) {
 	u.Id = id
 	u.require(userFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)

--- a/seed/go-sdk/version-no-default/user.go
+++ b/seed/go-sdk/version-no-default/user.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/version-no-default/fern/internal"
+	big "math/big"
+)
+
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
 )
 
 type User struct {
 	Id   UserId `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetId(id UserId) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -48,6 +74,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/version/internal/explicit_fields.go
+++ b/seed/go-sdk/version/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/version/internal/explicit_fields_test.go
+++ b/seed/go-sdk/version/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/version/user.go
+++ b/seed/go-sdk/version/user.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/version/fern/internal"
+	big "math/big"
+)
+
+var (
+	userFieldId   = big.NewInt(1 << 0)
+	userFieldName = big.NewInt(1 << 1)
 )
 
 type User struct {
 	Id   UserId `json:"id" url:"id"`
 	Name string `json:"name" url:"name"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (u *User) GetExtraProperties() map[string]interface{} {
 	return u.extraProperties
 }
 
+func (u *User) require(field *big.Int) {
+	if u.explicitFields == nil {
+		u.explicitFields = big.NewInt(0)
+	}
+	u.explicitFields.Or(u.explicitFields, field)
+}
+
+func (u *User) SetId(id UserId) {
+	u.Id = id
+	u.require(userFieldId)
+}
+
+func (u *User) SetName(name string) {
+	u.Name = name
+	u.require(userFieldName)
+}
+
 func (u *User) UnmarshalJSON(data []byte) error {
 	type unmarshaler User
 	var value unmarshaler
@@ -48,6 +74,17 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	u.extraProperties = extraProperties
 	u.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (u *User) MarshalJSON() ([]byte, error) {
+	type embed User
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*u),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, u.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (u *User) String() string {

--- a/seed/go-sdk/version/user.go
+++ b/seed/go-sdk/version/user.go
@@ -50,11 +50,15 @@ func (u *User) require(field *big.Int) {
 	u.explicitFields.Or(u.explicitFields, field)
 }
 
+// SetId sets the Id field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetId(id UserId) {
 	u.Id = id
 	u.require(userFieldId)
 }
 
+// SetName sets the Name field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (u *User) SetName(name string) {
 	u.Name = name
 	u.require(userFieldName)

--- a/seed/go-sdk/websocket-bearer-auth/internal/explicit_fields.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/websocket-bearer-auth/internal/explicit_fields_test.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/websocket-bearer-auth/realtime.go
+++ b/seed/go-sdk/websocket-bearer-auth/realtime.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket-bearer-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	receiveEventFieldAlpha = big.NewInt(1 << 0)
+	receiveEventFieldBeta  = big.NewInt(1 << 1)
 )
 
 type ReceiveEvent struct {
 	Alpha string `json:"alpha" url:"alpha"`
 	Beta  int    `json:"beta" url:"beta"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (r *ReceiveEvent) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent) SetAlpha(alpha string) {
+	r.Alpha = alpha
+	r.require(receiveEventFieldAlpha)
+}
+
+func (r *ReceiveEvent) SetBeta(beta int) {
+	r.Beta = beta
+	r.require(receiveEventFieldBeta)
+}
+
 func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent
 	var value unmarshaler
@@ -50,6 +76,17 @@ func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -62,10 +99,19 @@ func (r *ReceiveEvent) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent2FieldGamma   = big.NewInt(1 << 0)
+	receiveEvent2FieldDelta   = big.NewInt(1 << 1)
+	receiveEvent2FieldEpsilon = big.NewInt(1 << 2)
+)
+
 type ReceiveEvent2 struct {
 	Gamma   string `json:"gamma" url:"gamma"`
 	Delta   int    `json:"delta" url:"delta"`
 	Epsilon bool   `json:"epsilon" url:"epsilon"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -96,6 +142,28 @@ func (r *ReceiveEvent2) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent2) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent2) SetGamma(gamma string) {
+	r.Gamma = gamma
+	r.require(receiveEvent2FieldGamma)
+}
+
+func (r *ReceiveEvent2) SetDelta(delta int) {
+	r.Delta = delta
+	r.require(receiveEvent2FieldDelta)
+}
+
+func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
+	r.Epsilon = epsilon
+	r.require(receiveEvent2FieldEpsilon)
+}
+
 func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent2
 	var value unmarshaler
@@ -112,6 +180,17 @@ func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent2) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent2) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -124,8 +203,15 @@ func (r *ReceiveEvent2) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent3FieldReceiveText3 = big.NewInt(1 << 0)
+)
+
 type ReceiveEvent3 struct {
 	ReceiveText3 string `json:"receiveText3" url:"receiveText3"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -140,6 +226,18 @@ func (r *ReceiveEvent3) GetReceiveText3() string {
 
 func (r *ReceiveEvent3) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ReceiveEvent3) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
+	r.ReceiveText3 = receiveText3
+	r.require(receiveEvent3FieldReceiveText3)
 }
 
 func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
@@ -158,6 +256,17 @@ func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent3) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent3
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent3) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -170,9 +279,17 @@ func (r *ReceiveEvent3) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendEventFieldSendText  = big.NewInt(1 << 0)
+	sendEventFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendEvent struct {
 	SendText  string `json:"sendText" url:"sendText"`
 	SendParam int    `json:"sendParam" url:"sendParam"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -196,6 +313,23 @@ func (s *SendEvent) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEvent) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendEventFieldSendText)
+}
+
+func (s *SendEvent) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendEventFieldSendParam)
+}
+
 func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent
 	var value unmarshaler
@@ -212,6 +346,17 @@ func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent) MarshalJSON() ([]byte, error) {
+	type embed SendEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -224,9 +369,17 @@ func (s *SendEvent) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	sendEvent2FieldSendText2  = big.NewInt(1 << 0)
+	sendEvent2FieldSendParam2 = big.NewInt(1 << 1)
+)
+
 type SendEvent2 struct {
 	SendText2  string `json:"sendText2" url:"sendText2"`
 	SendParam2 bool   `json:"sendParam2" url:"sendParam2"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -250,6 +403,23 @@ func (s *SendEvent2) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent2) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEvent2) SetSendText2(sendText2 string) {
+	s.SendText2 = sendText2
+	s.require(sendEvent2FieldSendText2)
+}
+
+func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
+	s.SendParam2 = sendParam2
+	s.require(sendEvent2FieldSendParam2)
+}
+
 func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent2
 	var value unmarshaler
@@ -266,6 +436,17 @@ func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent2) MarshalJSON() ([]byte, error) {
+	type embed SendEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent2) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -278,9 +459,17 @@ func (s *SendEvent2) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	receiveSnakeCaseFieldReceiveText = big.NewInt(1 << 0)
+	receiveSnakeCaseFieldReceiveInt  = big.NewInt(1 << 1)
+)
+
 type ReceiveSnakeCase struct {
 	ReceiveText string `json:"receive_text" url:"receive_text"`
 	ReceiveInt  int    `json:"receive_int" url:"receive_int"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -304,6 +493,23 @@ func (r *ReceiveSnakeCase) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveSnakeCase) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
+	r.ReceiveText = receiveText
+	r.require(receiveSnakeCaseFieldReceiveText)
+}
+
+func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
+	r.ReceiveInt = receiveInt
+	r.require(receiveSnakeCaseFieldReceiveInt)
+}
+
 func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveSnakeCase
 	var value unmarshaler
@@ -320,6 +526,17 @@ func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed ReceiveSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveSnakeCase) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -332,9 +549,17 @@ func (r *ReceiveSnakeCase) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendSnakeCaseFieldSendText  = big.NewInt(1 << 0)
+	sendSnakeCaseFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendSnakeCase struct {
 	SendText  string `json:"send_text" url:"send_text"`
 	SendParam int    `json:"send_param" url:"send_param"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -358,6 +583,23 @@ func (s *SendSnakeCase) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendSnakeCase) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendSnakeCase) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendSnakeCaseFieldSendText)
+}
+
+func (s *SendSnakeCase) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendSnakeCaseFieldSendParam)
+}
+
 func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendSnakeCase
 	var value unmarshaler
@@ -372,6 +614,17 @@ func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *SendSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed SendSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SendSnakeCase) String() string {

--- a/seed/go-sdk/websocket-bearer-auth/realtime.go
+++ b/seed/go-sdk/websocket-bearer-auth/realtime.go
@@ -50,11 +50,15 @@ func (r *ReceiveEvent) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetAlpha sets the Alpha field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent) SetAlpha(alpha string) {
 	r.Alpha = alpha
 	r.require(receiveEventFieldAlpha)
 }
 
+// SetBeta sets the Beta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent) SetBeta(beta int) {
 	r.Beta = beta
 	r.require(receiveEventFieldBeta)
@@ -149,16 +153,22 @@ func (r *ReceiveEvent2) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetGamma sets the Gamma field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetGamma(gamma string) {
 	r.Gamma = gamma
 	r.require(receiveEvent2FieldGamma)
 }
 
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetDelta(delta int) {
 	r.Delta = delta
 	r.require(receiveEvent2FieldDelta)
 }
 
+// SetEpsilon sets the Epsilon field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
 	r.Epsilon = epsilon
 	r.require(receiveEvent2FieldEpsilon)
@@ -235,6 +245,8 @@ func (r *ReceiveEvent3) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetReceiveText3 sets the ReceiveText3 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
 	r.ReceiveText3 = receiveText3
 	r.require(receiveEvent3FieldReceiveText3)
@@ -320,11 +332,15 @@ func (s *SendEvent) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent) SetSendText(sendText string) {
 	s.SendText = sendText
 	s.require(sendEventFieldSendText)
 }
 
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent) SetSendParam(sendParam int) {
 	s.SendParam = sendParam
 	s.require(sendEventFieldSendParam)
@@ -410,11 +426,15 @@ func (s *SendEvent2) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText2 sets the SendText2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent2) SetSendText2(sendText2 string) {
 	s.SendText2 = sendText2
 	s.require(sendEvent2FieldSendText2)
 }
 
+// SetSendParam2 sets the SendParam2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
 	s.SendParam2 = sendParam2
 	s.require(sendEvent2FieldSendParam2)
@@ -500,11 +520,15 @@ func (r *ReceiveSnakeCase) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetReceiveText sets the ReceiveText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
 	r.ReceiveText = receiveText
 	r.require(receiveSnakeCaseFieldReceiveText)
 }
 
+// SetReceiveInt sets the ReceiveInt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
 	r.ReceiveInt = receiveInt
 	r.require(receiveSnakeCaseFieldReceiveInt)
@@ -590,11 +614,15 @@ func (s *SendSnakeCase) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendSnakeCase) SetSendText(sendText string) {
 	s.SendText = sendText
 	s.require(sendSnakeCaseFieldSendText)
 }
 
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendSnakeCase) SetSendParam(sendParam int) {
 	s.SendParam = sendParam
 	s.require(sendSnakeCaseFieldSendParam)

--- a/seed/go-sdk/websocket-inferred-auth/auth.go
+++ b/seed/go-sdk/websocket-inferred-auth/auth.go
@@ -43,21 +43,29 @@ func (g *GetTokenRequest) require(field *big.Int) {
 	g.explicitFields.Or(g.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
 	g.XApiKey = xApiKey
 	g.require(getTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientId(clientId string) {
 	g.ClientId = clientId
 	g.require(getTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
 	g.ClientSecret = clientSecret
 	g.require(getTokenRequestFieldClientSecret)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (g *GetTokenRequest) SetScope(scope *string) {
 	g.Scope = scope
 	g.require(getTokenRequestFieldScope)
@@ -126,26 +134,36 @@ func (r *RefreshTokenRequest) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetXApiKey sets the XApiKey field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
 	r.XApiKey = xApiKey
 	r.require(refreshTokenRequestFieldXApiKey)
 }
 
+// SetClientId sets the ClientId field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientId(clientId string) {
 	r.ClientId = clientId
 	r.require(refreshTokenRequestFieldClientId)
 }
 
+// SetClientSecret sets the ClientSecret field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
 	r.ClientSecret = clientSecret
 	r.require(refreshTokenRequestFieldClientSecret)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
 	r.RefreshToken = refreshToken
 	r.require(refreshTokenRequestFieldRefreshToken)
 }
 
+// SetScope sets the Scope field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *RefreshTokenRequest) SetScope(scope *string) {
 	r.Scope = scope
 	r.require(refreshTokenRequestFieldScope)
@@ -220,11 +238,15 @@ func (t *TokenResponse) require(field *big.Int) {
 	t.explicitFields.Or(t.explicitFields, field)
 }
 
+// SetAccessToken sets the AccessToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetAccessToken(accessToken string) {
 	t.AccessToken = accessToken
 	t.require(tokenResponseFieldAccessToken)
 }
 
+// SetRefreshToken sets the RefreshToken field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
 	t.RefreshToken = refreshToken
 	t.require(tokenResponseFieldRefreshToken)

--- a/seed/go-sdk/websocket-inferred-auth/auth.go
+++ b/seed/go-sdk/websocket-inferred-auth/auth.go
@@ -6,6 +6,14 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket-inferred-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	getTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	getTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	getTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	getTokenRequestFieldScope        = big.NewInt(1 << 3)
 )
 
 type GetTokenRequest struct {
@@ -15,6 +23,9 @@ type GetTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (g *GetTokenRequest) Audience() string {
@@ -23,6 +34,33 @@ func (g *GetTokenRequest) Audience() string {
 
 func (g *GetTokenRequest) GrantType() string {
 	return g.grantType
+}
+
+func (g *GetTokenRequest) require(field *big.Int) {
+	if g.explicitFields == nil {
+		g.explicitFields = big.NewInt(0)
+	}
+	g.explicitFields.Or(g.explicitFields, field)
+}
+
+func (g *GetTokenRequest) SetXApiKey(xApiKey string) {
+	g.XApiKey = xApiKey
+	g.require(getTokenRequestFieldXApiKey)
+}
+
+func (g *GetTokenRequest) SetClientId(clientId string) {
+	g.ClientId = clientId
+	g.require(getTokenRequestFieldClientId)
+}
+
+func (g *GetTokenRequest) SetClientSecret(clientSecret string) {
+	g.ClientSecret = clientSecret
+	g.require(getTokenRequestFieldClientSecret)
+}
+
+func (g *GetTokenRequest) SetScope(scope *string) {
+	g.Scope = scope
+	g.require(getTokenRequestFieldScope)
 }
 
 func (g *GetTokenRequest) UnmarshalJSON(data []byte) error {
@@ -48,8 +86,17 @@ func (g *GetTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "client_credentials",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, g.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
+
+var (
+	refreshTokenRequestFieldXApiKey      = big.NewInt(1 << 0)
+	refreshTokenRequestFieldClientId     = big.NewInt(1 << 1)
+	refreshTokenRequestFieldClientSecret = big.NewInt(1 << 2)
+	refreshTokenRequestFieldRefreshToken = big.NewInt(1 << 3)
+	refreshTokenRequestFieldScope        = big.NewInt(1 << 4)
+)
 
 type RefreshTokenRequest struct {
 	XApiKey      string  `json:"-" url:"-"`
@@ -59,6 +106,9 @@ type RefreshTokenRequest struct {
 	Scope        *string `json:"scope,omitempty" url:"-"`
 	audience     string
 	grantType    string
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 }
 
 func (r *RefreshTokenRequest) Audience() string {
@@ -67,6 +117,38 @@ func (r *RefreshTokenRequest) Audience() string {
 
 func (r *RefreshTokenRequest) GrantType() string {
 	return r.grantType
+}
+
+func (r *RefreshTokenRequest) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *RefreshTokenRequest) SetXApiKey(xApiKey string) {
+	r.XApiKey = xApiKey
+	r.require(refreshTokenRequestFieldXApiKey)
+}
+
+func (r *RefreshTokenRequest) SetClientId(clientId string) {
+	r.ClientId = clientId
+	r.require(refreshTokenRequestFieldClientId)
+}
+
+func (r *RefreshTokenRequest) SetClientSecret(clientSecret string) {
+	r.ClientSecret = clientSecret
+	r.require(refreshTokenRequestFieldClientSecret)
+}
+
+func (r *RefreshTokenRequest) SetRefreshToken(refreshToken string) {
+	r.RefreshToken = refreshToken
+	r.require(refreshTokenRequestFieldRefreshToken)
+}
+
+func (r *RefreshTokenRequest) SetScope(scope *string) {
+	r.Scope = scope
+	r.require(refreshTokenRequestFieldScope)
 }
 
 func (r *RefreshTokenRequest) UnmarshalJSON(data []byte) error {
@@ -92,13 +174,22 @@ func (r *RefreshTokenRequest) MarshalJSON() ([]byte, error) {
 		Audience:  "https://api.example.com",
 		GrantType: "refresh_token",
 	}
-	return json.Marshal(marshaler)
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 // An OAuth token response.
+var (
+	tokenResponseFieldAccessToken  = big.NewInt(1 << 0)
+	tokenResponseFieldRefreshToken = big.NewInt(1 << 1)
+)
+
 type TokenResponse struct {
 	AccessToken  string  `json:"access_token" url:"access_token"`
 	RefreshToken *string `json:"refresh_token,omitempty" url:"refresh_token,omitempty"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -122,6 +213,23 @@ func (t *TokenResponse) GetExtraProperties() map[string]interface{} {
 	return t.extraProperties
 }
 
+func (t *TokenResponse) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *TokenResponse) SetAccessToken(accessToken string) {
+	t.AccessToken = accessToken
+	t.require(tokenResponseFieldAccessToken)
+}
+
+func (t *TokenResponse) SetRefreshToken(refreshToken *string) {
+	t.RefreshToken = refreshToken
+	t.require(tokenResponseFieldRefreshToken)
+}
+
 func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	type unmarshaler TokenResponse
 	var value unmarshaler
@@ -136,6 +244,17 @@ func (t *TokenResponse) UnmarshalJSON(data []byte) error {
 	t.extraProperties = extraProperties
 	t.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TokenResponse) MarshalJSON() ([]byte, error) {
+	type embed TokenResponse
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, t.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (t *TokenResponse) String() string {

--- a/seed/go-sdk/websocket-inferred-auth/internal/explicit_fields.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/websocket-inferred-auth/internal/explicit_fields_test.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/websocket-inferred-auth/realtime.go
+++ b/seed/go-sdk/websocket-inferred-auth/realtime.go
@@ -50,11 +50,15 @@ func (r *ReceiveEvent) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetAlpha sets the Alpha field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent) SetAlpha(alpha string) {
 	r.Alpha = alpha
 	r.require(receiveEventFieldAlpha)
 }
 
+// SetBeta sets the Beta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent) SetBeta(beta int) {
 	r.Beta = beta
 	r.require(receiveEventFieldBeta)
@@ -149,16 +153,22 @@ func (r *ReceiveEvent2) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetGamma sets the Gamma field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetGamma(gamma string) {
 	r.Gamma = gamma
 	r.require(receiveEvent2FieldGamma)
 }
 
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetDelta(delta int) {
 	r.Delta = delta
 	r.require(receiveEvent2FieldDelta)
 }
 
+// SetEpsilon sets the Epsilon field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
 	r.Epsilon = epsilon
 	r.require(receiveEvent2FieldEpsilon)
@@ -235,6 +245,8 @@ func (r *ReceiveEvent3) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetReceiveText3 sets the ReceiveText3 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
 	r.ReceiveText3 = receiveText3
 	r.require(receiveEvent3FieldReceiveText3)
@@ -320,11 +332,15 @@ func (s *SendEvent) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent) SetSendText(sendText string) {
 	s.SendText = sendText
 	s.require(sendEventFieldSendText)
 }
 
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent) SetSendParam(sendParam int) {
 	s.SendParam = sendParam
 	s.require(sendEventFieldSendParam)
@@ -410,11 +426,15 @@ func (s *SendEvent2) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText2 sets the SendText2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent2) SetSendText2(sendText2 string) {
 	s.SendText2 = sendText2
 	s.require(sendEvent2FieldSendText2)
 }
 
+// SetSendParam2 sets the SendParam2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
 	s.SendParam2 = sendParam2
 	s.require(sendEvent2FieldSendParam2)
@@ -500,11 +520,15 @@ func (r *ReceiveSnakeCase) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetReceiveText sets the ReceiveText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
 	r.ReceiveText = receiveText
 	r.require(receiveSnakeCaseFieldReceiveText)
 }
 
+// SetReceiveInt sets the ReceiveInt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
 	r.ReceiveInt = receiveInt
 	r.require(receiveSnakeCaseFieldReceiveInt)
@@ -590,11 +614,15 @@ func (s *SendSnakeCase) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendSnakeCase) SetSendText(sendText string) {
 	s.SendText = sendText
 	s.require(sendSnakeCaseFieldSendText)
 }
 
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendSnakeCase) SetSendParam(sendParam int) {
 	s.SendParam = sendParam
 	s.require(sendSnakeCaseFieldSendParam)

--- a/seed/go-sdk/websocket-inferred-auth/realtime.go
+++ b/seed/go-sdk/websocket-inferred-auth/realtime.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket-inferred-auth/fern/internal"
+	big "math/big"
+)
+
+var (
+	receiveEventFieldAlpha = big.NewInt(1 << 0)
+	receiveEventFieldBeta  = big.NewInt(1 << 1)
 )
 
 type ReceiveEvent struct {
 	Alpha string `json:"alpha" url:"alpha"`
 	Beta  int    `json:"beta" url:"beta"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (r *ReceiveEvent) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent) SetAlpha(alpha string) {
+	r.Alpha = alpha
+	r.require(receiveEventFieldAlpha)
+}
+
+func (r *ReceiveEvent) SetBeta(beta int) {
+	r.Beta = beta
+	r.require(receiveEventFieldBeta)
+}
+
 func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent
 	var value unmarshaler
@@ -50,6 +76,17 @@ func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -62,10 +99,19 @@ func (r *ReceiveEvent) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent2FieldGamma   = big.NewInt(1 << 0)
+	receiveEvent2FieldDelta   = big.NewInt(1 << 1)
+	receiveEvent2FieldEpsilon = big.NewInt(1 << 2)
+)
+
 type ReceiveEvent2 struct {
 	Gamma   string `json:"gamma" url:"gamma"`
 	Delta   int    `json:"delta" url:"delta"`
 	Epsilon bool   `json:"epsilon" url:"epsilon"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -96,6 +142,28 @@ func (r *ReceiveEvent2) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent2) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent2) SetGamma(gamma string) {
+	r.Gamma = gamma
+	r.require(receiveEvent2FieldGamma)
+}
+
+func (r *ReceiveEvent2) SetDelta(delta int) {
+	r.Delta = delta
+	r.require(receiveEvent2FieldDelta)
+}
+
+func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
+	r.Epsilon = epsilon
+	r.require(receiveEvent2FieldEpsilon)
+}
+
 func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent2
 	var value unmarshaler
@@ -112,6 +180,17 @@ func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent2) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent2) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -124,8 +203,15 @@ func (r *ReceiveEvent2) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent3FieldReceiveText3 = big.NewInt(1 << 0)
+)
+
 type ReceiveEvent3 struct {
 	ReceiveText3 string `json:"receiveText3" url:"receiveText3"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -140,6 +226,18 @@ func (r *ReceiveEvent3) GetReceiveText3() string {
 
 func (r *ReceiveEvent3) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ReceiveEvent3) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
+	r.ReceiveText3 = receiveText3
+	r.require(receiveEvent3FieldReceiveText3)
 }
 
 func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
@@ -158,6 +256,17 @@ func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent3) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent3
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent3) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -170,9 +279,17 @@ func (r *ReceiveEvent3) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendEventFieldSendText  = big.NewInt(1 << 0)
+	sendEventFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendEvent struct {
 	SendText  string `json:"sendText" url:"sendText"`
 	SendParam int    `json:"sendParam" url:"sendParam"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -196,6 +313,23 @@ func (s *SendEvent) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEvent) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendEventFieldSendText)
+}
+
+func (s *SendEvent) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendEventFieldSendParam)
+}
+
 func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent
 	var value unmarshaler
@@ -212,6 +346,17 @@ func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent) MarshalJSON() ([]byte, error) {
+	type embed SendEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -224,9 +369,17 @@ func (s *SendEvent) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	sendEvent2FieldSendText2  = big.NewInt(1 << 0)
+	sendEvent2FieldSendParam2 = big.NewInt(1 << 1)
+)
+
 type SendEvent2 struct {
 	SendText2  string `json:"sendText2" url:"sendText2"`
 	SendParam2 bool   `json:"sendParam2" url:"sendParam2"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -250,6 +403,23 @@ func (s *SendEvent2) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent2) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEvent2) SetSendText2(sendText2 string) {
+	s.SendText2 = sendText2
+	s.require(sendEvent2FieldSendText2)
+}
+
+func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
+	s.SendParam2 = sendParam2
+	s.require(sendEvent2FieldSendParam2)
+}
+
 func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent2
 	var value unmarshaler
@@ -266,6 +436,17 @@ func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent2) MarshalJSON() ([]byte, error) {
+	type embed SendEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent2) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -278,9 +459,17 @@ func (s *SendEvent2) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	receiveSnakeCaseFieldReceiveText = big.NewInt(1 << 0)
+	receiveSnakeCaseFieldReceiveInt  = big.NewInt(1 << 1)
+)
+
 type ReceiveSnakeCase struct {
 	ReceiveText string `json:"receive_text" url:"receive_text"`
 	ReceiveInt  int    `json:"receive_int" url:"receive_int"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -304,6 +493,23 @@ func (r *ReceiveSnakeCase) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveSnakeCase) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
+	r.ReceiveText = receiveText
+	r.require(receiveSnakeCaseFieldReceiveText)
+}
+
+func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
+	r.ReceiveInt = receiveInt
+	r.require(receiveSnakeCaseFieldReceiveInt)
+}
+
 func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveSnakeCase
 	var value unmarshaler
@@ -320,6 +526,17 @@ func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed ReceiveSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveSnakeCase) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -332,9 +549,17 @@ func (r *ReceiveSnakeCase) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendSnakeCaseFieldSendText  = big.NewInt(1 << 0)
+	sendSnakeCaseFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendSnakeCase struct {
 	SendText  string `json:"send_text" url:"send_text"`
 	SendParam int    `json:"send_param" url:"send_param"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -358,6 +583,23 @@ func (s *SendSnakeCase) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendSnakeCase) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendSnakeCase) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendSnakeCaseFieldSendText)
+}
+
+func (s *SendSnakeCase) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendSnakeCaseFieldSendParam)
+}
+
 func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendSnakeCase
 	var value unmarshaler
@@ -372,6 +614,17 @@ func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *SendSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed SendSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SendSnakeCase) String() string {

--- a/seed/go-sdk/websocket/internal/explicit_fields.go
+++ b/seed/go-sdk/websocket/internal/explicit_fields.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+)
+
+// HandleExplicitFields processes a struct to remove `omitempty` from
+// fields that have been explicitly set (as indicated by their corresponding bit in explicitFields).
+// Note that `marshaler` should be an embedded struct to avoid infinite recursion.
+// Returns an interface{} that can be passed to json.Marshal.
+func HandleExplicitFields(marshaler interface{}, explicitFields *big.Int) interface{} {
+	val := reflect.ValueOf(marshaler)
+	typ := reflect.TypeOf(marshaler)
+
+	// Handle pointer types
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+
+	// Only handle struct types
+	if val.Kind() != reflect.Struct {
+		return marshaler
+	}
+
+	// Handle embedded struct pattern
+	var sourceVal reflect.Value
+	var sourceType reflect.Type
+
+	// Check if this is an embedded struct pattern
+	if typ.NumField() == 1 && typ.Field(0).Anonymous {
+		// This is likely an embedded struct, get the embedded value
+		embeddedField := val.Field(0)
+		sourceVal = embeddedField
+		sourceType = embeddedField.Type()
+	} else {
+		// Regular struct
+		sourceVal = val
+		sourceType = typ
+	}
+
+	// If no explicit fields set, use standard marshaling
+	if explicitFields == nil || explicitFields.Sign() == 0 {
+		return marshaler
+	}
+
+	// Create a new struct type with modified tags
+	fields := make([]reflect.StructField, 0, sourceType.NumField())
+
+	for i := 0; i < sourceType.NumField(); i++ {
+		field := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !field.IsExported() || field.Name == "explicitFields" {
+			continue
+		}
+
+		// Check if this field has been explicitly set
+		fieldBit := big.NewInt(1)
+		fieldBit.Lsh(fieldBit, uint(i))
+		if big.NewInt(0).And(explicitFields, fieldBit).Sign() != 0 {
+			// Remove omitempty from the json tag
+			tag := field.Tag.Get("json")
+			if tag != "" && tag != "-" {
+				// Parse the json tag, remove omitempty from options
+				parts := strings.Split(tag, ",")
+				if len(parts) > 1 {
+					var newParts []string
+					newParts = append(newParts, parts[0]) // Keep the field name
+					for _, part := range parts[1:] {
+						if strings.TrimSpace(part) != "omitempty" {
+							newParts = append(newParts, part)
+						}
+					}
+					tag = strings.Join(newParts, ",")
+				}
+
+				// Reconstruct the struct tag
+				newTag := `json:"` + tag + `"`
+				if urlTag := field.Tag.Get("url"); urlTag != "" {
+					newTag += ` url:"` + urlTag + `"`
+				}
+
+				field.Tag = reflect.StructTag(newTag)
+			}
+		}
+
+		fields = append(fields, field)
+	}
+
+	// Create new struct type with modified tags
+	newType := reflect.StructOf(fields)
+	newVal := reflect.New(newType).Elem()
+
+	// Copy field values from original struct to new struct
+	fieldIndex := 0
+	for i := 0; i < sourceType.NumField(); i++ {
+		originalField := sourceType.Field(i)
+
+		// Skip unexported fields and the explicitFields field itself
+		if !originalField.IsExported() || originalField.Name == "explicitFields" {
+			continue
+		}
+
+		originalValue := sourceVal.Field(i)
+		newVal.Field(fieldIndex).Set(originalValue)
+		fieldIndex++
+	}
+
+	return newVal.Interface()
+}

--- a/seed/go-sdk/websocket/internal/explicit_fields_test.go
+++ b/seed/go-sdk/websocket/internal/explicit_fields_test.go
@@ -1,0 +1,356 @@
+package internal
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExplicitFieldsStruct struct {
+	Name           *string  `json:"name,omitempty"`
+	Code           *string  `json:"code,omitempty"`
+	Count          *int     `json:"count,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	unexported     string   `json:"-"`
+	explicitFields *big.Int `json:"-"`
+}
+
+var (
+	testFieldName    = big.NewInt(1 << 0)
+	testFieldCode    = big.NewInt(1 << 1)
+	testFieldCount   = big.NewInt(1 << 2)
+	testFieldEnabled = big.NewInt(1 << 3)
+	testFieldTags    = big.NewInt(1 << 4)
+)
+
+func (t *testExplicitFieldsStruct) require(field *big.Int) {
+	if t.explicitFields == nil {
+		t.explicitFields = big.NewInt(0)
+	}
+	t.explicitFields.Or(t.explicitFields, field)
+}
+
+func (t *testExplicitFieldsStruct) SetName(name *string) {
+	t.Name = name
+	t.require(testFieldName)
+}
+
+func (t *testExplicitFieldsStruct) SetCode(code *string) {
+	t.Code = code
+	t.require(testFieldCode)
+}
+
+func (t *testExplicitFieldsStruct) SetCount(count *int) {
+	t.Count = count
+	t.require(testFieldCount)
+}
+
+func (t *testExplicitFieldsStruct) SetEnabled(enabled *bool) {
+	t.Enabled = enabled
+	t.require(testFieldEnabled)
+}
+
+func (t *testExplicitFieldsStruct) SetTags(tags []string) {
+	t.Tags = tags
+	t.require(testFieldTags)
+}
+
+func (t *testExplicitFieldsStruct) MarshalJSON() ([]byte, error) {
+	type embed testExplicitFieldsStruct
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*t),
+	}
+	return json.Marshal(HandleExplicitFields(marshaler, t.explicitFields))
+}
+
+type testStructWithoutExplicitFields struct {
+	Name *string `json:"name,omitempty"`
+	Code *string `json:"code,omitempty"`
+}
+
+func TestHandleExplicitFields(t *testing.T) {
+	tests := []struct {
+		desc      string
+		giveInput interface{}
+		wantBytes []byte
+		wantError string
+	}{
+		{
+			desc:      "nil input",
+			giveInput: nil,
+			wantBytes: []byte(`null`),
+		},
+		{
+			desc:      "non-struct input",
+			giveInput: "string",
+			wantBytes: []byte(`"string"`),
+		},
+		{
+			desc:      "slice input",
+			giveInput: []string{"a", "b"},
+			wantBytes: []byte(`["a","b"]`),
+		},
+		{
+			desc:      "map input",
+			giveInput: map[string]interface{}{"key": "value"},
+			wantBytes: []byte(`{"key":"value"}`),
+		},
+		{
+			desc: "struct without explicitFields field",
+			giveInput: &testStructWithoutExplicitFields{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with no explicit fields set",
+			giveInput: &testExplicitFieldsStruct{
+				Name: stringPtr("test"),
+				Code: nil,
+			},
+			wantBytes: []byte(`{"name":"test"}`),
+		},
+		{
+			desc: "struct with explicit nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null}`),
+		},
+		{
+			desc: "struct with explicit non-nil field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("explicit"))
+				s.SetCode(stringPtr("also-explicit"))
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"explicit","code":"also-explicit"}`),
+		},
+		{
+			desc: "struct with mixed explicit and implicit fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name:  stringPtr("implicit"),
+					Count: intPtr(42),
+				}
+				s.SetCode(nil) // explicit nil
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"implicit","code":null,"count":42}`),
+		},
+		{
+			desc: "struct with multiple explicit nil fields",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Name: stringPtr("test"),
+				}
+				s.SetCode(nil)
+				s.SetCount(nil)
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":null}`),
+		},
+		{
+			desc: "struct with slice field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{
+					Tags: []string{"tag1", "tag2"},
+				}
+				s.SetTags(nil) // explicit nil slice
+				return s
+			}(),
+			wantBytes: []byte(`{"tags":null}`),
+		},
+		{
+			desc: "struct with boolean field",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetEnabled(boolPtr(false)) // explicit false
+				return s
+			}(),
+			wantBytes: []byte(`{"enabled":false}`),
+		},
+		{
+			desc: "struct with all fields explicit",
+			giveInput: func() *testExplicitFieldsStruct {
+				s := &testExplicitFieldsStruct{}
+				s.SetName(stringPtr("test"))
+				s.SetCode(nil)
+				s.SetCount(intPtr(0))
+				s.SetEnabled(boolPtr(false))
+				s.SetTags([]string{})
+				return s
+			}(),
+			wantBytes: []byte(`{"name":"test","code":null,"count":0,"enabled":false,"tags":[]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var explicitFields *big.Int
+			if s, ok := tt.giveInput.(*testExplicitFieldsStruct); ok {
+				explicitFields = s.explicitFields
+			}
+			bytes, err := json.Marshal(HandleExplicitFields(tt.giveInput, explicitFields))
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+				assert.Nil(t, tt.wantBytes)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, string(tt.wantBytes), string(bytes))
+
+			// Verify it's valid JSON
+			var value interface{}
+			require.NoError(t, json.Unmarshal(bytes, &value))
+		})
+	}
+}
+
+func TestHandleExplicitFieldsCustomMarshaler(t *testing.T) {
+	t.Run("custom marshaler with explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("custom marshaler with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		bytes, err := s.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsPointerHandling(t *testing.T) {
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *testExplicitFieldsStruct
+		bytes, err := json.Marshal(HandleExplicitFields(s, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`null`), bytes)
+	})
+
+	t.Run("pointer to struct", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+
+		bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":null}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsEmbeddedStruct(t *testing.T) {
+	t.Run("embedded struct with explicit fields", func(t *testing.T) {
+		// Create a struct similar to what MarshalJSON creates
+		s := &testExplicitFieldsStruct{}
+		s.SetName(nil)
+		s.SetCode(stringPtr("test-code"))
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include both explicit fields (name as null, code as "test-code")
+		assert.JSONEq(t, `{"name":null,"code":"test-code"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with no explicit fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Name: stringPtr("implicit"),
+			Code: stringPtr("also-implicit"),
+		}
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should only include non-nil fields (omitempty behavior)
+		assert.JSONEq(t, `{"name":"implicit","code":"also-implicit"}`, string(bytes))
+	})
+
+	t.Run("embedded struct with mixed fields", func(t *testing.T) {
+		s := &testExplicitFieldsStruct{
+			Count: intPtr(42), // implicit field
+		}
+		s.SetName(nil)        // explicit nil
+		s.SetCode(stringPtr("explicit")) // explicit value
+
+		type embed testExplicitFieldsStruct
+		var marshaler = struct {
+			embed
+		}{
+			embed: embed(*s),
+		}
+
+		bytes, err := json.Marshal(HandleExplicitFields(marshaler, s.explicitFields))
+		require.NoError(t, err)
+		// Should include explicit null, explicit value, and implicit value
+		assert.JSONEq(t, `{"name":null,"code":"explicit","count":42}`, string(bytes))
+	})
+}
+
+func TestHandleExplicitFieldsTagHandling(t *testing.T) {
+	type testStructWithComplexTags struct {
+		Field1         *string `json:"field1,omitempty" url:"field1,omitempty"`
+		Field2         *string `json:"field2,omitempty,string" url:"field2"`
+		Field3         *string `json:"-"`
+		Field4         *string `json:"field4"`
+		explicitFields *big.Int `json:"-"`
+	}
+
+	s := &testStructWithComplexTags{
+		Field1:         stringPtr("test1"),
+		Field4:         stringPtr("test4"),
+		explicitFields: big.NewInt(1), // Only first field is explicit
+	}
+
+	bytes, err := json.Marshal(HandleExplicitFields(s, s.explicitFields))
+	require.NoError(t, err)
+
+	// Field1 should have omitempty removed, Field2 should keep omitempty, Field4 should be included
+	assert.JSONEq(t, `{"field1":"test1","field4":"test4"}`, string(bytes))
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/seed/go-sdk/websocket/realtime.go
+++ b/seed/go-sdk/websocket/realtime.go
@@ -50,11 +50,15 @@ func (r *ReceiveEvent) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetAlpha sets the Alpha field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent) SetAlpha(alpha string) {
 	r.Alpha = alpha
 	r.require(receiveEventFieldAlpha)
 }
 
+// SetBeta sets the Beta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent) SetBeta(beta int) {
 	r.Beta = beta
 	r.require(receiveEventFieldBeta)
@@ -149,16 +153,22 @@ func (r *ReceiveEvent2) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetGamma sets the Gamma field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetGamma(gamma string) {
 	r.Gamma = gamma
 	r.require(receiveEvent2FieldGamma)
 }
 
+// SetDelta sets the Delta field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetDelta(delta int) {
 	r.Delta = delta
 	r.require(receiveEvent2FieldDelta)
 }
 
+// SetEpsilon sets the Epsilon field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
 	r.Epsilon = epsilon
 	r.require(receiveEvent2FieldEpsilon)
@@ -235,6 +245,8 @@ func (r *ReceiveEvent3) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetReceiveText3 sets the ReceiveText3 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
 	r.ReceiveText3 = receiveText3
 	r.require(receiveEvent3FieldReceiveText3)
@@ -320,11 +332,15 @@ func (s *SendEvent) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent) SetSendText(sendText string) {
 	s.SendText = sendText
 	s.require(sendEventFieldSendText)
 }
 
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent) SetSendParam(sendParam int) {
 	s.SendParam = sendParam
 	s.require(sendEventFieldSendParam)
@@ -410,11 +426,15 @@ func (s *SendEvent2) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText2 sets the SendText2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent2) SetSendText2(sendText2 string) {
 	s.SendText2 = sendText2
 	s.require(sendEvent2FieldSendText2)
 }
 
+// SetSendParam2 sets the SendParam2 field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
 	s.SendParam2 = sendParam2
 	s.require(sendEvent2FieldSendParam2)
@@ -500,11 +520,15 @@ func (r *ReceiveSnakeCase) require(field *big.Int) {
 	r.explicitFields.Or(r.explicitFields, field)
 }
 
+// SetReceiveText sets the ReceiveText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
 	r.ReceiveText = receiveText
 	r.require(receiveSnakeCaseFieldReceiveText)
 }
 
+// SetReceiveInt sets the ReceiveInt field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
 	r.ReceiveInt = receiveInt
 	r.require(receiveSnakeCaseFieldReceiveInt)
@@ -590,11 +614,15 @@ func (s *SendSnakeCase) require(field *big.Int) {
 	s.explicitFields.Or(s.explicitFields, field)
 }
 
+// SetSendText sets the SendText field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendSnakeCase) SetSendText(sendText string) {
 	s.SendText = sendText
 	s.require(sendSnakeCaseFieldSendText)
 }
 
+// SetSendParam sets the SendParam field and marks it as non-optional;
+// this prevents an empty or null value for this field from being omitted during serialization.
 func (s *SendSnakeCase) SetSendParam(sendParam int) {
 	s.SendParam = sendParam
 	s.require(sendSnakeCaseFieldSendParam)

--- a/seed/go-sdk/websocket/realtime.go
+++ b/seed/go-sdk/websocket/realtime.go
@@ -6,11 +6,20 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	internal "github.com/websocket/fern/internal"
+	big "math/big"
+)
+
+var (
+	receiveEventFieldAlpha = big.NewInt(1 << 0)
+	receiveEventFieldBeta  = big.NewInt(1 << 1)
 )
 
 type ReceiveEvent struct {
 	Alpha string `json:"alpha" url:"alpha"`
 	Beta  int    `json:"beta" url:"beta"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -34,6 +43,23 @@ func (r *ReceiveEvent) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent) SetAlpha(alpha string) {
+	r.Alpha = alpha
+	r.require(receiveEventFieldAlpha)
+}
+
+func (r *ReceiveEvent) SetBeta(beta int) {
+	r.Beta = beta
+	r.require(receiveEventFieldBeta)
+}
+
 func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent
 	var value unmarshaler
@@ -50,6 +76,17 @@ func (r *ReceiveEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -62,10 +99,19 @@ func (r *ReceiveEvent) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent2FieldGamma   = big.NewInt(1 << 0)
+	receiveEvent2FieldDelta   = big.NewInt(1 << 1)
+	receiveEvent2FieldEpsilon = big.NewInt(1 << 2)
+)
+
 type ReceiveEvent2 struct {
 	Gamma   string `json:"gamma" url:"gamma"`
 	Delta   int    `json:"delta" url:"delta"`
 	Epsilon bool   `json:"epsilon" url:"epsilon"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -96,6 +142,28 @@ func (r *ReceiveEvent2) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveEvent2) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent2) SetGamma(gamma string) {
+	r.Gamma = gamma
+	r.require(receiveEvent2FieldGamma)
+}
+
+func (r *ReceiveEvent2) SetDelta(delta int) {
+	r.Delta = delta
+	r.require(receiveEvent2FieldDelta)
+}
+
+func (r *ReceiveEvent2) SetEpsilon(epsilon bool) {
+	r.Epsilon = epsilon
+	r.require(receiveEvent2FieldEpsilon)
+}
+
 func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveEvent2
 	var value unmarshaler
@@ -112,6 +180,17 @@ func (r *ReceiveEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent2) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent2) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -124,8 +203,15 @@ func (r *ReceiveEvent2) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	receiveEvent3FieldReceiveText3 = big.NewInt(1 << 0)
+)
+
 type ReceiveEvent3 struct {
 	ReceiveText3 string `json:"receiveText3" url:"receiveText3"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -140,6 +226,18 @@ func (r *ReceiveEvent3) GetReceiveText3() string {
 
 func (r *ReceiveEvent3) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
+}
+
+func (r *ReceiveEvent3) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveEvent3) SetReceiveText3(receiveText3 string) {
+	r.ReceiveText3 = receiveText3
+	r.require(receiveEvent3FieldReceiveText3)
 }
 
 func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
@@ -158,6 +256,17 @@ func (r *ReceiveEvent3) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveEvent3) MarshalJSON() ([]byte, error) {
+	type embed ReceiveEvent3
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveEvent3) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -170,9 +279,17 @@ func (r *ReceiveEvent3) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendEventFieldSendText  = big.NewInt(1 << 0)
+	sendEventFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendEvent struct {
 	SendText  string `json:"sendText" url:"sendText"`
 	SendParam int    `json:"sendParam" url:"sendParam"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -196,6 +313,23 @@ func (s *SendEvent) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEvent) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendEventFieldSendText)
+}
+
+func (s *SendEvent) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendEventFieldSendParam)
+}
+
 func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent
 	var value unmarshaler
@@ -212,6 +346,17 @@ func (s *SendEvent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent) MarshalJSON() ([]byte, error) {
+	type embed SendEvent
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -224,9 +369,17 @@ func (s *SendEvent) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	sendEvent2FieldSendText2  = big.NewInt(1 << 0)
+	sendEvent2FieldSendParam2 = big.NewInt(1 << 1)
+)
+
 type SendEvent2 struct {
 	SendText2  string `json:"sendText2" url:"sendText2"`
 	SendParam2 bool   `json:"sendParam2" url:"sendParam2"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -250,6 +403,23 @@ func (s *SendEvent2) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendEvent2) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendEvent2) SetSendText2(sendText2 string) {
+	s.SendText2 = sendText2
+	s.require(sendEvent2FieldSendText2)
+}
+
+func (s *SendEvent2) SetSendParam2(sendParam2 bool) {
+	s.SendParam2 = sendParam2
+	s.require(sendEvent2FieldSendParam2)
+}
+
 func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendEvent2
 	var value unmarshaler
@@ -266,6 +436,17 @@ func (s *SendEvent2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *SendEvent2) MarshalJSON() ([]byte, error) {
+	type embed SendEvent2
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (s *SendEvent2) String() string {
 	if len(s.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(s.rawJSON); err == nil {
@@ -278,9 +459,17 @@ func (s *SendEvent2) String() string {
 	return fmt.Sprintf("%#v", s)
 }
 
+var (
+	receiveSnakeCaseFieldReceiveText = big.NewInt(1 << 0)
+	receiveSnakeCaseFieldReceiveInt  = big.NewInt(1 << 1)
+)
+
 type ReceiveSnakeCase struct {
 	ReceiveText string `json:"receive_text" url:"receive_text"`
 	ReceiveInt  int    `json:"receive_int" url:"receive_int"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -304,6 +493,23 @@ func (r *ReceiveSnakeCase) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
+func (r *ReceiveSnakeCase) require(field *big.Int) {
+	if r.explicitFields == nil {
+		r.explicitFields = big.NewInt(0)
+	}
+	r.explicitFields.Or(r.explicitFields, field)
+}
+
+func (r *ReceiveSnakeCase) SetReceiveText(receiveText string) {
+	r.ReceiveText = receiveText
+	r.require(receiveSnakeCaseFieldReceiveText)
+}
+
+func (r *ReceiveSnakeCase) SetReceiveInt(receiveInt int) {
+	r.ReceiveInt = receiveInt
+	r.require(receiveSnakeCaseFieldReceiveInt)
+}
+
 func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler ReceiveSnakeCase
 	var value unmarshaler
@@ -320,6 +526,17 @@ func (r *ReceiveSnakeCase) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *ReceiveSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed ReceiveSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*r),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, r.explicitFields)
+	return json.Marshal(explicitMarshaler)
+}
+
 func (r *ReceiveSnakeCase) String() string {
 	if len(r.rawJSON) > 0 {
 		if value, err := internal.StringifyJSON(r.rawJSON); err == nil {
@@ -332,9 +549,17 @@ func (r *ReceiveSnakeCase) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
+var (
+	sendSnakeCaseFieldSendText  = big.NewInt(1 << 0)
+	sendSnakeCaseFieldSendParam = big.NewInt(1 << 1)
+)
+
 type SendSnakeCase struct {
 	SendText  string `json:"send_text" url:"send_text"`
 	SendParam int    `json:"send_param" url:"send_param"`
+
+	// Private bitmask of fields set to an explicit value and therefore not to be omitted
+	explicitFields *big.Int `json:"-" url:"-"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -358,6 +583,23 @@ func (s *SendSnakeCase) GetExtraProperties() map[string]interface{} {
 	return s.extraProperties
 }
 
+func (s *SendSnakeCase) require(field *big.Int) {
+	if s.explicitFields == nil {
+		s.explicitFields = big.NewInt(0)
+	}
+	s.explicitFields.Or(s.explicitFields, field)
+}
+
+func (s *SendSnakeCase) SetSendText(sendText string) {
+	s.SendText = sendText
+	s.require(sendSnakeCaseFieldSendText)
+}
+
+func (s *SendSnakeCase) SetSendParam(sendParam int) {
+	s.SendParam = sendParam
+	s.require(sendSnakeCaseFieldSendParam)
+}
+
 func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	type unmarshaler SendSnakeCase
 	var value unmarshaler
@@ -372,6 +614,17 @@ func (s *SendSnakeCase) UnmarshalJSON(data []byte) error {
 	s.extraProperties = extraProperties
 	s.rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (s *SendSnakeCase) MarshalJSON() ([]byte, error) {
+	type embed SendSnakeCase
+	var marshaler = struct {
+		embed
+	}{
+		embed: embed(*s),
+	}
+	explicitMarshaler := internal.HandleExplicitFields(marshaler, s.explicitFields)
+	return json.Marshal(explicitMarshaler)
 }
 
 func (s *SendSnakeCase) String() string {


### PR DESCRIPTION
## Description
Linear ticket: Fixes FER-3852, Fixes FER-6561
Adds setter methods for every object. These setters also mark a bitfield that keeps track of which fields have been set; just before serialization, these fields are made non-optional (i.e. `omitempty` is removed) which allows users to pass explicit null even when the argument is originally marked optional.

## Changes Made
Changes to the `v1` side of the generator; addition of two as-is files, `explicit_fields.go` and `explicit_fields_test.go`, that handle preprocessing of structs to un-optionalize any optional arguments that have been explicitly set to some value.

## Testing
Tested against Auth0's API and against all fixtures (hence this PR being completely massive; it adds about 400 lines of as-is Go to every fixture, for starters).
- [X] Unit tests added/updated
- [X] Manual testing completed
