### PR TITLE
fix(ci): move tests to run after merge since they require org secrets that can…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
 
   live-test-dev:
     environment: Fern Dev
-    if: github.repository == 'fern-api/fern'
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -163,7 +163,7 @@ jobs:
 
   generate-docs-test-windows:
     environment: Fern Dev
-    if: ${{ github.repository == 'fern-api/fern' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' }}
     runs-on: windows-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary
The following tests have been failing consistently on PR's for our external contributor @iamnamananand996:
1. [live-test-dev](https://github.com/fern-api/fern/actions/runs/17761752863/job/50475900682?pr=9315)
2. [generate-docs-test-windows](https://github.com/fern-api/fern/actions/runs/17761752863/job/50475900675?pr=9315)

After some investigation the reason I came up with is because those test jobs require access to the Github Organization Secret "FERN_ORG_TOKEN_DEV" to run properly. But since Naman is not member of our Github organization any workflows initiated by him will NOT pull these secrets and therefore will fail due to authentication errors. I believe this is a security measure to prevent malicious changes to workflows from leaking secrets.

From the Organization Secrets page:

> Anyone with collaborator access to the repositories with access to a secret or variable can use it for Actions. They are not passed to workflows that are triggered by a pull request from a fork.

The quick fix is to move these to run AFTER the PR is merged along with some of the other tests