### PR TITLE
fix(python): Generator no longer fails on failed generator-cli installation

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.28.5
+  changelogEntry:
+    - summary: |
+        Generator no longer fails on failed generator-cli installation
+      type: fix
+  createdAt: "2025-09-16"
+  irVersion: 59
+
 - version: 4.28.4
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generator_cli/generator_cli.py
+++ b/generators/python/src/fern_python/generator_cli/generator_cli.py
@@ -123,8 +123,18 @@ class GeneratorCli:
         )
 
     def _install(self) -> None:
-        self._run_command(command=["npm", "install", "-f", "-g", GENERATOR_CLI_NPM_PACKAGE])
-        version = self._run_command([GENERATOR_CLI, "--version"])
+        try:
+            self._run_command(command=["npm", "install", "-f", "-g", GENERATOR_CLI_NPM_PACKAGE])
+        except Exception as e:
+            self._debug_log(message=f"Failed to install {GENERATOR_CLI_NPM_PACKAGE} due to error: {e}")
+
+        try:
+            version = self._run_command([GENERATOR_CLI, "--version"])
+        except Exception as e:
+            _err_msg = f"Failed to get version of {GENERATOR_CLI_NPM_PACKAGE} due to error: {e}"
+            self._debug_log(message=_err_msg)
+            raise Exception(_err_msg)
+
         self._debug_log(message=f"Successfully installed {GENERATOR_CLI_NPM_PACKAGE} version {version}")
         self._installed = True
 


### PR DESCRIPTION
## Description
Generator doesn't need to fail on generator-cli installation because we pre-load it into the docker image.

## Testing
- [ ] Manual testing completed
