### PR TITLE
chore(ruby): Clean up calls to resolve the root module name.

### DIFF
--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -59,9 +59,13 @@ export abstract class AbstractRubyGeneratorContext<
         });
     }
 
+    public getRootModuleName(): string {
+        return capitalize(this.getRootFolderName());
+    }
+
     public getRootModule(): ruby.Module_ {
         return ruby.module({
-            name: capitalize(this.getRootFolderName()),
+            name: this.getRootModuleName(),
             statements: []
         });
     }

--- a/generators/ruby-v2/base/src/project/RubyProject.ts
+++ b/generators/ruby-v2/base/src/project/RubyProject.ts
@@ -201,7 +201,7 @@ class GemspecFile {
 
     public async toString(): Promise<string> {
         const moduleFolderName = this.context.getRootFolderName();
-        const moduleName = this.context.getRootModule().name;
+        const moduleName = this.context.getRootModuleName();
 
         return dedent`
             # frozen_string_literal: true
@@ -262,7 +262,7 @@ class CustomGemspecFile {
     }
 
     public async toString(): Promise<string> {
-        const moduleName = this.context.getRootModule().name;
+        const moduleName = this.context.getRootModuleName();
 
         return dedent`
             # frozen_string_literal: true
@@ -436,7 +436,7 @@ class VersionFile {
     }
 
     public toString(): string {
-        const seedName = this.context.getRootModule().name;
+        const seedName = this.context.getRootModuleName();
         const version = this.context.getVersionFromConfig();
 
         return dedent`

--- a/generators/ruby-v2/model/src/ModelGeneratorContext.ts
+++ b/generators/ruby-v2/model/src/ModelGeneratorContext.ts
@@ -35,7 +35,7 @@ export class ModelGeneratorContext extends AbstractRubyGeneratorContext<ModelCus
 
     public getModuleNamesForTypeId(typeId: TypeId): string[] {
         const typeDeclaration = this.getTypeDeclarationOrThrow(typeId);
-        return [this.getRootModule().name, ...this.pascalNames(typeDeclaration), this.getTypesModule().name];
+        return [this.getRootModuleName(), ...this.pascalNames(typeDeclaration), this.getTypesModule().name];
     }
 
     public getModulesForTypeId(typeId: TypeId): ruby.Module_[] {

--- a/generators/ruby-v2/model/src/enum/EnumGenerator.ts
+++ b/generators/ruby-v2/model/src/enum/EnumGenerator.ts
@@ -27,7 +27,7 @@ export class EnumGenerator extends FileGenerator<RubyFile, ModelCustomConfigSche
         const enumModule = ruby.module({
             name: this.typeDeclaration.name.name.pascalCase.safeName
         });
-        enumModule.addStatement(ruby.codeblock(`extend ${this.context.getRootModule().name}::Internal::Types::Enum`));
+        enumModule.addStatement(ruby.codeblock(`extend ${this.context.getRootModuleName()}::Internal::Types::Enum`));
 
         for (const enumValue of this.enumDeclaration.values) {
             enumModule.addStatement(

--- a/generators/ruby-v2/model/src/union/UnionGenerator.ts
+++ b/generators/ruby-v2/model/src/union/UnionGenerator.ts
@@ -40,7 +40,7 @@ export class UnionGenerator extends FileGenerator<RubyFile, ModelCustomConfigSch
             superclass: this.context.getModelClassReference(),
             docstring: this.typeDeclaration.docs ?? undefined
         });
-        classNode.addStatement(ruby.codeblock(`extend ${this.context.getRootModule().name}::Internal::Types::Union`));
+        classNode.addStatement(ruby.codeblock(`extend ${this.context.getRootModuleName()}::Internal::Types::Union`));
 
         classNode.addStatement(
             ruby.codeblock((writer) => {

--- a/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorContext.ts
@@ -79,7 +79,7 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
 
     public getModuleNamesForTypeId(typeId: TypeId): string[] {
         const typeDeclaration = this.getTypeDeclarationOrThrow(typeId);
-        return [this.getRootModule().name, ...this.pascalNames(typeDeclaration), this.getTypesModule().name];
+        return [this.getRootModuleName(), ...this.pascalNames(typeDeclaration), this.getTypesModule().name];
     }
 
     public getModulesForTypeId(typeId: TypeId): ruby.Module_[] {
@@ -146,7 +146,7 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
     public getRawClientClassReference(): ClassReference {
         return ruby.classReference({
             name: "RawClient",
-            modules: [this.getRootModule().name, "Internal", "Http"],
+            modules: [this.getRootModuleName(), "Internal", "Http"],
             fullyQualified: true
         });
     }
@@ -154,7 +154,7 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
     public getEnvironmentsClassReference(): ruby.ClassReference {
         return ruby.classReference({
             name: "Environment",
-            modules: [this.getRootModule().name]
+            modules: [this.getRootModuleName()]
         });
     }
 
@@ -176,7 +176,7 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
         // Return the class reference, performing the same casing as the SingleUrlEnvironmentGenerator
         return ruby.classReference({
             name: defaultEnvironment.name.screamingSnakeCase.safeName,
-            modules: [this.getRootModule().name, "Environment"]
+            modules: [this.getRootModuleName(), "Environment"]
         });
     }
 
@@ -187,14 +187,14 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
     public getReferenceToInternalJSONRequest(): ruby.ClassReference {
         return ruby.classReference({
             name: "Request",
-            modules: [this.getRootModule().name, "Internal", "JSON"]
+            modules: [this.getRootModuleName(), "Internal", "JSON"]
         });
     }
 
     public getReferenceToInternalMultipartRequest(): ruby.ClassReference {
         return ruby.classReference({
             name: "Request",
-            modules: [this.getRootModule().name, "Internal", "Multipart"]
+            modules: [this.getRootModuleName(), "Internal", "Multipart"]
         });
     }
 
@@ -203,7 +203,7 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
         return ruby.classReference({
             name: typeDeclaration.name.name.pascalCase.safeName,
             modules: [
-                this.getRootModule().name,
+                this.getRootModuleName(),
                 ...typeDeclaration.name.fernFilepath.allParts.map((path) => path.pascalCase.safeName),
                 "Types"
             ]
@@ -212,7 +212,7 @@ export class SdkGeneratorContext extends AbstractRubyGeneratorContext<SdkCustomC
 
     public getModuleNamesForServiceId(serviceId: ServiceId): string[] {
         return [
-            this.getRootModule().name,
+            this.getRootModuleName(),
             ...this.getSubpackageForServiceId(serviceId).fernFilepath.allParts.map((part) => part.pascalCase.safeName),
             this.getTypesModule().name
         ];

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -86,7 +86,7 @@ export class HttpEndpointGenerator {
                         body: ruby.raise({
                             errorClass: ruby.classReference({
                                 name: "TimeoutError",
-                                modules: [this.context.getRootModule().name, "Errors"]
+                                modules: [this.context.getRootModuleName(), "Errors"]
                             })
                         })
                     }
@@ -120,7 +120,7 @@ export class HttpEndpointGenerator {
                     ]
                 },
                 elseBody: ruby.codeblock((writer) => {
-                    const rootModuleName = this.context.getRootModule().name;
+                    const rootModuleName = this.context.getRootModuleName();
                     writer.writeLine(
                         `${ERROR_CLASS_VN} = ${rootModuleName}::Errors::ResponseError.subclass_for_code(${CODE_VN})`
                     );

--- a/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -43,7 +43,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
                 ? this.context.ir.readmeConfig.defaultEndpoint
                 : this.getDefaultEndpointId();
         this.rootPackageName = this.context.getRootFolderName();
-        this.rootPackageClientName = this.context.getRootModule().name;
+        this.rootPackageClientName = this.context.getRootModuleName();
     }
 
     public buildReadmeSnippetsByFeatureId(): Record<FernGeneratorCli.FeatureId, string[]> {

--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -70,7 +70,7 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
             returnType: ruby.Type.class_(
                 ruby.classReference({
                     name: "Client",
-                    modules: [this.context.getRootModule().name],
+                    modules: [this.context.getRootModuleName()],
                     fullyQualified: true
                 })
             )

--- a/generators/ruby-v2/sdk/src/subpackage-client/SubPackageClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/subpackage-client/SubPackageClientGenerator.ts
@@ -82,7 +82,7 @@ export class SubPackageClientGenerator extends FileGenerator<RubyFile, SdkCustom
 
     private getClientModuleNames(): string[] {
         return [
-            this.context.getRootModule().name,
+            this.context.getRootModuleName(),
             ...this.subpackage.fernFilepath.allParts.map((path) => path.pascalCase.safeName)
         ];
     }
@@ -95,7 +95,7 @@ export class SubPackageClientGenerator extends FileGenerator<RubyFile, SdkCustom
         return ruby.classReference({
             name: CLIENT_CLASS_NAME,
             modules: [
-                this.context.getRootModule().name,
+                this.context.getRootModuleName(),
                 ...this.subpackage.fernFilepath.allParts.map((path) => path.pascalCase.safeName)
             ],
             fullyQualified: true


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Minor refactoring. We shouldn't need to instantiate an AST node and throw it away every time we want to look up the root module name (which it turns out we want to do a lot).

## Testing
<!-- Describe how you tested these changes -->
- No behavioral changes - relying on typechecking and existing tests.
