### PR TITLE
chore(typescript): update retrier strategy

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.12.3
+  changelogEntry:
+    - summary: Updated retry strategy; in particular, don't jitter for `retry-after` header.
+      type: chore
+  createdAt: "2025-09-17"
+  irVersion: 60
+
 - version: 2.12.2
   changelogEntry:
     - summary: Generate correct types for pagination with inline types.
@@ -25,7 +32,7 @@
 - version: 2.11.2
   changelogEntry:
     - summary: |
-        Websocket client generation compiles when there are no query parameters and when the auth 
+        Websocket client generation compiles when there are no query parameters and when the auth
         scheme has custom authentication headers.
       type: fix
 
@@ -35,7 +42,7 @@
 - version: 2.11.1
   changelogEntry:
     - summary: |
-        The `_getAuthorizationHeader` method now returns `Promise<string | undefined>` when oauth is enabled. 
+        The `_getAuthorizationHeader` method now returns `Promise<string | undefined>` when oauth is enabled.
         This prevents compilation errors in the TypeScript SDK.
       type: fix
   createdAt: "2025-09-15"

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
@@ -21,7 +21,7 @@ function getRetryDelayFromHeaders(response: Response, retryAttempt: number): num
     if (retryAfter) {
         // Parse as number of seconds...
         const retryAfterSeconds = parseInt(retryAfter, 10);
-		if (!isNaN(retryAfterSeconds) && retryAfterSeconds > 0) {
+        if (!isNaN(retryAfterSeconds) && retryAfterSeconds > 0) {
             return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
         }
 
@@ -29,9 +29,9 @@ function getRetryDelayFromHeaders(response: Response, retryAttempt: number): num
         const retryAfterDate = new Date(retryAfter);
         if (!isNaN(retryAfterDate.getTime())) {
             const delay = retryAfterDate.getTime() - Date.now();
-			if (delay > 0) {
-				return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
-			}
+            if (delay > 0) {
+                return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+            }
         }
     }
 

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
@@ -1,22 +1,27 @@
 const INITIAL_RETRY_DELAY = 1000; // in milliseconds
 const MAX_RETRY_DELAY = 60000; // in milliseconds
 const DEFAULT_MAX_RETRIES = 2;
-const JITTER_FACTOR = 0.2; // 20% random jitter
+const JITTER_FACTOR = 0.25; // 20% random jitter
 
-function addJitter(delay: number): number {
+function addPositiveJitter(delay: number): number {
+    // Generate a random value between 0 and +JITTER_FACTOR
+    const jitterMultiplier = 1 + Math.random() * JITTER_FACTOR;
+    return delay * jitterMultiplier;
+}
+
+function addSymmetricJitter(delay: number): number {
     // Generate a random value between -JITTER_FACTOR and +JITTER_FACTOR
     const jitterMultiplier = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
     return delay * jitterMultiplier;
 }
 
 function getRetryDelayFromHeaders(response: Response, retryAttempt: number): number {
-    // Check for Retry-After header first (RFC 7231)
+    // Check for Retry-After header first (RFC 7231), with no jitter
     const retryAfter = response.headers.get("Retry-After");
     if (retryAfter) {
         // Parse as number of seconds...
         const retryAfterSeconds = parseInt(retryAfter, 10);
-        if (!isNaN(retryAfterSeconds)) {
-            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+		if (!isNaN(retryAfterSeconds) && retryAfterSeconds > 0) {
             return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
         }
 
@@ -24,11 +29,13 @@ function getRetryDelayFromHeaders(response: Response, retryAttempt: number): num
         const retryAfterDate = new Date(retryAfter);
         if (!isNaN(retryAfterDate.getTime())) {
             const delay = retryAfterDate.getTime() - Date.now();
-            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+			if (delay > 0) {
+				return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+			}
         }
     }
 
-    // Then check for industry-standard X-RateLimit-Reset header
+    // Then check for industry-standard X-RateLimit-Reset header, with positive jitter
     const rateLimitReset = response.headers.get("X-RateLimit-Reset");
     if (rateLimitReset) {
         const resetTime = parseInt(rateLimitReset, 10);
@@ -36,13 +43,13 @@ function getRetryDelayFromHeaders(response: Response, retryAttempt: number): num
             // Assume Unix timestamp in epoch seconds
             const delay = resetTime * 1000 - Date.now();
             if (delay > 0) {
-                return Math.min(delay, MAX_RETRY_DELAY);
+                return addPositiveJitter(Math.min(delay, MAX_RETRY_DELAY));
             }
         }
     }
 
-    // Fall back to exponential backoff
-    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+    // Fall back to exponential backoff, with symmetric jitter
+    return addSymmetricJitter(Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY));
 }
 
 export async function requestWithRetries(
@@ -53,13 +60,10 @@ export async function requestWithRetries(
 
     for (let i = 0; i < maxRetries; ++i) {
         if ([408, 429].includes(response.status) || response.status >= 500) {
-            // Get delay from headers or fall back to exponential backoff
-            const baseDelay = getRetryDelayFromHeaders(response, i);
+            // Get delay with appropriate jitter applied
+            const delay = getRetryDelayFromHeaders(response, i);
 
-            // Add jitter to the delay
-            const delayWithJitter = addJitter(baseDelay);
-
-            await new Promise((resolve) => setTimeout(resolve, delayWithJitter));
+            await new Promise((resolve) => setTimeout(resolve, delay));
             response = await requestFn();
         } else {
             break;

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/requestWithRetries.ts
@@ -1,7 +1,7 @@
 const INITIAL_RETRY_DELAY = 1000; // in milliseconds
 const MAX_RETRY_DELAY = 60000; // in milliseconds
 const DEFAULT_MAX_RETRIES = 2;
-const JITTER_FACTOR = 0.25; // 20% random jitter
+const JITTER_FACTOR = 0.2; // 20% random jitter
 
 function addPositiveJitter(delay: number): number {
     // Generate a random value between 0 and +JITTER_FACTOR
@@ -10,8 +10,8 @@ function addPositiveJitter(delay: number): number {
 }
 
 function addSymmetricJitter(delay: number): number {
-    // Generate a random value between -JITTER_FACTOR and +JITTER_FACTOR
-    const jitterMultiplier = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
+    // Generate a random value in a JITTER_FACTOR-sized percentage range around delay
+    const jitterMultiplier = 1 + (Math.random() - 0.5) * JITTER_FACTOR;
     return delay * jitterMultiplier;
 }
 

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/alias/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/any-auth/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/any-auth/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/client-side-params/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/custom-auth/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/custom-auth/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/empty-clients/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/enum/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/enum/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/errors/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/errors/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/bundle/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/bundle/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/jsr/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/jsr/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/requestWithRetries.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/fetcher/requestWithRetries.js
@@ -14,29 +14,35 @@ const INITIAL_RETRY_DELAY = 1000; // in milliseconds
 const MAX_RETRY_DELAY = 60000; // in milliseconds
 const DEFAULT_MAX_RETRIES = 2;
 const JITTER_FACTOR = 0.2; // 20% random jitter
-function addJitter(delay) {
-    // Generate a random value between -JITTER_FACTOR and +JITTER_FACTOR
-    const jitterMultiplier = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
+function addPositiveJitter(delay) {
+    // Generate a random value between 0 and +JITTER_FACTOR
+    const jitterMultiplier = 1 + Math.random() * JITTER_FACTOR;
+    return delay * jitterMultiplier;
+}
+function addSymmetricJitter(delay) {
+    // Generate a random value in a JITTER_FACTOR-sized percentage range around delay
+    const jitterMultiplier = 1 + (Math.random() - 0.5) * JITTER_FACTOR;
     return delay * jitterMultiplier;
 }
 function getRetryDelayFromHeaders(response, retryAttempt) {
-    // Check for Retry-After header first (RFC 7231)
+    // Check for Retry-After header first (RFC 7231), with no jitter
     const retryAfter = response.headers.get("Retry-After");
     if (retryAfter) {
         // Parse as number of seconds...
         const retryAfterSeconds = parseInt(retryAfter, 10);
-        if (!isNaN(retryAfterSeconds)) {
-            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+        if (!isNaN(retryAfterSeconds) && retryAfterSeconds > 0) {
             return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
         }
         // ...or as an HTTP date; both are valid
         const retryAfterDate = new Date(retryAfter);
         if (!isNaN(retryAfterDate.getTime())) {
             const delay = retryAfterDate.getTime() - Date.now();
-            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+            if (delay > 0) {
+                return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+            }
         }
     }
-    // Then check for industry-standard X-RateLimit-Reset header
+    // Then check for industry-standard X-RateLimit-Reset header, with positive jitter
     const rateLimitReset = response.headers.get("X-RateLimit-Reset");
     if (rateLimitReset) {
         const resetTime = parseInt(rateLimitReset, 10);
@@ -44,23 +50,21 @@ function getRetryDelayFromHeaders(response, retryAttempt) {
             // Assume Unix timestamp in epoch seconds
             const delay = resetTime * 1000 - Date.now();
             if (delay > 0) {
-                return Math.min(delay, MAX_RETRY_DELAY);
+                return addPositiveJitter(Math.min(delay, MAX_RETRY_DELAY));
             }
         }
     }
-    // Fall back to exponential backoff
-    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+    // Fall back to exponential backoff, with symmetric jitter
+    return addSymmetricJitter(Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY));
 }
 function requestWithRetries(requestFn_1) {
     return __awaiter(this, arguments, void 0, function* (requestFn, maxRetries = DEFAULT_MAX_RETRIES) {
         let response = yield requestFn();
         for (let i = 0; i < maxRetries; ++i) {
             if ([408, 429].includes(response.status) || response.status >= 500) {
-                // Get delay from headers or fall back to exponential backoff
-                const baseDelay = getRetryDelayFromHeaders(response, i);
-                // Add jitter to the delay
-                const delayWithJitter = addJitter(baseDelay);
-                yield new Promise((resolve) => setTimeout(resolve, delayWithJitter));
+                // Get delay with appropriate jitter applied
+                const delay = getRetryDelayFromHeaders(response, i);
+                yield new Promise((resolve) => setTimeout(resolve, delay));
                 response = yield requestFn();
             }
             else {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/requestWithRetries.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/fetcher/requestWithRetries.mjs
@@ -11,29 +11,35 @@ const INITIAL_RETRY_DELAY = 1000; // in milliseconds
 const MAX_RETRY_DELAY = 60000; // in milliseconds
 const DEFAULT_MAX_RETRIES = 2;
 const JITTER_FACTOR = 0.2; // 20% random jitter
-function addJitter(delay) {
-    // Generate a random value between -JITTER_FACTOR and +JITTER_FACTOR
-    const jitterMultiplier = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
+function addPositiveJitter(delay) {
+    // Generate a random value between 0 and +JITTER_FACTOR
+    const jitterMultiplier = 1 + Math.random() * JITTER_FACTOR;
+    return delay * jitterMultiplier;
+}
+function addSymmetricJitter(delay) {
+    // Generate a random value in a JITTER_FACTOR-sized percentage range around delay
+    const jitterMultiplier = 1 + (Math.random() - 0.5) * JITTER_FACTOR;
     return delay * jitterMultiplier;
 }
 function getRetryDelayFromHeaders(response, retryAttempt) {
-    // Check for Retry-After header first (RFC 7231)
+    // Check for Retry-After header first (RFC 7231), with no jitter
     const retryAfter = response.headers.get("Retry-After");
     if (retryAfter) {
         // Parse as number of seconds...
         const retryAfterSeconds = parseInt(retryAfter, 10);
-        if (!isNaN(retryAfterSeconds)) {
-            // Convert seconds to milliseconds and cap at MAX_RETRY_DELAY
+        if (!isNaN(retryAfterSeconds) && retryAfterSeconds > 0) {
             return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY);
         }
         // ...or as an HTTP date; both are valid
         const retryAfterDate = new Date(retryAfter);
         if (!isNaN(retryAfterDate.getTime())) {
             const delay = retryAfterDate.getTime() - Date.now();
-            return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+            if (delay > 0) {
+                return Math.min(Math.max(delay, 0), MAX_RETRY_DELAY);
+            }
         }
     }
-    // Then check for industry-standard X-RateLimit-Reset header
+    // Then check for industry-standard X-RateLimit-Reset header, with positive jitter
     const rateLimitReset = response.headers.get("X-RateLimit-Reset");
     if (rateLimitReset) {
         const resetTime = parseInt(rateLimitReset, 10);
@@ -41,23 +47,21 @@ function getRetryDelayFromHeaders(response, retryAttempt) {
             // Assume Unix timestamp in epoch seconds
             const delay = resetTime * 1000 - Date.now();
             if (delay > 0) {
-                return Math.min(delay, MAX_RETRY_DELAY);
+                return addPositiveJitter(Math.min(delay, MAX_RETRY_DELAY));
             }
         }
     }
-    // Fall back to exponential backoff
-    return Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY);
+    // Fall back to exponential backoff, with symmetric jitter
+    return addSymmetricJitter(Math.min(INITIAL_RETRY_DELAY * Math.pow(2, retryAttempt), MAX_RETRY_DELAY));
 }
 export function requestWithRetries(requestFn_1) {
     return __awaiter(this, arguments, void 0, function* (requestFn, maxRetries = DEFAULT_MAX_RETRIES) {
         let response = yield requestFn();
         for (let i = 0; i < maxRetries; ++i) {
             if ([408, 429].includes(response.status) || response.status >= 500) {
-                // Get delay from headers or fall back to exponential backoff
-                const baseDelay = getRetryDelayFromHeaders(response, i);
-                // Add jitter to the delay
-                const delayWithJitter = addJitter(baseDelay);
-                yield new Promise((resolve) => setTimeout(resolve, delayWithJitter));
+                // Get delay with appropriate jitter applied
+                const delay = getRetryDelayFromHeaders(response, i);
+                yield new Promise((resolve) => setTimeout(resolve, delay));
                 response = yield requestFn();
             }
             else {

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/use-pnpm/pnpm-lock.yaml
+++ b/seed/ts-sdk/exhaustive/use-pnpm/pnpm-lock.yaml
@@ -579,8 +579,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.4:
-    resolution: {integrity: sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==}
+  baseline-browser-mapping@2.8.5:
+    resolution: {integrity: sha512-TiU4qUT9jdCuh4aVOG7H1QozyeI2sZRqoRPdqBIaslfNt4WUSanRBueAwl2x5jt4rXBMim3lIN2x6yT8PDi24Q==}
     hasBin: true
 
   brace-expansion@1.1.12:
@@ -750,8 +750,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.219:
-    resolution: {integrity: sha512-JqaXfxHOS0WvKweEnrPHWRm8cnPVbdB7vXCQHPPFoAJFM3xig5/+/H08ZVkvJf4unvj8yncKy6MerOPj1NW1GQ==}
+  electron-to-chromium@1.5.220:
+    resolution: {integrity: sha512-TWXijEwR1ggr4BdAKrb1nMNqYLTx1/4aD1fkeZU+FVJGTKu53/T7UyHKXlqEX3Ub02csyHePbHmkvnrjcaYzMA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -2529,7 +2529,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.4: {}
+  baseline-browser-mapping@2.8.5: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -2542,9 +2542,9 @@ snapshots:
 
   browserslist@4.26.2:
     dependencies:
-      baseline-browser-mapping: 2.8.4
+      baseline-browser-mapping: 2.8.5
       caniuse-lite: 1.0.30001743
-      electron-to-chromium: 1.5.219
+      electron-to-chromium: 1.5.220
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
@@ -2675,7 +2675,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.219: {}
+  electron-to-chromium@1.5.220: {}
 
   emittery@0.13.1: {}
 

--- a/seed/ts-sdk/exhaustive/use-pnpm/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/use-pnpm/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/extends/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-download/stream/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-download/stream/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-download/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-download/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/folders/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/noScripts/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/license/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/literal/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/literals-unions/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/literals-unions/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/nullable-optional/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/nullable-optional/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/object/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/optional/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/pagination/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/pagination/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/path-parameters/default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/query-parameters-openapi/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/query-parameters/serde-layer-query/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/simple-api/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-api/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/streaming/no-serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming/no-serde-layer/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/trace/serde-trace/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/trace/serde-trace/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/unions/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/unions/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/validation/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/variables/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/version/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/requestWithRetries.test.ts
@@ -201,11 +201,11 @@ describe("requestWithRetries", () => {
         await jest.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 


### PR DESCRIPTION
## Description
Refines the strategy introduced in https://github.com/fern-api/fern/pull/9281; in particular, makes it so `retry-after` doesn't use jitter and is instead respected exactly.
