### PR TITLE
feat(ci): Adding rust-model to the set of generators that run seed tests

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -424,6 +424,24 @@ jobs:
           generator-name: swift-sdk
           generator-path: generators/swift
 
+  rust-model:
+    runs-on: Seed
+    needs: changes
+    if: >-
+      ${{
+        ((needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true')
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: rust-model
+          generator-path: generators/rust
+
   rust-sdk:
     runs-on: Seed
     needs: changes

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/poetry.lock
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/poetry.lock
@@ -1175,13 +1175,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.107.3"
+version = "1.108.0"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "openai-1.107.3-py3-none-any.whl", hash = "sha256:4ca54a847235ac04c6320da70fdc06b62d71439de9ec0aa40d5690c3064d4025"},
-    {file = "openai-1.107.3.tar.gz", hash = "sha256:69bb8032b05c5f00f7660e422f70f9aabc94793b9a30c5f899360ed21e46314f"},
+    {file = "openai-1.108.0-py3-none-any.whl", hash = "sha256:31f2e58230e2703f13ddbb50c285f39dacf7fca64ab19882fd8a7a0b2bccd781"},
+    {file = "openai-1.108.0.tar.gz", hash = "sha256:e859c64e4202d7f5956f19280eee92bb281f211c41cdd5be9e63bf51a024ff72"},
 ]
 
 [package.dependencies]

--- a/seed/ts-sdk/exhaustive/use-pnpm/pnpm-lock.yaml
+++ b/seed/ts-sdk/exhaustive/use-pnpm/pnpm-lock.yaml
@@ -16,22 +16,22 @@ importers:
         version: 29.5.14
       '@types/node':
         specifier: ^18.19.70
-        version: 18.19.126
+        version: 18.19.127
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.126)
+        version: 29.7.0(@types/node@18.19.127)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
       msw:
         specifier: ^2.8.4
-        version: 2.11.2(@types/node@18.19.126)(typescript@5.7.3)
+        version: 2.11.2(@types/node@18.19.127)(typescript@5.7.3)
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
       ts-jest:
         specifier: ^29.3.4
-        version: 29.4.2(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.126))(typescript@5.7.3)
+        version: 29.4.3(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.127))(typescript@5.7.3)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.4(typescript@5.7.3)(webpack@5.101.3)
@@ -414,8 +414,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@18.19.126':
-    resolution: {integrity: sha512-8AXQlBfrGmtYJEJUPs63F/uZQqVeFiN9o6NUjbDJYfxNxFnArlZufANPw4h6dGhYGKxcyw+TapXFvEsguzIQow==}
+  '@types/node@18.19.127':
+    resolution: {integrity: sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -579,8 +579,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.5:
-    resolution: {integrity: sha512-TiU4qUT9jdCuh4aVOG7H1QozyeI2sZRqoRPdqBIaslfNt4WUSanRBueAwl2x5jt4rXBMim3lIN2x6yT8PDi24Q==}
+  baseline-browser-mapping@2.8.6:
+    resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
     hasBin: true
 
   brace-expansion@1.1.12:
@@ -1617,8 +1617,8 @@ packages:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
 
-  ts-jest@29.4.2:
-    resolution: {integrity: sha512-pBNOkn4HtuLpNrXTMVRC9b642CBaDnKqWXny4OzuoULT9S7Kf8MMlaRe2veKax12rjf5WcpMBhVPbQurlWGNxA==}
+  ts-jest@29.4.3:
+    resolution: {integrity: sha512-KTWbK2Wot8VXargsLoxhSoEQ9OyMdzQXQoUDeIulWu2Tf7gghuBHeg+agZqVLdTOHhQHVKAaeuctBDRkhWE7hg==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -2000,31 +2000,31 @@ snapshots:
 
   '@inquirer/ansi@1.0.0': {}
 
-  '@inquirer/confirm@5.1.18(@types/node@18.19.126)':
+  '@inquirer/confirm@5.1.18(@types/node@18.19.127)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@18.19.126)
-      '@inquirer/type': 3.0.8(@types/node@18.19.126)
+      '@inquirer/core': 10.2.2(@types/node@18.19.127)
+      '@inquirer/type': 3.0.8(@types/node@18.19.127)
     optionalDependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
 
-  '@inquirer/core@10.2.2(@types/node@18.19.126)':
+  '@inquirer/core@10.2.2(@types/node@18.19.127)':
     dependencies:
       '@inquirer/ansi': 1.0.0
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@18.19.126)
+      '@inquirer/type': 3.0.8(@types/node@18.19.127)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
 
   '@inquirer/figures@1.0.13': {}
 
-  '@inquirer/type@3.0.8(@types/node@18.19.126)':
+  '@inquirer/type@3.0.8(@types/node@18.19.127)':
     optionalDependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -2039,7 +2039,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -2052,14 +2052,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.126)
+      jest-config: 29.7.0(@types/node@18.19.127)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -2084,7 +2084,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -2102,7 +2102,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -2124,7 +2124,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -2194,7 +2194,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -2289,7 +2289,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -2308,13 +2308,13 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@18.19.126':
+  '@types/node@18.19.127':
     dependencies:
       undici-types: 5.26.5
 
@@ -2529,7 +2529,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.5: {}
+  baseline-browser-mapping@2.8.6: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -2542,7 +2542,7 @@ snapshots:
 
   browserslist@4.26.2:
     dependencies:
-      baseline-browser-mapping: 2.8.5
+      baseline-browser-mapping: 2.8.6
       caniuse-lite: 1.0.30001743
       electron-to-chromium: 1.5.221
       node-releases: 2.0.21
@@ -2614,13 +2614,13 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  create-jest@29.7.0(@types/node@18.19.126):
+  create-jest@29.7.0(@types/node@18.19.127):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.126)
+      jest-config: 29.7.0(@types/node@18.19.127)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -2976,7 +2976,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0
@@ -2996,16 +2996,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.126):
+  jest-cli@29.7.0(@types/node@18.19.127):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.126)
+      create-jest: 29.7.0(@types/node@18.19.127)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@18.19.126)
+      jest-config: 29.7.0(@types/node@18.19.127)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -3015,7 +3015,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.126):
+  jest-config@29.7.0(@types/node@18.19.127):
     dependencies:
       '@babel/core': 7.28.4
       '@jest/test-sequencer': 29.7.0
@@ -3040,7 +3040,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -3070,7 +3070,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -3084,7 +3084,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -3094,7 +3094,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3133,7 +3133,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -3168,7 +3168,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3196,7 +3196,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -3242,7 +3242,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3261,7 +3261,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3270,23 +3270,23 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 18.19.126
+      '@types/node': 18.19.127
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.126):
+  jest@29.7.0(@types/node@18.19.127):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@18.19.126)
+      jest-cli: 29.7.0(@types/node@18.19.127)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3394,11 +3394,11 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.11.2(@types/node@18.19.126)(typescript@5.7.3):
+  msw@2.11.2(@types/node@18.19.127)(typescript@5.7.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
-      '@inquirer/confirm': 5.1.18(@types/node@18.19.126)
+      '@inquirer/confirm': 5.1.18(@types/node@18.19.127)
       '@mswjs/interceptors': 0.39.6
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -3689,12 +3689,12 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  ts-jest@29.4.2(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.126))(typescript@5.7.3):
+  ts-jest@29.4.3(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.127))(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@18.19.126)
+      jest: 29.7.0(@types/node@18.19.127)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6

--- a/seed/ts-sdk/exhaustive/use-vitest/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/use-vitest/tests/unit/fetcher/requestWithRetries.test.ts
@@ -216,11 +216,11 @@ describe("requestWithRetries", () => {
         await vi.runAllTimersAsync();
         const response = await responsePromise;
 
-        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with jitter)
+        // Should use the x-ratelimit-reset delay (approximately 4000ms, but with positive jitter)
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         const actualDelay = setTimeoutSpy.mock.calls[0][1];
         expect(actualDelay).toBeGreaterThan(3000);
-        expect(actualDelay).toBeLessThan(5000);
+        expect(actualDelay).toBeLessThan(6000);
         expect(response.status).toBe(200);
     });
 


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6635/ci-add-rust-model-to-list-of-generators-that-run-seed-tests
Adding rust-model to set of generators running seed tests
Closes FER-6635

## Changes Made
- Added rust-model to seed.yml (note: already in update-seed workflow)

## Testing
Will verify in CI
