### PR TITLE
feat(typescript): Release 3.0.0 TypeScript SDK generator

### DIFF
--- a/generators/typescript/express/cli/src/ExpressGeneratorCli.ts
+++ b/generators/typescript/express/cli/src/ExpressGeneratorCli.ts
@@ -33,7 +33,7 @@ export class ExpressGeneratorCli extends AbstractGeneratorCli<ExpressCustomConfi
             noOptionalProperties: parsed?.noOptionalProperties ?? false,
             enableInlineTypes,
             packagePath: parsed?.packagePath ?? undefined,
-            packageManager: parsed?.packageManager ?? "yarn"
+            packageManager: parsed?.packageManager ?? "pnpm"
         };
     }
 

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -79,11 +79,11 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
             packagePath: parsed?.packagePath,
             omitFernHeaders: parsed?.omitFernHeaders ?? false,
             useDefaultRequestParameterValues: parsed?.useDefaultRequestParameterValues ?? false,
-            packageManager: parsed?.packageManager ?? "yarn",
+            packageManager: parsed?.packageManager ?? "pnpm",
             generateReadWriteOnlyTypes: parsed?.experimentalGenerateReadWriteOnlyTypes ?? false,
             flattenRequestParameters: parsed?.flattenRequestParameters ?? false,
             exportAllRequestsAtRoot: parsed?.exportAllRequestsAtRoot ?? false,
-            testFramework: parsed?.testFramework ?? "jest"
+            testFramework: parsed?.testFramework ?? "vitest"
         };
 
         if (parsed?.noSerdeLayer === false && typeof parsed?.enableInlineTypes === "undefined") {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.0.0
+  changelogEntry:
+    - summary: |
+        Change defaults configuration in _generators.yml_ to use pnpm package manager and vitest test framework.
+        To avoid breaking changes, explicitly set the options above with the `Before` values in the `config` of your generator in _generators.yml_.
+
+        | Option | Before | Now |
+        |--------|--------|-----|
+        | `packageManager` | `yarn` | `pnpm` |
+        | `testFramework` | `jest` | `vitest` |
+      type: feat
+  createdAt: "2025-09-18"
+  irVersion: 60
+
 - version: 2.13.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
Release 3.0.0 TypeScript SDK generator

Change defaults configuration in _generators.yml_ to use pnpm package manager and vitest test framework.
To avoid breaking changes, explicitly set the options above with the `Before` values in the `config` of your generator in _generators.yml_.

| Option | Before | Now |
|--------|--------|-----|
| `packageManager` | `yarn` | `pnpm` |
| `testFramework` | `jest` | `vitest` |
