### PR TITLE
fix(go): use correct pointer reference for enum arguments in dynamic snippets

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -777,7 +777,7 @@ export class EndpointSnippetGenerator {
         for (const parameter of pathParameters) {
             args.push({
                 name: this.context.getTypeName(parameter.name.name),
-                value: this.context.dynamicTypeInstantiationMapper.convert(parameter)
+                value: this.context.dynamicTypeInstantiationMapper.convertToPointerIfPossible(parameter)
             });
         }
 

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
@@ -68,6 +68,27 @@ export class DynamicTypeInstantiationMapper {
         }
     }
 
+    public convertToPointerIfPossible(args: DynamicTypeInstantiationMapper.Args): go.TypeInstantiation {
+        const converted = this.convert(args);
+        switch (args.typeReference.type) {
+            case "named": {
+                const named = this.context.resolveNamedType({ typeId: args.typeReference.value });
+                if (named?.type === "enum") {
+                    return go.TypeInstantiation.reference(
+                        go.invokeMethod({
+                            on: converted,
+                            method: "Ptr",
+                            arguments_: []
+                        })
+                    );
+                }
+                return converted;
+            }
+            default:
+                return converted;
+        }
+    }
+
     private convertList({ list, value }: { list: FernIr.dynamic.TypeReference; value: unknown }): go.TypeInstantiation {
         if (!Array.isArray(value)) {
             this.context.errors.add({

--- a/seed/go-sdk/enum/dynamic-snippets/example3/snippet.go
+++ b/seed/go-sdk/enum/dynamic-snippets/example3/snippet.go
@@ -15,7 +15,7 @@ func do() {
     )
     client.PathParam.Send(
         context.TODO(),
-        fern.OperandGreaterThan,
+        fern.OperandGreaterThan.Ptr(),
         &fern.ColorOrOperand{
             Color: fern.ColorRed,
         },

--- a/seed/go-sdk/enum/dynamic-snippets/example4/snippet.go
+++ b/seed/go-sdk/enum/dynamic-snippets/example4/snippet.go
@@ -15,7 +15,7 @@ func do() {
     )
     client.PathParam.Send(
         context.TODO(),
-        fern.OperandGreaterThan,
+        fern.OperandGreaterThan.Ptr(),
         &fern.ColorOrOperand{
             Color: fern.ColorRed,
         },

--- a/seed/go-sdk/enum/reference.md
+++ b/seed/go-sdk/enum/reference.md
@@ -164,7 +164,7 @@ client.InlinedRequest.Send(
 ```go
 client.PathParam.Send(
         context.TODO(),
-        fern.OperandGreaterThan,
+        fern.OperandGreaterThan.Ptr(),
         &fern.ColorOrOperand{
             Color: fern.ColorRed,
         },

--- a/seed/go-sdk/examples/export-all-requests-at-root/README.md
+++ b/seed/go-sdk/examples/export-all-requests-at-root/README.md
@@ -29,7 +29,7 @@ func do() {
     )
     client.Echo(
         context.TODO(),
-        "string",
+        "Hello world!\n\nwith\n\tnewlines",
     )
 }
 ```


### PR DESCRIPTION
## Description
Linear ticket: This is the first of several PR's to address "Fix existing dynamic snippets" milestone in the [[SDKs] Go Wire tests](https://linear.app/buildwithfern/project/sdks-go-wire-tests-3609ed54df72/overview) project

The fix is very subtle. I noticed some broken dynamic snippets when generating wire tests for the Auth0 SDK that did not correctly use pointers to enums when used as endpoint method arguments. As you can see in `GoTypeMapper.convertNamed` [here](https://github.com/fern-api/fern/blob/522c06f2438324a89ca966e3bd4eee0cfb1ac2b9/generators/go-v2/base/src/context/GoTypeMapper.ts#L104) used when building endpoint method signatures we always use pointer argument types.

This made slightly more complicated because we cannot use the `&` reference operator on enums since we use **CONST ENUMs** so we need to use the defined `.Ptr()` method. As far as I can see the only types we could use for top-level path/query param arguments would be string/int/float/etc literals, object pointers (for the request body), or enums so we have now correctly addressed all cases but lmk if I'm missing something

## Changes Made
- Convert to pointer if possible in `EndpointSnippetGenerator.getPathParameters`
- only need to address enum case for now??
- regenerate seed to show applicable changes

## Testing
- [x] reran seed
