### PR TITLE
chore(rust): implement builder pattern for query parameters

### DIFF
--- a/generators/rust/base/src/AsIs.ts
+++ b/generators/rust/base/src/AsIs.ts
@@ -43,6 +43,10 @@ const AsIsFileSpecs = {
         relativePathToDir: "src",
         filename: "query_parameter_builder.rs"
     },
+    Utils: {
+        relativePathToDir: "src",
+        filename: "utils.rs"
+    },
     // Project-level configuration files
     CargoToml: {
         relativePathToDir: "",

--- a/generators/rust/base/src/asIs/api_client_builder.rs
+++ b/generators/rust/base/src/asIs/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{Utils::join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/generators/rust/base/src/asIs/mod.rs
+++ b/generators/rust/base/src/asIs/mod.rs
@@ -5,9 +5,11 @@ mod api_client_builder;
 mod http_client;
 mod request_options;
 mod query_parameter_builder;
+mod utils;
 
 pub use client_config::ClientConfig;
 pub use api_client_builder::ApiClientBuilder;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
-pub use query_parameter_builder::{QueryParameterBuilder, QueryBuilderError, parse_structured_query};
+pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
+pub use utils::Utils;

--- a/generators/rust/base/src/asIs/query_parameter_builder.rs
+++ b/generators/rust/base/src/asIs/query_parameter_builder.rs
@@ -1,58 +1,141 @@
-use percent_encoding::{utf8_percent_encode, CONTROLS};
-use thiserror::Error;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
 
-/// Generic query parameter builder for various query patterns
+/// Modern query builder with type-safe method chaining
+/// Provides a clean, Swift-like API for building HTTP query parameters
 #[derive(Debug, Default)]
-pub struct QueryParameterBuilder {
+pub struct QueryBuilder {
     params: Vec<(String, String)>,
 }
 
-/// Errors that can occur during query building
-#[derive(Debug, Error)]
-pub enum QueryBuilderError {
-    #[error("Invalid query syntax: {0}")]
-    InvalidQuerySyntax(String),
-    #[error("URL encoding error: {0}")]
-    EncodingError(String),
-}
-
-impl QueryParameterBuilder {
+impl QueryBuilder {
     /// Create a new query parameter builder
     pub fn new() -> Self {
-        Self { params: Vec::new() }
+        Self::default()
     }
 
-    /// Add a simple key-value parameter with URL encoding
-    pub fn add_simple<T: ToString>(&mut self, key: &str, value: T) {
-        let encoded_key = utf8_percent_encode(key, CONTROLS).to_string();
-        let encoded_value = utf8_percent_encode(&value.to_string(), CONTROLS).to_string();
-        self.params.push((encoded_key, encoded_value));
+    /// Add a string parameter
+    pub fn string(mut self, key: &str, value: Option<String>) -> Self {
+        if let Some(v) = value {
+            self.params.push((key.to_string(), v));
+        }
+        self
     }
 
-    /// Try to parse a complex query string using common patterns
-    /// This is a best-effort generic parser that handles:
+    /// Add an integer parameter - handles both i32 and i64 automatically
+    pub fn int(mut self, key: &str, value: Option<impl Into<i64>>) -> Self {
+        if let Some(v) = value {
+            self.params.push((key.to_string(), v.into().to_string()));
+        }
+        self
+    }
+
+    /// Add a float parameter
+    pub fn float(mut self, key: &str, value: Option<f64>) -> Self {
+        if let Some(v) = value {
+            self.params.push((key.to_string(), v.to_string()));
+        }
+        self
+    }
+
+    /// Add a boolean parameter
+    pub fn bool(mut self, key: &str, value: Option<bool>) -> Self {
+        if let Some(v) = value {
+            self.params.push((key.to_string(), v.to_string()));
+        }
+        self
+    }
+
+    /// Add a datetime parameter
+    pub fn datetime(mut self, key: &str, value: Option<DateTime<Utc>>) -> Self {
+        if let Some(v) = value {
+            self.params.push((key.to_string(), v.to_rfc3339()));
+        }
+        self
+    }
+
+    /// Add a UUID parameter (converts to string)
+    pub fn uuid(mut self, key: &str, value: Option<uuid::Uuid>) -> Self {
+        if let Some(v) = value {
+            self.params.push((key.to_string(), v.to_string()));
+        }
+        self
+    }
+
+    /// Add a date parameter (converts NaiveDate to DateTime<Utc>)
+    pub fn date(mut self, key: &str, value: Option<chrono::NaiveDate>) -> Self {
+        if let Some(v) = value {
+            // Convert NaiveDate to DateTime<Utc> at start of day
+            let datetime = v.and_hms_opt(0, 0, 0).unwrap().and_utc();
+            self.params.push((key.to_string(), datetime.to_rfc3339()));
+        }
+        self
+    }
+
+    /// Add any serializable parameter (for enums and complex types)
+    pub fn serialize<T: Serialize>(mut self, key: &str, value: Option<T>) -> Self {
+        if let Some(v) = value {
+            if let Ok(serialized) = serde_json::to_string(&v) {
+                self.params.push((key.to_string(), serialized));
+            }
+        }
+        self
+    }
+
+    /// Parse and add a structured query string
+    /// Handles complex query patterns like:
     /// - "key:value" patterns
     /// - "key:value1,value2" (comma-separated values)
     /// - Quoted values: "key:\"value with spaces\""
     /// - Space-separated terms (treated as AND logic)
-    pub fn add_structured_query(&mut self, query: &str) -> Result<(), QueryBuilderError> {
-        let parsed_params = parse_structured_query(query)?;
-        self.params.extend(parsed_params);
-        Ok(())
+    pub fn structured_query(mut self, key: &str, query: Option<String>) -> Self {
+        if let Some(query_str) = query {
+            if let Ok(parsed_params) = parse_structured_query(&query_str) {
+                self.params.extend(parsed_params);
+            } else {
+                // Fall back to simple query parameter if parsing fails
+                self.params.push((key.to_string(), query_str));
+            }
+        }
+        self
     }
 
-    /// Build the final query parameter vector
-    pub fn build(self) -> Vec<(String, String)> {
-        self.params
+    /// Build the final query parameters
+    pub fn build(self) -> Option<Vec<(String, String)>> {
+        if self.params.is_empty() {
+            None
+        } else {
+            Some(self.params)
+        }
     }
 }
 
-/// Generic parser for structured query strings
-/// Handles common patterns like "key:value key2:value1,value2"
+/// Errors that can occur during structured query parsing
+#[derive(Debug)]
+pub enum QueryBuilderError {
+    InvalidQuerySyntax(String),
+}
+
+impl std::fmt::Display for QueryBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryBuilderError::InvalidQuerySyntax(msg) => write!(f, "Invalid query syntax: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for QueryBuilderError {}
+
+/// Parse structured query strings like "key:value key2:value1,value2"
+/// Used for complex filtering patterns in APIs like Foxglove
+///
+/// Supported patterns:
+/// - Simple: "status:active"
+/// - Multiple values: "type:sensor,camera"
+/// - Quoted values: "location:\"New York\""
+/// - Complex: "status:active type:sensor location:\"San Francisco\""
 pub fn parse_structured_query(query: &str) -> Result<Vec<(String, String)>, QueryBuilderError> {
     let mut params = Vec::new();
-
-    // Tokenize the query string properly handling quoted strings
     let terms = tokenize_query(query);
 
     for term in terms {
@@ -60,13 +143,10 @@ pub fn parse_structured_query(query: &str) -> Result<Vec<(String, String)>, Quer
             // Handle comma-separated values
             for value in values.split(',') {
                 let clean_value = value.trim_matches('"'); // Remove quotes
-                let encoded_key = utf8_percent_encode(key, CONTROLS).to_string();
-                let encoded_value = utf8_percent_encode(clean_value, CONTROLS).to_string();
-                params.push((encoded_key, encoded_value));
+                params.push((key.to_string(), clean_value.to_string()));
             }
         } else {
-            // For terms without colons, we could treat them as general search
-            // but since this is generic, we'll return an error to be explicit
+            // For terms without colons, return error to be explicit about expected format
             return Err(QueryBuilderError::InvalidQuerySyntax(format!(
                 "Cannot parse term '{}' - expected 'key:value' format for structured queries",
                 term
@@ -112,3 +192,4 @@ fn tokenize_query(input: &str) -> Vec<String> {
 
     tokens
 }
+

--- a/generators/rust/base/src/asIs/utils.rs
+++ b/generators/rust/base/src/asIs/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -212,6 +212,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
         moduleDeclarations.push(new ModuleDeclaration({ name: "request_options", isPublic: true }));
         moduleDeclarations.push(new ModuleDeclaration({ name: "pagination", isPublic: true }));
         moduleDeclarations.push(new ModuleDeclaration({ name: "query_parameter_builder", isPublic: true }));
+        moduleDeclarations.push(new ModuleDeclaration({ name: "utils", isPublic: true }));
 
         if (this.hasEnvironments(context)) {
             moduleDeclarations.push(new ModuleDeclaration({ name: "environment", isPublic: true }));
@@ -274,6 +275,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
         );
         useStatements.push(new UseStatement({ path: "pagination", items: ["*"], isPublic: true }));
         useStatements.push(new UseStatement({ path: "query_parameter_builder", items: ["*"], isPublic: true }));
+        useStatements.push(new UseStatement({ path: "utils", items: ["*"], isPublic: true }));
 
         return new Module({
             moduleDeclarations,

--- a/generators/rust/sdk/src/__test__/QueryParameterGenerator.test.ts
+++ b/generators/rust/sdk/src/__test__/QueryParameterGenerator.test.ts
@@ -177,7 +177,7 @@ describe("QueryParameterGenerator", () => {
         const methodBody = method.body;
         const fullMethod = `${methodSignature} {\n    ${methodBody}\n}`;
 
-        // await expect(fullMethod).toMatchFileSnapshot("snapshots/method-without-query-params.rs");
+        await expect(fullMethod).toMatchFileSnapshot("snapshots/method-without-query-params.rs");
     });
 
     it("should generate method with single query parameter correctly", async () => {

--- a/generators/rust/sdk/src/__test__/snapshots/api-client-builder-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/api-client-builder-api-key.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/generators/rust/sdk/src/__test__/snapshots/api-key-auth-client.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/api-key-auth-client.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 
 pub struct Client {

--- a/generators/rust/sdk/src/__test__/snapshots/basic-auth-client.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/basic-auth-client.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 
 pub struct Client {

--- a/generators/rust/sdk/src/__test__/snapshots/bearer-token-auth-client.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/bearer-token-auth-client.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 
 pub struct Client {

--- a/generators/rust/sdk/src/__test__/snapshots/custom-header-auth-client.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/custom-header-auth-client.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 
 pub struct Client {

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{Utils::join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/generators/rust/sdk/src/__test__/snapshots/method-with-multiple-query-params.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/method-with-multiple-query-params.rs
@@ -3,16 +3,8 @@ pub async fn gettest(limit: Option<String>, offset: Option<String>, options: Opt
             Method::GET,
             "/api/test",
             None,
-            {
-            let mut query_params = Vec::new();
-            if let Some(value) = limit {
-                query_params.push(("limit".to_string(), value.clone()));
-            }
-            if let Some(value) = offset {
-                query_params.push(("offset".to_string(), value.clone()));
-            }
-            Some(query_params)
-        },
+            QueryBuilder::new().string("limit", limit).string("offset", offset)
+            .build(),
             options,
         ).await
 }

--- a/generators/rust/sdk/src/__test__/snapshots/method-with-single-query-param.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/method-with-single-query-param.rs
@@ -3,13 +3,8 @@ pub async fn gettest(limit: Option<String>, options: Option<RequestOptions>) -> 
             Method::GET,
             "/api/test",
             None,
-            {
-            let mut query_params = Vec::new();
-            if let Some(value) = limit {
-                query_params.push(("limit".to_string(), value.clone()));
-            }
-            Some(query_params)
-        },
+            QueryBuilder::new().string("limit", limit)
+            .build(),
             options,
         ).await
 }

--- a/generators/rust/sdk/src/__test__/snapshots/method-without-query-params.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/method-without-query-params.rs
@@ -1,7 +1,8 @@
-pub async fn gettest(options: Option<RequestOptions>) -> Result<(), ClientError> {
+pub async fn gettest(options: Option<RequestOptions>) -> Result<(), ApiError> {
     self.http_client.execute_request(
             Method::GET,
             "/api/test",
+            None,
             None,
             options,
         ).await

--- a/generators/rust/sdk/src/__test__/snapshots/multiple-auth-methods-client.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/multiple-auth-methods-client.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 
 pub struct Client {

--- a/generators/rust/sdk/src/__test__/snapshots/no-auth-client.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/no-auth-client.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 
 pub struct Client {

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -1,7 +1,7 @@
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { RustFile } from "@fern-api/rust-base";
 import { rust, UseStatement } from "@fern-api/rust-codegen";
-import { generateRustTypeForTypeReference, isDateTimeType } from "@fern-api/rust-model";
+import { generateRustTypeForTypeReference } from "@fern-api/rust-model";
 
 import {
     CursorPagination,
@@ -79,7 +79,7 @@ export class SubClientGenerator {
         const imports = [
             new UseStatement({
                 path: "crate",
-                items: ["ClientConfig", "ApiError", "HttpClient", "RequestOptions"]
+                items: ["ClientConfig", "ApiError", "HttpClient", "QueryBuilder", "RequestOptions"]
             }),
             new UseStatement({
                 path: "reqwest",
@@ -309,17 +309,82 @@ export class SubClientGenerator {
     // QUERY PARAMETER BUILDING
     // =============================================================================
 
+    private getQueryBuilderMethod(queryParam: QueryParameter): string {
+        const valueType = queryParam.valueType;
+
+        // Check for structured query parameter by name
+        if (queryParam.name.wireValue === "query" && this.isStringType(valueType)) {
+            return "structured_query";
+        }
+
+        // Map types to appropriate QueryBuilder methods
+        return TypeReference._visit(valueType, {
+            primitive: (primitive) => {
+                return PrimitiveTypeV1._visit(primitive.v1, {
+                    string: () => "string",
+                    boolean: () => "bool",
+                    integer: () => "int",
+                    uint: () => "int",
+                    uint64: () => "int",
+                    long: () => "int",
+                    float: () => "float",
+                    double: () => "float",
+                    bigInteger: () => "string", // Serialize as string
+                    date: () => "date",
+                    dateTime: () => "datetime",
+                    base64: () => "string",
+                    uuid: () => "uuid",
+                    _other: () => "serialize"
+                });
+            },
+            named: () => "serialize", // User-defined types need serialization
+            container: (container) => {
+                return container._visit({
+                    optional: (innerType) => this.getQueryBuilderMethodForType(innerType),
+                    nullable: (innerType) => this.getQueryBuilderMethodForType(innerType),
+                    map: () => "serialize",
+                    set: () => "serialize",
+                    list: () => "serialize",
+                    literal: () => "string",
+                    _other: () => "serialize"
+                });
+            },
+            unknown: () => "serialize",
+            _other: () => "serialize"
+        });
+    }
+
+    private getQueryBuilderMethodForType(typeRef: TypeReference): string {
+        return TypeReference._visit(typeRef, {
+            primitive: (primitive) => {
+                return PrimitiveTypeV1._visit(primitive.v1, {
+                    string: () => "string",
+                    boolean: () => "bool",
+                    integer: () => "int",
+                    uint: () => "int",
+                    uint64: () => "int",
+                    long: () => "int",
+                    float: () => "float",
+                    double: () => "float",
+                    bigInteger: () => "string",
+                    date: () => "date",
+                    dateTime: () => "datetime",
+                    base64: () => "string",
+                    uuid: () => "uuid",
+                    _other: () => "serialize"
+                });
+            },
+            named: () => "serialize",
+            container: () => "serialize",
+            unknown: () => "serialize",
+            _other: () => "serialize"
+        });
+    }
+
     private buildQueryParameters(endpoint: HttpEndpoint): string {
         const queryParams = endpoint.queryParameters;
         if (queryParams.length === 0) {
             return "None";
-        }
-
-        // Check if this endpoint would benefit from enhanced query parameter handling
-        const shouldUseEnhancedBuilder = this.shouldUseEnhancedQueryBuilder(endpoint);
-
-        if (shouldUseEnhancedBuilder) {
-            return this.buildEnhancedQueryParameters(endpoint);
         }
 
         return this.buildQueryParameterStatements(queryParams);
@@ -345,33 +410,16 @@ export class SubClientGenerator {
     }
 
     private buildQueryParameterStatements(queryParams: QueryParameter[]): string {
-        const queryParamStatements = queryParams.map((queryParam) => {
+        const builderChain = queryParams.map((queryParam) => {
             const paramName = queryParam.name.name.snakeCase.safeName;
             const wireValue = queryParam.name.wireValue;
-            const pattern = `Some(value)`;
+            const method = this.getQueryBuilderMethod(queryParam);
 
-            // Handle different types properly for query parameters
-            let valueExpression: string;
-            if (this.isStringType(queryParam.valueType)) {
-                valueExpression = "value.clone()";
-            } else if (this.isDateTimeTypeRecursive(queryParam.valueType)) {
-                valueExpression = "value.to_rfc3339()";
-            } else if (this.isComplexType(queryParam.valueType)) {
-                valueExpression = "serde_json::to_string(&value).unwrap_or_default()";
-            } else {
-                valueExpression = "value.to_string()";
-            }
-
-            return `if let ${pattern} = ${paramName} {
-                query_params.push(("${wireValue}".to_string(), ${valueExpression}));
-            }`;
+            return `.${method}("${wireValue}", ${paramName})`;
         });
 
-        return `{
-            let mut query_params = Vec::new();
-            ${queryParamStatements.join("\n            ")}
-            Some(query_params)
-        }`;
+        return `QueryBuilder::new()${builderChain.join("")}
+            .build()`;
     }
 
     private extractPaginationParameterNames(paginationConfig: Pagination): Set<string> {
@@ -426,68 +474,6 @@ export class SubClientGenerator {
             });
         }
         return paginationParamNames;
-    }
-
-    private shouldUseEnhancedQueryBuilder(endpoint: HttpEndpoint): boolean {
-        const queryParams = endpoint.queryParameters;
-
-        // Use enhanced builder if:
-        // 1. There's a parameter named "query" (structured query string)
-        // 2. There are many query parameters (>5) suggesting complex filtering
-        // 3. There's a mix of sort parameters (sortBy, sortOrder) indicating advanced querying
-        return (
-            queryParams.some(
-                (param) =>
-                    param.name.wireValue === "query" || // Structured query parameter
-                    param.name.wireValue === "filter" || // Generic filter parameter
-                    param.name.wireValue.includes("sort") // Sort-related parameters
-            ) || queryParams.length > 5
-        ); // Many parameters suggest complex usage
-    }
-
-    private buildEnhancedQueryParameters(endpoint: HttpEndpoint): string {
-        const queryParams = endpoint.queryParameters;
-        const statements: string[] = [];
-
-        queryParams.forEach((param) => {
-            const paramName = param.name.name.snakeCase.safeName;
-            const wireValue = param.name.wireValue;
-            const pattern = `Some(value)`;
-
-            if (wireValue === "query" && this.isStringType(param.valueType)) {
-                // Handle structured query strings with fallback
-                statements.push(`
-            if let ${pattern} = ${paramName} {
-                // Try to parse as structured query, fall back to simple if it fails
-                if let Err(_) = query_builder.add_structured_query(&value) {
-                    query_builder.add_simple("${wireValue}", &value);
-                }
-            }`);
-            } else {
-                // Handle regular parameters
-                let valueExpression: string;
-                if (this.isStringType(param.valueType)) {
-                    valueExpression = "&value";
-                } else if (this.isDateTimeTypeRecursive(param.valueType)) {
-                    valueExpression = "&value.to_rfc3339()";
-                } else if (this.isComplexType(param.valueType)) {
-                    valueExpression = "&serde_json::to_string(&value).unwrap_or_default()";
-                } else {
-                    valueExpression = "&value.to_string()";
-                }
-
-                statements.push(`
-            if let ${pattern} = ${paramName} {
-                query_builder.add_simple("${wireValue}", ${valueExpression});
-            }`);
-            }
-        });
-
-        return `{
-            let mut query_builder = crate::QueryParameterBuilder::new();${statements.join("")}
-            let params = query_builder.build();
-            if params.is_empty() { None } else { Some(params) }
-        }`;
     }
 
     // =============================================================================
@@ -633,16 +619,6 @@ export class SubClientGenerator {
         });
     }
 
-    private isComplexType(typeRef: TypeReference): boolean {
-        return TypeReference._visit(typeRef, {
-            primitive: () => false,
-            named: () => true,
-            container: () => true,
-            unknown: () => true,
-            _other: () => true
-        });
-    }
-
     private isStringType(typeRef: TypeReference): boolean {
         return TypeReference._visit(typeRef, {
             primitive: (primitive) => {
@@ -654,29 +630,6 @@ export class SubClientGenerator {
                 return container._visit({
                     optional: (innerType) => this.isStringType(innerType),
                     nullable: (innerType) => this.isStringType(innerType),
-                    list: () => false,
-                    set: () => false,
-                    map: () => false,
-                    literal: () => false,
-                    _other: () => false
-                });
-            },
-            unknown: () => false,
-            _other: () => false
-        });
-    }
-
-    private isDateTimeTypeRecursive(typeRef: TypeReference): boolean {
-        return TypeReference._visit(typeRef, {
-            primitive: (primitive) => {
-                return isDateTimeType(typeRef);
-            },
-            named: () => false,
-            container: (container) => {
-                // Check if it's an optional DateTime
-                return container._visit({
-                    optional: (innerType) => this.isDateTimeTypeRecursive(innerType),
-                    nullable: (innerType) => this.isDateTimeTypeRecursive(innerType),
                     list: () => false,
                     set: () => false,
                     map: () => false,

--- a/seed/rust-sdk/accept-header/src/api_client_builder.rs
+++ b/seed/rust-sdk/accept-header/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/accept-header/src/client/service.rs
+++ b/seed/rust-sdk/accept-header/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/accept-header/src/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/accept-header/src/lib.rs
+++ b/seed/rust-sdk/accept-header/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/accept-header/src/utils.rs
+++ b/seed/rust-sdk/accept-header/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/alias-extends/src/api_client_builder.rs
+++ b/seed/rust-sdk/alias-extends/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/alias-extends/src/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/alias-extends/src/lib.rs
+++ b/seed/rust-sdk/alias-extends/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/alias-extends/src/utils.rs
+++ b/seed/rust-sdk/alias-extends/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/alias/src/api_client_builder.rs
+++ b/seed/rust-sdk/alias/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/alias/src/http_client.rs
+++ b/seed/rust-sdk/alias/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/alias/src/lib.rs
+++ b/seed/rust-sdk/alias/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/alias/src/utils.rs
+++ b/seed/rust-sdk/alias/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/any-auth/src/api_client_builder.rs
+++ b/seed/rust-sdk/any-auth/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/any-auth/src/client/auth.rs
+++ b/seed/rust-sdk/any-auth/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/any-auth/src/client/user.rs
+++ b/seed/rust-sdk/any-auth/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/any-auth/src/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/any-auth/src/lib.rs
+++ b/seed/rust-sdk/any-auth/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/any-auth/src/utils.rs
+++ b/seed/rust-sdk/any-auth/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/api-wide-base-path/src/api_client_builder.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/api-wide-base-path/src/client/service.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/api-wide-base-path/src/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/api-wide-base-path/src/lib.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/api-wide-base-path/src/utils.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/audiences/src/api_client_builder.rs
+++ b/seed/rust-sdk/audiences/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/audiences/src/client/folder_a.rs
+++ b/seed/rust-sdk/audiences/src/client/folder_a.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderAClient {

--- a/seed/rust-sdk/audiences/src/client/folder_a_service.rs
+++ b/seed/rust-sdk/audiences/src/client/folder_a_service.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/audiences/src/client/folder_d.rs
+++ b/seed/rust-sdk/audiences/src/client/folder_d.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderDClient {

--- a/seed/rust-sdk/audiences/src/client/folder_d_service.rs
+++ b/seed/rust-sdk/audiences/src/client/folder_d_service.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/audiences/src/client/foo.rs
+++ b/seed/rust-sdk/audiences/src/client/foo.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct FooClient {
@@ -23,16 +23,9 @@ impl FooClient {
                 Method::POST,
                 "",
                 Some(serde_json::to_value(request).unwrap_or_default()),
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = optional_string {
-                        query_params.push((
-                            "optionalString".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .serialize("optionalString", optional_string)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/audiences/src/http_client.rs
+++ b/seed/rust-sdk/audiences/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/audiences/src/lib.rs
+++ b/seed/rust-sdk/audiences/src/lib.rs
@@ -8,6 +8,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -19,3 +20,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/audiences/src/utils.rs
+++ b/seed/rust-sdk/audiences/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/auth-environment-variables/src/api_client_builder.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/auth-environment-variables/src/client/service.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/auth-environment-variables/src/http_client.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/auth-environment-variables/src/lib.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/auth-environment-variables/src/utils.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/basic-auth-environment-variables/src/api_client_builder.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/basic-auth-environment-variables/src/client/basic_auth.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/client/basic_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct BasicAuthClient {

--- a/seed/rust-sdk/basic-auth-environment-variables/src/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/basic-auth-environment-variables/src/lib.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/basic-auth-environment-variables/src/utils.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/basic-auth/src/api_client_builder.rs
+++ b/seed/rust-sdk/basic-auth/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/basic-auth/src/client/basic_auth.rs
+++ b/seed/rust-sdk/basic-auth/src/client/basic_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct BasicAuthClient {

--- a/seed/rust-sdk/basic-auth/src/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/basic-auth/src/lib.rs
+++ b/seed/rust-sdk/basic-auth/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/basic-auth/src/utils.rs
+++ b/seed/rust-sdk/basic-auth/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/bearer-token-environment-variable/src/api_client_builder.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/bearer-token-environment-variable/src/client/service.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/bearer-token-environment-variable/src/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/bearer-token-environment-variable/src/lib.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/bearer-token-environment-variable/src/utils.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/bytes-download/src/api_client_builder.rs
+++ b/seed/rust-sdk/bytes-download/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/bytes-download/src/client/service.rs
+++ b/seed/rust-sdk/bytes-download/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/bytes-download/src/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/bytes-download/src/lib.rs
+++ b/seed/rust-sdk/bytes-download/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/bytes-download/src/utils.rs
+++ b/seed/rust-sdk/bytes-download/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/bytes-upload/src/api_client_builder.rs
+++ b/seed/rust-sdk/bytes-upload/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/bytes-upload/src/client/service.rs
+++ b/seed/rust-sdk/bytes-upload/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/bytes-upload/src/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/bytes-upload/src/lib.rs
+++ b/seed/rust-sdk/bytes-upload/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/bytes-upload/src/utils.rs
+++ b/seed/rust-sdk/bytes-upload/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/circular-references-advanced/src/api_client_builder.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/circular-references-advanced/src/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/circular-references-advanced/src/lib.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/circular-references-advanced/src/utils.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/circular-references/src/api_client_builder.rs
+++ b/seed/rust-sdk/circular-references/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/circular-references/src/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/circular-references/src/lib.rs
+++ b/seed/rust-sdk/circular-references/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/circular-references/src/utils.rs
+++ b/seed/rust-sdk/circular-references/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/client-side-params/src/api_client_builder.rs
+++ b/seed/rust-sdk/client-side-params/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/client-side-params/src/client/service.rs
+++ b/seed/rust-sdk/client-side-params/src/client/service.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {
@@ -28,36 +28,15 @@ impl ServiceClient {
                 Method::GET,
                 "/api/resources",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = page {
-                        query_builder.add_simple("page", &value.to_string());
-                    }
-                    if let Some(value) = per_page {
-                        query_builder.add_simple("per_page", &value.to_string());
-                    }
-                    if let Some(value) = sort {
-                        query_builder.add_simple("sort", &value);
-                    }
-                    if let Some(value) = order {
-                        query_builder.add_simple("order", &value);
-                    }
-                    if let Some(value) = include_totals {
-                        query_builder.add_simple("include_totals", &value.to_string());
-                    }
-                    if let Some(value) = fields {
-                        query_builder.add_simple("fields", &value);
-                    }
-                    if let Some(value) = search {
-                        query_builder.add_simple("search", &value);
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .int("page", page)
+                    .int("per_page", per_page)
+                    .string("sort", sort)
+                    .string("order", order)
+                    .bool("include_totals", include_totals)
+                    .string("fields", fields)
+                    .string("search", search)
+                    .build(),
                 options,
             )
             .await
@@ -75,16 +54,10 @@ impl ServiceClient {
                 Method::GET,
                 &format!("/api/resources/{}", resource_id),
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = include_metadata {
-                        query_params.push(("include_metadata".to_string(), value.to_string()));
-                    }
-                    if let Some(value) = format {
-                        query_params.push(("format".to_string(), value.clone()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .bool("include_metadata", include_metadata)
+                    .string("format", format)
+                    .build(),
                 options,
             )
             .await
@@ -102,16 +75,10 @@ impl ServiceClient {
                 Method::POST,
                 "/api/resources/search",
                 Some(serde_json::to_value(request).unwrap_or_default()),
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = limit {
-                        query_params.push(("limit".to_string(), value.to_string()));
-                    }
-                    if let Some(value) = offset {
-                        query_params.push(("offset".to_string(), value.to_string()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .int("limit", limit)
+                    .int("offset", offset)
+                    .build(),
                 options,
             )
             .await
@@ -134,46 +101,16 @@ impl ServiceClient {
                 Method::GET,
                 "/api/users",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = page {
-                        query_builder
-                            .add_simple("page", &serde_json::to_string(&value).unwrap_or_default());
-                    }
-                    if let Some(value) = per_page {
-                        query_builder.add_simple(
-                            "per_page",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = include_totals {
-                        query_builder.add_simple(
-                            "include_totals",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = sort {
-                        query_builder.add_simple("sort", &value);
-                    }
-                    if let Some(value) = connection {
-                        query_builder.add_simple("connection", &value);
-                    }
-                    if let Some(value) = q {
-                        query_builder.add_simple("q", &value);
-                    }
-                    if let Some(value) = search_engine {
-                        query_builder.add_simple("search_engine", &value);
-                    }
-                    if let Some(value) = fields {
-                        query_builder.add_simple("fields", &value);
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .int("page", page)
+                    .int("per_page", per_page)
+                    .bool("include_totals", include_totals)
+                    .string("sort", sort)
+                    .string("connection", connection)
+                    .string("q", q)
+                    .string("search_engine", search_engine)
+                    .string("fields", fields)
+                    .build(),
                 options,
             )
             .await
@@ -191,19 +128,10 @@ impl ServiceClient {
                 Method::GET,
                 &format!("/api/users/{}", user_id),
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = fields {
-                        query_params.push(("fields".to_string(), value.clone()));
-                    }
-                    if let Some(value) = include_fields {
-                        query_params.push((
-                            "include_fields".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .string("fields", fields)
+                    .bool("include_fields", include_fields)
+                    .build(),
                 options,
             )
             .await
@@ -270,19 +198,11 @@ impl ServiceClient {
                 Method::GET,
                 "/api/connections",
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = strategy {
-                        query_params.push(("strategy".to_string(), value.clone()));
-                    }
-                    if let Some(value) = name {
-                        query_params.push(("name".to_string(), value.clone()));
-                    }
-                    if let Some(value) = fields {
-                        query_params.push(("fields".to_string(), value.clone()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .string("strategy", strategy)
+                    .string("name", name)
+                    .string("fields", fields)
+                    .build(),
                 options,
             )
             .await
@@ -299,13 +219,7 @@ impl ServiceClient {
                 Method::GET,
                 &format!("/api/connections/{}", connection_id),
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = fields {
-                        query_params.push(("fields".to_string(), value.clone()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new().string("fields", fields).build(),
                 options,
             )
             .await
@@ -328,58 +242,16 @@ impl ServiceClient {
                 Method::GET,
                 "/api/clients",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = fields {
-                        query_builder.add_simple("fields", &value);
-                    }
-                    if let Some(value) = include_fields {
-                        query_builder.add_simple(
-                            "include_fields",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = page {
-                        query_builder
-                            .add_simple("page", &serde_json::to_string(&value).unwrap_or_default());
-                    }
-                    if let Some(value) = per_page {
-                        query_builder.add_simple(
-                            "per_page",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = include_totals {
-                        query_builder.add_simple(
-                            "include_totals",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = is_global {
-                        query_builder.add_simple(
-                            "is_global",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = is_first_party {
-                        query_builder.add_simple(
-                            "is_first_party",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = app_type {
-                        query_builder.add_simple(
-                            "app_type",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .string("fields", fields)
+                    .bool("include_fields", include_fields)
+                    .int("page", page)
+                    .int("per_page", per_page)
+                    .bool("include_totals", include_totals)
+                    .bool("is_global", is_global)
+                    .bool("is_first_party", is_first_party)
+                    .serialize("app_type", app_type)
+                    .build(),
                 options,
             )
             .await
@@ -397,19 +269,10 @@ impl ServiceClient {
                 Method::GET,
                 &format!("/api/clients/{}", client_id),
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = fields {
-                        query_params.push(("fields".to_string(), value.clone()));
-                    }
-                    if let Some(value) = include_fields {
-                        query_params.push((
-                            "include_fields".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .string("fields", fields)
+                    .bool("include_fields", include_fields)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/client-side-params/src/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/client-side-params/src/lib.rs
+++ b/seed/rust-sdk/client-side-params/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/client-side-params/src/utils.rs
+++ b/seed/rust-sdk/client-side-params/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/content-type/src/api_client_builder.rs
+++ b/seed/rust-sdk/content-type/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/content-type/src/client/service.rs
+++ b/seed/rust-sdk/content-type/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/content-type/src/http_client.rs
+++ b/seed/rust-sdk/content-type/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/content-type/src/lib.rs
+++ b/seed/rust-sdk/content-type/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/content-type/src/utils.rs
+++ b/seed/rust-sdk/content-type/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/cross-package-type-names/src/api_client_builder.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/cross-package-type-names/src/client/folder_a.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/client/folder_a.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderAClient {

--- a/seed/rust-sdk/cross-package-type-names/src/client/folder_a_service.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/client/folder_a_service.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/cross-package-type-names/src/client/folder_d.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/client/folder_d.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderDClient {

--- a/seed/rust-sdk/cross-package-type-names/src/client/folder_d_service.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/client/folder_d_service.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/cross-package-type-names/src/client/foo.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/client/foo.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct FooClient {
@@ -23,16 +23,9 @@ impl FooClient {
                 Method::POST,
                 "",
                 Some(serde_json::to_value(request).unwrap_or_default()),
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = optional_string {
-                        query_params.push((
-                            "optionalString".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .serialize("optionalString", optional_string)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/cross-package-type-names/src/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/cross-package-type-names/src/lib.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/cross-package-type-names/src/utils.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/custom-auth/src/api_client_builder.rs
+++ b/seed/rust-sdk/custom-auth/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/custom-auth/src/client/custom_auth.rs
+++ b/seed/rust-sdk/custom-auth/src/client/custom_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct CustomAuthClient {

--- a/seed/rust-sdk/custom-auth/src/http_client.rs
+++ b/seed/rust-sdk/custom-auth/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/custom-auth/src/lib.rs
+++ b/seed/rust-sdk/custom-auth/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/custom-auth/src/utils.rs
+++ b/seed/rust-sdk/custom-auth/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/empty-clients/src/api_client_builder.rs
+++ b/seed/rust-sdk/empty-clients/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/empty-clients/src/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/empty-clients/src/lib.rs
+++ b/seed/rust-sdk/empty-clients/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/empty-clients/src/utils.rs
+++ b/seed/rust-sdk/empty-clients/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/enum/src/api_client_builder.rs
+++ b/seed/rust-sdk/enum/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/enum/src/client/headers.rs
+++ b/seed/rust-sdk/enum/src/client/headers.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/enum/src/client/inlined_request.rs
+++ b/seed/rust-sdk/enum/src/client/inlined_request.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/enum/src/client/path_param.rs
+++ b/seed/rust-sdk/enum/src/client/path_param.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/enum/src/client/query_param.rs
+++ b/seed/rust-sdk/enum/src/client/query_param.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 
@@ -17,22 +17,8 @@ impl QueryParamClient {
             Method::POST,
             "query",
             None,
-            {
-            let mut query_params = Vec::new();
-            if let Some(value) = operand {
-                query_params.push(("operand".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = maybe_operand {
-                query_params.push(("maybeOperand".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = operand_or_color {
-                query_params.push(("operandOrColor".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = maybe_operand_or_color {
-                query_params.push(("maybeOperandOrColor".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            Some(query_params)
-        },
+            QueryBuilder::new().serialize("operand", operand).serialize("maybeOperand", maybe_operand).serialize("operandOrColor", operand_or_color).serialize("maybeOperandOrColor", maybe_operand_or_color)
+            .build(),
             options,
         ).await
     }
@@ -42,22 +28,8 @@ impl QueryParamClient {
             Method::POST,
             "query-list",
             None,
-            {
-            let mut query_params = Vec::new();
-            if let Some(value) = operand {
-                query_params.push(("operand".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = maybe_operand {
-                query_params.push(("maybeOperand".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = operand_or_color {
-                query_params.push(("operandOrColor".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = maybe_operand_or_color {
-                query_params.push(("maybeOperandOrColor".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            Some(query_params)
-        },
+            QueryBuilder::new().serialize("operand", operand).serialize("maybeOperand", maybe_operand).serialize("operandOrColor", operand_or_color).serialize("maybeOperandOrColor", maybe_operand_or_color)
+            .build(),
             options,
         ).await
     }

--- a/seed/rust-sdk/enum/src/http_client.rs
+++ b/seed/rust-sdk/enum/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/enum/src/lib.rs
+++ b/seed/rust-sdk/enum/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod request_options;
 pub mod pagination;
 pub mod query_parameter_builder;
+pub mod utils;
 pub mod types;
 
 pub use client::{*};
@@ -17,4 +18,5 @@ pub use http_client::{*};
 pub use request_options::{*};
 pub use pagination::{*};
 pub use query_parameter_builder::{*};
+pub use utils::{*};
 

--- a/seed/rust-sdk/enum/src/utils.rs
+++ b/seed/rust-sdk/enum/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/error-property/src/api_client_builder.rs
+++ b/seed/rust-sdk/error-property/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/error-property/src/client/property_based_error.rs
+++ b/seed/rust-sdk/error-property/src/client/property_based_error.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct PropertyBasedErrorClient {

--- a/seed/rust-sdk/error-property/src/http_client.rs
+++ b/seed/rust-sdk/error-property/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/error-property/src/lib.rs
+++ b/seed/rust-sdk/error-property/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/error-property/src/utils.rs
+++ b/seed/rust-sdk/error-property/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/errors/src/api_client_builder.rs
+++ b/seed/rust-sdk/errors/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/errors/src/client/simple.rs
+++ b/seed/rust-sdk/errors/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/errors/src/http_client.rs
+++ b/seed/rust-sdk/errors/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/errors/src/lib.rs
+++ b/seed/rust-sdk/errors/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/errors/src/utils.rs
+++ b/seed/rust-sdk/errors/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/exhaustive/src/api_client_builder.rs
+++ b/seed/rust-sdk/exhaustive/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/exhaustive/src/client/endpoints.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsClient {

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_container.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_container.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_content_type.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_content_type.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_enum_.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_enum_.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_http_methods.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_http_methods.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_object.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_object.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_params.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_params.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 
@@ -37,20 +37,8 @@ impl EndpointsParamsClient {
             Method::GET,
             "/params",
             None,
-            {
-            let mut query_builder = crate::QueryParameterBuilder::new();
-            if let Some(value) = query {
-                // Try to parse as structured query, fall back to simple if it fails
-                if let Err(_) = query_builder.add_structured_query(&value) {
-                    query_builder.add_simple("query", &value);
-                }
-            }
-            if let Some(value) = number {
-                query_builder.add_simple("number", &value.to_string());
-            }
-            let params = query_builder.build();
-            if params.is_empty() { None } else { Some(params) }
-        },
+            QueryBuilder::new().structured_query("query", query).int("number", number)
+            .build(),
             options,
         ).await
     }
@@ -60,20 +48,8 @@ impl EndpointsParamsClient {
             Method::GET,
             "/params",
             None,
-            {
-            let mut query_builder = crate::QueryParameterBuilder::new();
-            if let Some(value) = query {
-                // Try to parse as structured query, fall back to simple if it fails
-                if let Err(_) = query_builder.add_structured_query(&value) {
-                    query_builder.add_simple("query", &value);
-                }
-            }
-            if let Some(value) = number {
-                query_builder.add_simple("number", &value.to_string());
-            }
-            let params = query_builder.build();
-            if params.is_empty() { None } else { Some(params) }
-        },
+            QueryBuilder::new().structured_query("query", query).int("number", number)
+            .build(),
             options,
         ).await
     }
@@ -83,17 +59,8 @@ impl EndpointsParamsClient {
             Method::GET,
             &format!("/params/path-query/{}", param),
             None,
-            {
-            let mut query_builder = crate::QueryParameterBuilder::new();
-            if let Some(value) = query {
-                // Try to parse as structured query, fall back to simple if it fails
-                if let Err(_) = query_builder.add_structured_query(&value) {
-                    query_builder.add_simple("query", &value);
-                }
-            }
-            let params = query_builder.build();
-            if params.is_empty() { None } else { Some(params) }
-        },
+            QueryBuilder::new().structured_query("query", query)
+            .build(),
             options,
         ).await
     }
@@ -103,17 +70,8 @@ impl EndpointsParamsClient {
             Method::GET,
             &format!("/params/path-query/{}", param),
             None,
-            {
-            let mut query_builder = crate::QueryParameterBuilder::new();
-            if let Some(value) = query {
-                // Try to parse as structured query, fall back to simple if it fails
-                if let Err(_) = query_builder.add_structured_query(&value) {
-                    query_builder.add_simple("query", &value);
-                }
-            }
-            let params = query_builder.build();
-            if params.is_empty() { None } else { Some(params) }
-        },
+            QueryBuilder::new().structured_query("query", query)
+            .build(),
             options,
         ).await
     }

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_primitive.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_primitive.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_put.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_put.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_union_.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_union_.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/endpoints_urls.rs
+++ b/seed/rust-sdk/exhaustive/src/client/endpoints_urls.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/exhaustive/src/client/inlined_requests.rs
+++ b/seed/rust-sdk/exhaustive/src/client/inlined_requests.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct InlinedRequestsClient {

--- a/seed/rust-sdk/exhaustive/src/client/no_auth.rs
+++ b/seed/rust-sdk/exhaustive/src/client/no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NoAuthClient {

--- a/seed/rust-sdk/exhaustive/src/client/no_req_body.rs
+++ b/seed/rust-sdk/exhaustive/src/client/no_req_body.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NoReqBodyClient {

--- a/seed/rust-sdk/exhaustive/src/client/req_with_headers.rs
+++ b/seed/rust-sdk/exhaustive/src/client/req_with_headers.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ReqWithHeadersClient {

--- a/seed/rust-sdk/exhaustive/src/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/exhaustive/src/lib.rs
+++ b/seed/rust-sdk/exhaustive/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/exhaustive/src/utils.rs
+++ b/seed/rust-sdk/exhaustive/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/extends/src/api_client_builder.rs
+++ b/seed/rust-sdk/extends/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/extends/src/http_client.rs
+++ b/seed/rust-sdk/extends/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/extends/src/lib.rs
+++ b/seed/rust-sdk/extends/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/extends/src/utils.rs
+++ b/seed/rust-sdk/extends/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/extra-properties/src/api_client_builder.rs
+++ b/seed/rust-sdk/extra-properties/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/extra-properties/src/client/user.rs
+++ b/seed/rust-sdk/extra-properties/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/extra-properties/src/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/extra-properties/src/lib.rs
+++ b/seed/rust-sdk/extra-properties/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/extra-properties/src/utils.rs
+++ b/seed/rust-sdk/extra-properties/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/file-download/src/api_client_builder.rs
+++ b/seed/rust-sdk/file-download/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/file-download/src/client/service.rs
+++ b/seed/rust-sdk/file-download/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/file-download/src/http_client.rs
+++ b/seed/rust-sdk/file-download/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/file-download/src/lib.rs
+++ b/seed/rust-sdk/file-download/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/file-download/src/utils.rs
+++ b/seed/rust-sdk/file-download/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/file-upload/src/api_client_builder.rs
+++ b/seed/rust-sdk/file-upload/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/file-upload/src/client/service.rs
+++ b/seed/rust-sdk/file-upload/src/client/service.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {
@@ -59,28 +59,13 @@ impl ServiceClient {
                 Method::POST,
                 "/just-file-with-query-params",
                 Some(serde_json::to_value(request).unwrap_or_default()),
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = maybe_string {
-                        query_params.push(("maybeString".to_string(), value.clone()));
-                    }
-                    if let Some(value) = integer {
-                        query_params.push(("integer".to_string(), value.to_string()));
-                    }
-                    if let Some(value) = maybe_integer {
-                        query_params.push((
-                            "maybeInteger".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    if let Some(value) = list_of_strings {
-                        query_params.push(("listOfStrings".to_string(), value.clone()));
-                    }
-                    if let Some(value) = optional_list_of_strings {
-                        query_params.push(("optionalListOfStrings".to_string(), value.clone()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .string("maybeString", maybe_string)
+                    .int("integer", integer)
+                    .int("maybeInteger", maybe_integer)
+                    .string("listOfStrings", list_of_strings)
+                    .string("optionalListOfStrings", optional_list_of_strings)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/file-upload/src/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/file-upload/src/lib.rs
+++ b/seed/rust-sdk/file-upload/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/file-upload/src/utils.rs
+++ b/seed/rust-sdk/file-upload/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/folders/src/api_client_builder.rs
+++ b/seed/rust-sdk/folders/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/folders/src/client/a.rs
+++ b/seed/rust-sdk/folders/src/client/a.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AClient {

--- a/seed/rust-sdk/folders/src/client/a_b.rs
+++ b/seed/rust-sdk/folders/src/client/a_b.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/folders/src/client/a_c.rs
+++ b/seed/rust-sdk/folders/src/client/a_c.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/folders/src/client/folder.rs
+++ b/seed/rust-sdk/folders/src/client/folder.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderClient {

--- a/seed/rust-sdk/folders/src/client/folder_service.rs
+++ b/seed/rust-sdk/folders/src/client/folder_service.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/folders/src/http_client.rs
+++ b/seed/rust-sdk/folders/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/folders/src/lib.rs
+++ b/seed/rust-sdk/folders/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/folders/src/utils.rs
+++ b/seed/rust-sdk/folders/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/http-head/src/api_client_builder.rs
+++ b/seed/rust-sdk/http-head/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/http-head/src/client/user.rs
+++ b/seed/rust-sdk/http-head/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {
@@ -28,13 +28,7 @@ impl UserClient {
                 Method::GET,
                 "/users",
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = limit {
-                        query_params.push(("limit".to_string(), value.to_string()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new().int("limit", limit).build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/http-head/src/http_client.rs
+++ b/seed/rust-sdk/http-head/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/http-head/src/lib.rs
+++ b/seed/rust-sdk/http-head/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/http-head/src/utils.rs
+++ b/seed/rust-sdk/http-head/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/idempotency-headers/src/api_client_builder.rs
+++ b/seed/rust-sdk/idempotency-headers/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/idempotency-headers/src/client/payment.rs
+++ b/seed/rust-sdk/idempotency-headers/src/client/payment.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct PaymentClient {

--- a/seed/rust-sdk/idempotency-headers/src/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/idempotency-headers/src/lib.rs
+++ b/seed/rust-sdk/idempotency-headers/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/idempotency-headers/src/utils.rs
+++ b/seed/rust-sdk/idempotency-headers/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/imdb/imdb/src/api_client_builder.rs
+++ b/seed/rust-sdk/imdb/imdb/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/imdb/imdb/src/client/imdb.rs
+++ b/seed/rust-sdk/imdb/imdb/src/client/imdb.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ImdbClient {

--- a/seed/rust-sdk/imdb/imdb/src/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/imdb/imdb/src/lib.rs
+++ b/seed/rust-sdk/imdb/imdb/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/imdb/imdb/src/utils.rs
+++ b/seed/rust-sdk/imdb/imdb/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/inferred-auth-explicit/src/api_client_builder.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/inferred-auth-explicit/src/client/auth.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/client/nested.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/client/nested_api.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/inferred-auth-explicit/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/inferred-auth-explicit/src/client/simple.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/inferred-auth-explicit/src/lib.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/inferred-auth-explicit/src/utils.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api_client_builder.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/simple.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/lib.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/utils.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/inferred-auth-implicit/src/api_client_builder.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/inferred-auth-implicit/src/client/auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/client/nested.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/client/nested_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/inferred-auth-implicit/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/inferred-auth-implicit/src/client/simple.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/inferred-auth-implicit/src/lib.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/inferred-auth-implicit/src/utils.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/license/src/api_client_builder.rs
+++ b/seed/rust-sdk/license/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/license/src/http_client.rs
+++ b/seed/rust-sdk/license/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/license/src/lib.rs
+++ b/seed/rust-sdk/license/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/license/src/utils.rs
+++ b/seed/rust-sdk/license/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/literal/src/api_client_builder.rs
+++ b/seed/rust-sdk/literal/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/literal/src/client/headers.rs
+++ b/seed/rust-sdk/literal/src/client/headers.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct HeadersClient {

--- a/seed/rust-sdk/literal/src/client/inlined.rs
+++ b/seed/rust-sdk/literal/src/client/inlined.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct InlinedClient {

--- a/seed/rust-sdk/literal/src/client/path.rs
+++ b/seed/rust-sdk/literal/src/client/path.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct PathClient {

--- a/seed/rust-sdk/literal/src/client/query.rs
+++ b/seed/rust-sdk/literal/src/client/query.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct QueryClient {
@@ -30,69 +30,17 @@ impl QueryClient {
                 Method::POST,
                 "query",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = prompt {
-                        query_builder.add_simple(
-                            "prompt",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_prompt {
-                        query_builder.add_simple(
-                            "optional_prompt",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = alias_prompt {
-                        query_builder.add_simple(
-                            "alias_prompt",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = alias_optional_prompt {
-                        query_builder.add_simple(
-                            "alias_optional_prompt",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = query {
-                        // Try to parse as structured query, fall back to simple if it fails
-                        if let Err(_) = query_builder.add_structured_query(&value) {
-                            query_builder.add_simple("query", &value);
-                        }
-                    }
-                    if let Some(value) = stream {
-                        query_builder.add_simple(
-                            "stream",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_stream {
-                        query_builder.add_simple(
-                            "optional_stream",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = alias_stream {
-                        query_builder.add_simple(
-                            "alias_stream",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = alias_optional_stream {
-                        query_builder.add_simple(
-                            "alias_optional_stream",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .string("prompt", prompt)
+                    .serialize("optional_prompt", optional_prompt)
+                    .serialize("alias_prompt", alias_prompt)
+                    .serialize("alias_optional_prompt", alias_optional_prompt)
+                    .structured_query("query", query)
+                    .string("stream", stream)
+                    .serialize("optional_stream", optional_stream)
+                    .serialize("alias_stream", alias_stream)
+                    .serialize("alias_optional_stream", alias_optional_stream)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/literal/src/client/reference.rs
+++ b/seed/rust-sdk/literal/src/client/reference.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ReferenceClient {

--- a/seed/rust-sdk/literal/src/http_client.rs
+++ b/seed/rust-sdk/literal/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/literal/src/lib.rs
+++ b/seed/rust-sdk/literal/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/literal/src/utils.rs
+++ b/seed/rust-sdk/literal/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/literals-unions/src/api_client_builder.rs
+++ b/seed/rust-sdk/literals-unions/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/literals-unions/src/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/literals-unions/src/lib.rs
+++ b/seed/rust-sdk/literals-unions/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/literals-unions/src/utils.rs
+++ b/seed/rust-sdk/literals-unions/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/mixed-case/src/api_client_builder.rs
+++ b/seed/rust-sdk/mixed-case/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/mixed-case/src/client/service.rs
+++ b/seed/rust-sdk/mixed-case/src/client/service.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {
@@ -39,16 +39,10 @@ impl ServiceClient {
                 Method::GET,
                 "/resource",
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = page_limit {
-                        query_params.push(("page_limit".to_string(), value.to_string()));
-                    }
-                    if let Some(value) = before_date {
-                        query_params.push(("beforeDate".to_string(), value.to_rfc3339()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .int("page_limit", page_limit)
+                    .date("beforeDate", before_date)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/mixed-case/src/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/mixed-case/src/lib.rs
+++ b/seed/rust-sdk/mixed-case/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/mixed-case/src/utils.rs
+++ b/seed/rust-sdk/mixed-case/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/mixed-file-directory/src/api_client_builder.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/mixed-file-directory/src/client/organization.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/client/organization.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct OrganizationClient {

--- a/seed/rust-sdk/mixed-file-directory/src/client/user.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {
@@ -22,16 +22,7 @@ impl UserClient {
                 Method::GET,
                 "/users/",
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = limit {
-                        query_params.push((
-                            "limit".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new().int("limit", limit).build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/mixed-file-directory/src/client/user_events.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/client/user_events.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 
@@ -17,13 +17,8 @@ impl UserEventsClient {
             Method::GET,
             "/users/events/",
             None,
-            {
-            let mut query_params = Vec::new();
-            if let Some(value) = limit {
-                query_params.push(("limit".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            Some(query_params)
-        },
+            QueryBuilder::new().int("limit", limit)
+            .build(),
             options,
         ).await
     }

--- a/seed/rust-sdk/mixed-file-directory/src/client/user_events_metadata.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/client/user_events_metadata.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 
@@ -17,13 +17,8 @@ impl UserEventsMetadataClient {
             Method::GET,
             "/users/events/metadata/",
             None,
-            {
-            let mut query_params = Vec::new();
-            if let Some(value) = id {
-                query_params.push(("id".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            Some(query_params)
-        },
+            QueryBuilder::new().serialize("id", id)
+            .build(),
             options,
         ).await
     }

--- a/seed/rust-sdk/mixed-file-directory/src/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/mixed-file-directory/src/lib.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/mixed-file-directory/src/utils.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/multi-line-docs/src/api_client_builder.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/multi-line-docs/src/client/user.rs
+++ b/seed/rust-sdk/multi-line-docs/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/multi-line-docs/src/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/multi-line-docs/src/lib.rs
+++ b/seed/rust-sdk/multi-line-docs/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/multi-line-docs/src/utils.rs
+++ b/seed/rust-sdk/multi-line-docs/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/multi-url-environment-no-default/src/api_client_builder.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/multi-url-environment-no-default/src/client/ec_2.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/client/ec_2.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct Ec2Client {

--- a/seed/rust-sdk/multi-url-environment-no-default/src/client/s_3.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/client/s_3.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct S3Client {

--- a/seed/rust-sdk/multi-url-environment-no-default/src/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/multi-url-environment-no-default/src/lib.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/lib.rs
@@ -7,6 +7,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/multi-url-environment-no-default/src/utils.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/multi-url-environment/src/api_client_builder.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/multi-url-environment/src/client/ec_2.rs
+++ b/seed/rust-sdk/multi-url-environment/src/client/ec_2.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct Ec2Client {

--- a/seed/rust-sdk/multi-url-environment/src/client/s_3.rs
+++ b/seed/rust-sdk/multi-url-environment/src/client/s_3.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct S3Client {

--- a/seed/rust-sdk/multi-url-environment/src/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/multi-url-environment/src/lib.rs
+++ b/seed/rust-sdk/multi-url-environment/src/lib.rs
@@ -7,6 +7,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/multi-url-environment/src/utils.rs
+++ b/seed/rust-sdk/multi-url-environment/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/multiple-request-bodies/src/api_client_builder.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/multiple-request-bodies/src/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/multiple-request-bodies/src/lib.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/lib.rs
@@ -8,6 +8,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -19,3 +20,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/multiple-request-bodies/src/utils.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/no-environment/src/api_client_builder.rs
+++ b/seed/rust-sdk/no-environment/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/no-environment/src/client/dummy.rs
+++ b/seed/rust-sdk/no-environment/src/client/dummy.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/no-environment/src/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/no-environment/src/lib.rs
+++ b/seed/rust-sdk/no-environment/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/no-environment/src/utils.rs
+++ b/seed/rust-sdk/no-environment/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/nullable-optional/src/api_client_builder.rs
+++ b/seed/rust-sdk/nullable-optional/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/nullable-optional/src/client/nullable_optional.rs
+++ b/seed/rust-sdk/nullable-optional/src/client/nullable_optional.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NullableOptionalClient {
@@ -74,36 +74,12 @@ impl NullableOptionalClient {
                 Method::GET,
                 "/api/users",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = limit {
-                        query_builder.add_simple(
-                            "limit",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = offset {
-                        query_builder.add_simple(
-                            "offset",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = include_deleted {
-                        query_builder.add_simple(
-                            "includeDeleted",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = sort_by {
-                        query_builder.add_simple("sortBy", &value);
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .int("limit", limit)
+                    .int("offset", offset)
+                    .bool("includeDeleted", include_deleted)
+                    .serialize("sortBy", sort_by)
+                    .build(),
                 options,
             )
             .await
@@ -122,33 +98,12 @@ impl NullableOptionalClient {
                 Method::GET,
                 "/api/users/search",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = query {
-                        // Try to parse as structured query, fall back to simple if it fails
-                        if let Err(_) = query_builder.add_structured_query(&value) {
-                            query_builder.add_simple("query", &value);
-                        }
-                    }
-                    if let Some(value) = department {
-                        query_builder.add_simple("department", &value);
-                    }
-                    if let Some(value) = role {
-                        query_builder.add_simple("role", &value);
-                    }
-                    if let Some(value) = is_active {
-                        query_builder.add_simple(
-                            "isActive",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .structured_query("query", query)
+                    .string("department", department)
+                    .string("role", role)
+                    .serialize("isActive", is_active)
+                    .build(),
                 options,
             )
             .await
@@ -231,28 +186,11 @@ impl NullableOptionalClient {
                 Method::GET,
                 "/api/users/filter",
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = role {
-                        query_params.push((
-                            "role".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    if let Some(value) = status {
-                        query_params.push((
-                            "status".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    if let Some(value) = secondary_role {
-                        query_params.push((
-                            "secondaryRole".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .serialize("role", role)
+                    .serialize("status", status)
+                    .serialize("secondaryRole", secondary_role)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/nullable-optional/src/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/nullable-optional/src/lib.rs
+++ b/seed/rust-sdk/nullable-optional/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/nullable-optional/src/utils.rs
+++ b/seed/rust-sdk/nullable-optional/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/nullable/src/api_client_builder.rs
+++ b/seed/rust-sdk/nullable/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/nullable/src/client/nullable.rs
+++ b/seed/rust-sdk/nullable/src/client/nullable.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NullableClient {
@@ -26,31 +26,13 @@ impl NullableClient {
                 Method::GET,
                 "/users",
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = usernames {
-                        query_params.push(("usernames".to_string(), value.clone()));
-                    }
-                    if let Some(value) = avatar {
-                        query_params.push(("avatar".to_string(), value.clone()));
-                    }
-                    if let Some(value) = activated {
-                        query_params.push((
-                            "activated".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    if let Some(value) = tags {
-                        query_params.push(("tags".to_string(), value.clone()));
-                    }
-                    if let Some(value) = extra {
-                        query_params.push((
-                            "extra".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .string("usernames", usernames)
+                    .string("avatar", avatar)
+                    .bool("activated", activated)
+                    .serialize("tags", tags)
+                    .serialize("extra", extra)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/nullable/src/http_client.rs
+++ b/seed/rust-sdk/nullable/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/nullable/src/lib.rs
+++ b/seed/rust-sdk/nullable/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/nullable/src/utils.rs
+++ b/seed/rust-sdk/nullable/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api_client_builder.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/client/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/client/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/lib.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api_client_builder.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/oauth-client-credentials-default/src/client/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/client/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/client/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-default/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-default/src/client/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/oauth-client-credentials-default/src/lib.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-default/src/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api_client_builder.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/lib.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api_client_builder.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/lib.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api_client_builder.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/service.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/service.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/lib.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/oauth-client-credentials/src/api_client_builder.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/oauth-client-credentials/src/client/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/client/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/client/nested.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/client/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/client/nested_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials/src/client/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/client/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/client/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/client/nested_no_auth_api.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/oauth-client-credentials/src/client/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/client/simple.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/oauth-client-credentials/src/lib.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials/src/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/object/src/api_client_builder.rs
+++ b/seed/rust-sdk/object/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/object/src/http_client.rs
+++ b/seed/rust-sdk/object/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/object/src/lib.rs
+++ b/seed/rust-sdk/object/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/object/src/utils.rs
+++ b/seed/rust-sdk/object/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/optional/src/api_client_builder.rs
+++ b/seed/rust-sdk/optional/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/optional/src/client/optional.rs
+++ b/seed/rust-sdk/optional/src/client/optional.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct OptionalClient {

--- a/seed/rust-sdk/optional/src/http_client.rs
+++ b/seed/rust-sdk/optional/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/optional/src/lib.rs
+++ b/seed/rust-sdk/optional/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/optional/src/utils.rs
+++ b/seed/rust-sdk/optional/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/package-yml/src/api_client_builder.rs
+++ b/seed/rust-sdk/package-yml/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/package-yml/src/client/service.rs
+++ b/seed/rust-sdk/package-yml/src/client/service.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/package-yml/src/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/package-yml/src/lib.rs
+++ b/seed/rust-sdk/package-yml/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/package-yml/src/utils.rs
+++ b/seed/rust-sdk/package-yml/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/pagination-custom/src/api_client_builder.rs
+++ b/seed/rust-sdk/pagination-custom/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/pagination-custom/src/client/users.rs
+++ b/seed/rust-sdk/pagination-custom/src/client/users.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use crate::{AsyncPaginator, PaginationResult};
 use reqwest::Method;
 
@@ -19,13 +19,9 @@ impl UsersClient {
         options: Option<RequestOptions>,
     ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-        let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = starting_after {
-                query_params.push(("starting_after".to_string(), value.clone()));
-            }
-            Some(query_params)
-        };
+        let base_query_params = QueryBuilder::new()
+            .string("starting_after", starting_after)
+            .build();
         let options_clone = options.clone();
 
         AsyncPaginator::new(

--- a/seed/rust-sdk/pagination-custom/src/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/pagination-custom/src/lib.rs
+++ b/seed/rust-sdk/pagination-custom/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/pagination-custom/src/utils.rs
+++ b/seed/rust-sdk/pagination-custom/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/pagination/src/api_client_builder.rs
+++ b/seed/rust-sdk/pagination/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/pagination/src/client/complex.rs
+++ b/seed/rust-sdk/pagination/src/client/complex.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use crate::{AsyncPaginator, PaginationResult};
 use reqwest::Method;
 

--- a/seed/rust-sdk/pagination/src/client/inline_users.rs
+++ b/seed/rust-sdk/pagination/src/client/inline_users.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct InlineUsersClient {

--- a/seed/rust-sdk/pagination/src/client/inline_users_inline_users.rs
+++ b/seed/rust-sdk/pagination/src/client/inline_users_inline_users.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 use crate::{AsyncPaginator, PaginationResult};
@@ -15,19 +15,8 @@ impl InlineUsersInlineUsersClient {
 
     pub async fn list_with_cursor_pagination(&self, page: Option<i32>, per_page: Option<i32>, order: Option<Order>, starting_after: Option<String>, options: Option<RequestOptions>) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-            let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = page {
-                query_params.push(("page".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = per_page {
-                query_params.push(("per_page".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = order {
-                query_params.push(("order".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            Some(query_params)
-        };
+            let base_query_params = QueryBuilder::new().int("page", page).int("per_page", per_page).serialize("order", order)
+            .build();
             let options_clone = options.clone();
             
             
@@ -177,19 +166,8 @@ impl InlineUsersInlineUsersClient {
 
     pub async fn list_with_offset_pagination(&self, page: Option<i32>, per_page: Option<i32>, order: Option<Order>, starting_after: Option<String>, options: Option<RequestOptions>) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-            let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = per_page {
-                query_params.push(("per_page".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = order {
-                query_params.push(("order".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = starting_after {
-                query_params.push(("starting_after".to_string(), value.clone()));
-            }
-            Some(query_params)
-        };
+            let base_query_params = QueryBuilder::new().int("per_page", per_page).serialize("order", order).string("starting_after", starting_after)
+            .build();
             let options_clone = options.clone();
             
             
@@ -251,19 +229,8 @@ impl InlineUsersInlineUsersClient {
 
     pub async fn list_with_double_offset_pagination(&self, page: Option<f64>, per_page: Option<f64>, order: Option<Order>, starting_after: Option<String>, options: Option<RequestOptions>) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-            let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = per_page {
-                query_params.push(("per_page".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = order {
-                query_params.push(("order".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            if let Some(value) = starting_after {
-                query_params.push(("starting_after".to_string(), value.clone()));
-            }
-            Some(query_params)
-        };
+            let base_query_params = QueryBuilder::new().float("per_page", per_page).serialize("order", order).string("starting_after", starting_after)
+            .build();
             let options_clone = options.clone();
             
             
@@ -387,13 +354,8 @@ impl InlineUsersInlineUsersClient {
 
     pub async fn list_with_offset_step_pagination(&self, page: Option<i32>, limit: Option<i32>, order: Option<Order>, options: Option<RequestOptions>) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-            let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = order {
-                query_params.push(("order".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            Some(query_params)
-        };
+            let base_query_params = QueryBuilder::new().serialize("order", order)
+            .build();
             let options_clone = options.clone();
             
             
@@ -455,13 +417,8 @@ impl InlineUsersInlineUsersClient {
 
     pub async fn list_with_offset_pagination_has_next_page(&self, page: Option<i32>, limit: Option<i32>, order: Option<Order>, options: Option<RequestOptions>) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-            let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = order {
-                query_params.push(("order".to_string(), serde_json::to_string(&value).unwrap_or_default()));
-            }
-            Some(query_params)
-        };
+            let base_query_params = QueryBuilder::new().serialize("order", order)
+            .build();
             let options_clone = options.clone();
             
             

--- a/seed/rust-sdk/pagination/src/client/users.rs
+++ b/seed/rust-sdk/pagination/src/client/users.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use crate::{AsyncPaginator, PaginationResult};
 use reqwest::Method;
 
@@ -22,28 +22,11 @@ impl UsersClient {
         options: Option<RequestOptions>,
     ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-        let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = page {
-                query_params.push((
-                    "page".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            if let Some(value) = per_page {
-                query_params.push((
-                    "per_page".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            if let Some(value) = order {
-                query_params.push((
-                    "order".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            Some(query_params)
-        };
+        let base_query_params = QueryBuilder::new()
+            .int("page", page)
+            .int("per_page", per_page)
+            .serialize("order", order)
+            .build();
         let options_clone = options.clone();
 
         AsyncPaginator::new(
@@ -223,25 +206,11 @@ impl UsersClient {
         options: Option<RequestOptions>,
     ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-        let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = per_page {
-                query_params.push((
-                    "per_page".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            if let Some(value) = order {
-                query_params.push((
-                    "order".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            if let Some(value) = starting_after {
-                query_params.push(("starting_after".to_string(), value.clone()));
-            }
-            Some(query_params)
-        };
+        let base_query_params = QueryBuilder::new()
+            .int("per_page", per_page)
+            .serialize("order", order)
+            .string("starting_after", starting_after)
+            .build();
         let options_clone = options.clone();
 
         AsyncPaginator::new(
@@ -311,25 +280,11 @@ impl UsersClient {
         options: Option<RequestOptions>,
     ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-        let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = per_page {
-                query_params.push((
-                    "per_page".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            if let Some(value) = order {
-                query_params.push((
-                    "order".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            if let Some(value) = starting_after {
-                query_params.push(("starting_after".to_string(), value.clone()));
-            }
-            Some(query_params)
-        };
+        let base_query_params = QueryBuilder::new()
+            .float("per_page", per_page)
+            .serialize("order", order)
+            .string("starting_after", starting_after)
+            .build();
         let options_clone = options.clone();
 
         AsyncPaginator::new(
@@ -467,16 +422,7 @@ impl UsersClient {
         options: Option<RequestOptions>,
     ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-        let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = order {
-                query_params.push((
-                    "order".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            Some(query_params)
-        };
+        let base_query_params = QueryBuilder::new().serialize("order", order).build();
         let options_clone = options.clone();
 
         AsyncPaginator::new(
@@ -545,16 +491,7 @@ impl UsersClient {
         options: Option<RequestOptions>,
     ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
         let http_client = std::sync::Arc::new(self.http_client.clone());
-        let base_query_params = {
-            let mut query_params = Vec::new();
-            if let Some(value) = order {
-                query_params.push((
-                    "order".to_string(),
-                    serde_json::to_string(&value).unwrap_or_default(),
-                ));
-            }
-            Some(query_params)
-        };
+        let base_query_params = QueryBuilder::new().serialize("order", order).build();
         let options_clone = options.clone();
 
         AsyncPaginator::new(

--- a/seed/rust-sdk/pagination/src/http_client.rs
+++ b/seed/rust-sdk/pagination/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/pagination/src/lib.rs
+++ b/seed/rust-sdk/pagination/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/pagination/src/utils.rs
+++ b/seed/rust-sdk/pagination/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/path-parameters/src/api_client_builder.rs
+++ b/seed/rust-sdk/path-parameters/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/path-parameters/src/client/organizations.rs
+++ b/seed/rust-sdk/path-parameters/src/client/organizations.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct OrganizationsClient {
@@ -59,16 +59,7 @@ impl OrganizationsClient {
                 Method::GET,
                 &format!("/{}{}", tenant_id, organization_id),
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = limit {
-                        query_params.push((
-                            "limit".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new().int("limit", limit).build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/path-parameters/src/client/user.rs
+++ b/seed/rust-sdk/path-parameters/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {
@@ -76,16 +76,7 @@ impl UserClient {
                 Method::GET,
                 &format!("/{}{}", tenant_id, user_id),
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = limit {
-                        query_params.push((
-                            "limit".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new().int("limit", limit).build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/path-parameters/src/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/path-parameters/src/lib.rs
+++ b/seed/rust-sdk/path-parameters/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/path-parameters/src/utils.rs
+++ b/seed/rust-sdk/path-parameters/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/plain-text/src/api_client_builder.rs
+++ b/seed/rust-sdk/plain-text/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/plain-text/src/client/service.rs
+++ b/seed/rust-sdk/plain-text/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/plain-text/src/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/plain-text/src/lib.rs
+++ b/seed/rust-sdk/plain-text/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/plain-text/src/utils.rs
+++ b/seed/rust-sdk/plain-text/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/property-access/src/api_client_builder.rs
+++ b/seed/rust-sdk/property-access/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/property-access/src/http_client.rs
+++ b/seed/rust-sdk/property-access/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/property-access/src/lib.rs
+++ b/seed/rust-sdk/property-access/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/property-access/src/utils.rs
+++ b/seed/rust-sdk/property-access/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/public-object/src/api_client_builder.rs
+++ b/seed/rust-sdk/public-object/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/public-object/src/client/service.rs
+++ b/seed/rust-sdk/public-object/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/public-object/src/http_client.rs
+++ b/seed/rust-sdk/public-object/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/public-object/src/lib.rs
+++ b/seed/rust-sdk/public-object/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/public-object/src/utils.rs
+++ b/seed/rust-sdk/public-object/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/api_client_builder.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/lib.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/utils.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/query-parameters-openapi/src/api_client_builder.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/query-parameters-openapi/src/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/query-parameters-openapi/src/lib.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/query-parameters-openapi/src/utils.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/query-parameters/src/api_client_builder.rs
+++ b/seed/rust-sdk/query-parameters/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/query-parameters/src/client/user.rs
+++ b/seed/rust-sdk/query-parameters/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 use std::collections::HashMap;
 
@@ -36,73 +36,22 @@ impl UserClient {
                 Method::GET,
                 "/user",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = limit {
-                        query_builder.add_simple("limit", &value.to_string());
-                    }
-                    if let Some(value) = id {
-                        query_builder.add_simple("id", &value.to_string());
-                    }
-                    if let Some(value) = date {
-                        query_builder.add_simple("date", &value.to_rfc3339());
-                    }
-                    if let Some(value) = deadline {
-                        query_builder.add_simple("deadline", &value.to_rfc3339());
-                    }
-                    if let Some(value) = bytes {
-                        query_builder.add_simple("bytes", &value.to_string());
-                    }
-                    if let Some(value) = user {
-                        query_builder
-                            .add_simple("user", &serde_json::to_string(&value).unwrap_or_default());
-                    }
-                    if let Some(value) = user_list {
-                        query_builder.add_simple(
-                            "userList",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_deadline {
-                        query_builder.add_simple("optionalDeadline", &value.to_rfc3339());
-                    }
-                    if let Some(value) = key_value {
-                        query_builder.add_simple(
-                            "keyValue",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_string {
-                        query_builder.add_simple("optionalString", &value);
-                    }
-                    if let Some(value) = nested_user {
-                        query_builder.add_simple(
-                            "nestedUser",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_user {
-                        query_builder.add_simple(
-                            "optionalUser",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = exclude_user {
-                        query_builder.add_simple(
-                            "excludeUser",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = filter {
-                        query_builder.add_simple("filter", &value);
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .int("limit", limit)
+                    .uuid("id", id)
+                    .date("date", date)
+                    .datetime("deadline", deadline)
+                    .string("bytes", bytes)
+                    .serialize("user", user)
+                    .serialize("userList", user_list)
+                    .datetime("optionalDeadline", optional_deadline)
+                    .serialize("keyValue", key_value)
+                    .string("optionalString", optional_string)
+                    .serialize("nestedUser", nested_user)
+                    .serialize("optionalUser", optional_user)
+                    .serialize("excludeUser", exclude_user)
+                    .string("filter", filter)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/query-parameters/src/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/query-parameters/src/lib.rs
+++ b/seed/rust-sdk/query-parameters/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/query-parameters/src/utils.rs
+++ b/seed/rust-sdk/query-parameters/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/request-parameters/src/api_client_builder.rs
+++ b/seed/rust-sdk/request-parameters/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/request-parameters/src/client/user.rs
+++ b/seed/rust-sdk/request-parameters/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 use std::collections::HashMap;
 
@@ -24,16 +24,7 @@ impl UserClient {
                 Method::POST,
                 "/user/username",
                 Some(serde_json::to_value(request).unwrap_or_default()),
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = tags {
-                        query_params.push((
-                            "tags".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new().serialize("tags", tags).build(),
                 options,
             )
             .await
@@ -50,16 +41,7 @@ impl UserClient {
                 Method::POST,
                 "/user/username-referenced",
                 Some(serde_json::to_value(request).unwrap_or_default()),
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = tags {
-                        query_params.push((
-                            "tags".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new().serialize("tags", tags).build(),
                 options,
             )
             .await
@@ -90,79 +72,24 @@ impl UserClient {
                 Method::GET,
                 "/user",
                 None,
-                {
-                    let mut query_builder = crate::QueryParameterBuilder::new();
-                    if let Some(value) = limit {
-                        query_builder.add_simple("limit", &value.to_string());
-                    }
-                    if let Some(value) = id {
-                        query_builder.add_simple("id", &value.to_string());
-                    }
-                    if let Some(value) = date {
-                        query_builder.add_simple("date", &value.to_rfc3339());
-                    }
-                    if let Some(value) = deadline {
-                        query_builder.add_simple("deadline", &value.to_rfc3339());
-                    }
-                    if let Some(value) = bytes {
-                        query_builder.add_simple("bytes", &value.to_string());
-                    }
-                    if let Some(value) = user {
-                        query_builder
-                            .add_simple("user", &serde_json::to_string(&value).unwrap_or_default());
-                    }
-                    if let Some(value) = user_list {
-                        query_builder.add_simple(
-                            "userList",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_deadline {
-                        query_builder.add_simple("optionalDeadline", &value.to_rfc3339());
-                    }
-                    if let Some(value) = key_value {
-                        query_builder.add_simple(
-                            "keyValue",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_string {
-                        query_builder.add_simple("optionalString", &value);
-                    }
-                    if let Some(value) = nested_user {
-                        query_builder.add_simple(
-                            "nestedUser",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = optional_user {
-                        query_builder.add_simple(
-                            "optionalUser",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = exclude_user {
-                        query_builder.add_simple(
-                            "excludeUser",
-                            &serde_json::to_string(&value).unwrap_or_default(),
-                        );
-                    }
-                    if let Some(value) = filter {
-                        query_builder.add_simple("filter", &value);
-                    }
-                    if let Some(value) = long_param {
-                        query_builder.add_simple("longParam", &value.to_string());
-                    }
-                    if let Some(value) = big_int_param {
-                        query_builder.add_simple("bigIntParam", &value.to_string());
-                    }
-                    let params = query_builder.build();
-                    if params.is_empty() {
-                        None
-                    } else {
-                        Some(params)
-                    }
-                },
+                QueryBuilder::new()
+                    .int("limit", limit)
+                    .uuid("id", id)
+                    .date("date", date)
+                    .datetime("deadline", deadline)
+                    .string("bytes", bytes)
+                    .serialize("user", user)
+                    .serialize("userList", user_list)
+                    .datetime("optionalDeadline", optional_deadline)
+                    .serialize("keyValue", key_value)
+                    .string("optionalString", optional_string)
+                    .serialize("nestedUser", nested_user)
+                    .serialize("optionalUser", optional_user)
+                    .serialize("excludeUser", exclude_user)
+                    .string("filter", filter)
+                    .int("longParam", long_param)
+                    .string("bigIntParam", big_int_param)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/request-parameters/src/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/request-parameters/src/lib.rs
+++ b/seed/rust-sdk/request-parameters/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/request-parameters/src/utils.rs
+++ b/seed/rust-sdk/request-parameters/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/reserved-keywords/src/api_client_builder.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/reserved-keywords/src/client/package.rs
+++ b/seed/rust-sdk/reserved-keywords/src/client/package.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 
@@ -17,13 +17,8 @@ impl PackageClient {
             Method::POST,
             "",
             None,
-            {
-            let mut query_params = Vec::new();
-            if let Some(value) = for_ {
-                query_params.push(("for".to_string(), value.clone()));
-            }
-            Some(query_params)
-        },
+            QueryBuilder::new().string("for", for_)
+            .build(),
             options,
         ).await
     }

--- a/seed/rust-sdk/reserved-keywords/src/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/reserved-keywords/src/lib.rs
+++ b/seed/rust-sdk/reserved-keywords/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod request_options;
 pub mod pagination;
 pub mod query_parameter_builder;
+pub mod utils;
 pub mod types;
 
 pub use client::{*};
@@ -17,4 +18,5 @@ pub use http_client::{*};
 pub use request_options::{*};
 pub use pagination::{*};
 pub use query_parameter_builder::{*};
+pub use utils::{*};
 

--- a/seed/rust-sdk/reserved-keywords/src/utils.rs
+++ b/seed/rust-sdk/reserved-keywords/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/response-property/src/api_client_builder.rs
+++ b/seed/rust-sdk/response-property/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/response-property/src/client/service.rs
+++ b/seed/rust-sdk/response-property/src/client/service.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/response-property/src/http_client.rs
+++ b/seed/rust-sdk/response-property/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/response-property/src/lib.rs
+++ b/seed/rust-sdk/response-property/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/response-property/src/utils.rs
+++ b/seed/rust-sdk/response-property/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/server-sent-event-examples/src/api_client_builder.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/server-sent-event-examples/src/client/completions.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/client/completions.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct CompletionsClient {

--- a/seed/rust-sdk/server-sent-event-examples/src/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/server-sent-event-examples/src/lib.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/server-sent-event-examples/src/utils.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/server-sent-events/src/api_client_builder.rs
+++ b/seed/rust-sdk/server-sent-events/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/server-sent-events/src/client/completions.rs
+++ b/seed/rust-sdk/server-sent-events/src/client/completions.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct CompletionsClient {

--- a/seed/rust-sdk/server-sent-events/src/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/server-sent-events/src/lib.rs
+++ b/seed/rust-sdk/server-sent-events/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/server-sent-events/src/utils.rs
+++ b/seed/rust-sdk/server-sent-events/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/simple-api/src/api_client_builder.rs
+++ b/seed/rust-sdk/simple-api/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/simple-api/src/client/user.rs
+++ b/seed/rust-sdk/simple-api/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/simple-api/src/http_client.rs
+++ b/seed/rust-sdk/simple-api/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/simple-api/src/lib.rs
+++ b/seed/rust-sdk/simple-api/src/lib.rs
@@ -8,6 +8,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -19,3 +20,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/simple-api/src/utils.rs
+++ b/seed/rust-sdk/simple-api/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/simple-fhir/src/api_client_builder.rs
+++ b/seed/rust-sdk/simple-fhir/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/simple-fhir/src/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/simple-fhir/src/lib.rs
+++ b/seed/rust-sdk/simple-fhir/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/simple-fhir/src/utils.rs
+++ b/seed/rust-sdk/simple-fhir/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/single-url-environment-default/src/api_client_builder.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/single-url-environment-default/src/client/dummy.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/client/dummy.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/single-url-environment-default/src/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/single-url-environment-default/src/lib.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/lib.rs
@@ -7,6 +7,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/single-url-environment-default/src/utils.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/single-url-environment-no-default/src/api_client_builder.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/single-url-environment-no-default/src/client/dummy.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/client/dummy.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/single-url-environment-no-default/src/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/single-url-environment-no-default/src/lib.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/lib.rs
@@ -7,6 +7,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/single-url-environment-no-default/src/utils.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/streaming-parameter/src/api_client_builder.rs
+++ b/seed/rust-sdk/streaming-parameter/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/streaming-parameter/src/client/dummy.rs
+++ b/seed/rust-sdk/streaming-parameter/src/client/dummy.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/streaming-parameter/src/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/streaming-parameter/src/lib.rs
+++ b/seed/rust-sdk/streaming-parameter/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/streaming-parameter/src/utils.rs
+++ b/seed/rust-sdk/streaming-parameter/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/streaming/src/api_client_builder.rs
+++ b/seed/rust-sdk/streaming/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/streaming/src/client/dummy.rs
+++ b/seed/rust-sdk/streaming/src/client/dummy.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/streaming/src/http_client.rs
+++ b/seed/rust-sdk/streaming/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/streaming/src/lib.rs
+++ b/seed/rust-sdk/streaming/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/streaming/src/utils.rs
+++ b/seed/rust-sdk/streaming/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/trace/src/api_client_builder.rs
+++ b/seed/rust-sdk/trace/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/trace/src/client/admin.rs
+++ b/seed/rust-sdk/trace/src/client/admin.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AdminClient {

--- a/seed/rust-sdk/trace/src/client/homepage.rs
+++ b/seed/rust-sdk/trace/src/client/homepage.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct HomepageClient {

--- a/seed/rust-sdk/trace/src/client/migration.rs
+++ b/seed/rust-sdk/trace/src/client/migration.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct MigrationClient {

--- a/seed/rust-sdk/trace/src/client/playlist.rs
+++ b/seed/rust-sdk/trace/src/client/playlist.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct PlaylistClient {
@@ -25,16 +25,10 @@ impl PlaylistClient {
                 Method::POST,
                 &format!("/v2/playlist/{}", service_param),
                 Some(serde_json::to_value(request).unwrap_or_default()),
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = datetime {
-                        query_params.push(("datetime".to_string(), value.to_rfc3339()));
-                    }
-                    if let Some(value) = optional_datetime {
-                        query_params.push(("optionalDatetime".to_string(), value.to_rfc3339()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .datetime("datetime", datetime)
+                    .datetime("optionalDatetime", optional_datetime)
+                    .build(),
                 options,
             )
             .await
@@ -55,28 +49,13 @@ impl PlaylistClient {
                 Method::GET,
                 &format!("/v2/playlist/{}", service_param),
                 None,
-                {
-                    let mut query_params = Vec::new();
-                    if let Some(value) = limit {
-                        query_params.push((
-                            "limit".to_string(),
-                            serde_json::to_string(&value).unwrap_or_default(),
-                        ));
-                    }
-                    if let Some(value) = other_field {
-                        query_params.push(("otherField".to_string(), value.clone()));
-                    }
-                    if let Some(value) = multi_line_docs {
-                        query_params.push(("multiLineDocs".to_string(), value.clone()));
-                    }
-                    if let Some(value) = optional_multiple_field {
-                        query_params.push(("optionalMultipleField".to_string(), value.clone()));
-                    }
-                    if let Some(value) = multiple_field {
-                        query_params.push(("multipleField".to_string(), value.clone()));
-                    }
-                    Some(query_params)
-                },
+                QueryBuilder::new()
+                    .int("limit", limit)
+                    .string("otherField", other_field)
+                    .string("multiLineDocs", multi_line_docs)
+                    .string("optionalMultipleField", optional_multiple_field)
+                    .string("multipleField", multiple_field)
+                    .build(),
                 options,
             )
             .await

--- a/seed/rust-sdk/trace/src/client/problem.rs
+++ b/seed/rust-sdk/trace/src/client/problem.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ProblemClient {

--- a/seed/rust-sdk/trace/src/client/submission.rs
+++ b/seed/rust-sdk/trace/src/client/submission.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SubmissionClient {

--- a/seed/rust-sdk/trace/src/client/sysprop.rs
+++ b/seed/rust-sdk/trace/src/client/sysprop.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct SyspropClient {

--- a/seed/rust-sdk/trace/src/client/v_2.rs
+++ b/seed/rust-sdk/trace/src/client/v_2.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct V2Client {

--- a/seed/rust-sdk/trace/src/client/v_2_problem.rs
+++ b/seed/rust-sdk/trace/src/client/v_2_problem.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/trace/src/client/v_2_v_3.rs
+++ b/seed/rust-sdk/trace/src/client/v_2_v_3.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/trace/src/client/v_2_v_3_problem.rs
+++ b/seed/rust-sdk/trace/src/client/v_2_v_3_problem.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::{Method};
 use crate::{types::*};
 

--- a/seed/rust-sdk/trace/src/http_client.rs
+++ b/seed/rust-sdk/trace/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/trace/src/lib.rs
+++ b/seed/rust-sdk/trace/src/lib.rs
@@ -8,6 +8,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -19,3 +20,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/trace/src/utils.rs
+++ b/seed/rust-sdk/trace/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/undiscriminated-unions/src/api_client_builder.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/undiscriminated-unions/src/client/union_.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/client/union_.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UnionClient {

--- a/seed/rust-sdk/undiscriminated-unions/src/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/undiscriminated-unions/src/lib.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/undiscriminated-unions/src/utils.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/unions/src/api_client_builder.rs
+++ b/seed/rust-sdk/unions/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/unions/src/client/bigunion.rs
+++ b/seed/rust-sdk/unions/src/client/bigunion.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct BigunionClient {

--- a/seed/rust-sdk/unions/src/client/union_.rs
+++ b/seed/rust-sdk/unions/src/client/union_.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UnionClient {

--- a/seed/rust-sdk/unions/src/http_client.rs
+++ b/seed/rust-sdk/unions/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/unions/src/lib.rs
+++ b/seed/rust-sdk/unions/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/unions/src/utils.rs
+++ b/seed/rust-sdk/unions/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/unknown/src/api_client_builder.rs
+++ b/seed/rust-sdk/unknown/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/unknown/src/client/unknown.rs
+++ b/seed/rust-sdk/unknown/src/client/unknown.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UnknownClient {

--- a/seed/rust-sdk/unknown/src/http_client.rs
+++ b/seed/rust-sdk/unknown/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/unknown/src/lib.rs
+++ b/seed/rust-sdk/unknown/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/unknown/src/utils.rs
+++ b/seed/rust-sdk/unknown/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/validation/src/api_client_builder.rs
+++ b/seed/rust-sdk/validation/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/validation/src/http_client.rs
+++ b/seed/rust-sdk/validation/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/validation/src/lib.rs
+++ b/seed/rust-sdk/validation/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/validation/src/utils.rs
+++ b/seed/rust-sdk/validation/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/variables/src/api_client_builder.rs
+++ b/seed/rust-sdk/variables/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/variables/src/client/service.rs
+++ b/seed/rust-sdk/variables/src/client/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/variables/src/http_client.rs
+++ b/seed/rust-sdk/variables/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/variables/src/lib.rs
+++ b/seed/rust-sdk/variables/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http_client;
 pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -15,3 +16,4 @@ pub use http_client::*;
 pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
+pub use utils::*;

--- a/seed/rust-sdk/variables/src/utils.rs
+++ b/seed/rust-sdk/variables/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/version-no-default/src/api_client_builder.rs
+++ b/seed/rust-sdk/version-no-default/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/version-no-default/src/client/user.rs
+++ b/seed/rust-sdk/version-no-default/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/version-no-default/src/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/version-no-default/src/lib.rs
+++ b/seed/rust-sdk/version-no-default/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/version-no-default/src/utils.rs
+++ b/seed/rust-sdk/version-no-default/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/version/src/api_client_builder.rs
+++ b/seed/rust-sdk/version/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/version/src/client/user.rs
+++ b/seed/rust-sdk/version/src/client/user.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/version/src/http_client.rs
+++ b/seed/rust-sdk/version/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/version/src/lib.rs
+++ b/seed/rust-sdk/version/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/version/src/utils.rs
+++ b/seed/rust-sdk/version/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/websocket-bearer-auth/src/api_client_builder.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/websocket-bearer-auth/src/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/websocket-bearer-auth/src/lib.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/websocket-bearer-auth/src/utils.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/websocket-inferred-auth/src/api_client_builder.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/websocket-inferred-auth/src/client/auth.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/client/auth.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/websocket-inferred-auth/src/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/websocket-inferred-auth/src/lib.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/websocket-inferred-auth/src/utils.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}

--- a/seed/rust-sdk/websocket/src/api_client_builder.rs
+++ b/seed/rust-sdk/websocket/src/api_client_builder.rs
@@ -3,6 +3,21 @@ use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
 
+/*
+Things to know:
+
+`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
+It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
+
+Types that implement Into<String>:
+
+// All of these work:
+builder.api_key("hello")           // &str
+builder.api_key("hello".to_string()) // String
+builder.api_key(format!("key_{}", id)) // String from format!
+builder.api_key(my_string_variable)    // String variable
+*/
+
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,

--- a/seed/rust-sdk/websocket/src/http_client.rs
+++ b/seed/rust-sdk/websocket/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions};
+use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,
@@ -34,13 +34,9 @@ impl HttpClient {
         options: Option<RequestOptions>,
     ) -> Result<T, ApiError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned, // Generic T: DeserializeOwned means the response will be automatically deserialized into whatever type you specify:
     {
-        let url = format!(
-            "{}/{}",
-            self.config.base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        );
+        let url = join_url(&self.config.base_url, path);
         let mut request = self.client.request(method, &url);
 
         // Apply query parameters if provided

--- a/seed/rust-sdk/websocket/src/lib.rs
+++ b/seed/rust-sdk/websocket/src/lib.rs
@@ -7,6 +7,7 @@ pub mod pagination;
 pub mod query_parameter_builder;
 pub mod request_options;
 pub mod types;
+pub mod utils;
 
 pub use api_client_builder::*;
 pub use client::*;
@@ -17,3 +18,4 @@ pub use pagination::*;
 pub use query_parameter_builder::*;
 pub use request_options::*;
 pub use types::*;
+pub use utils::*;

--- a/seed/rust-sdk/websocket/src/utils.rs
+++ b/seed/rust-sdk/websocket/src/utils.rs
@@ -1,0 +1,21 @@
+/// URL building utilities
+pub mod Utils {
+    /// Safely join a base URL with a path, handling slashes properly
+    ///
+    /// # Examples
+    /// ```
+    /// use example_api::utils::url::join_url;
+    ///
+    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+    /// ```
+    pub fn join_url(base_url: &str, path: &str) -> String {
+        format!(
+            "{}/{}",
+            base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}


### PR DESCRIPTION
## Description
  
Linear ticket: https://linear.app/buildwithfern/issue/FER-6637/refactor-query-params-to-use-builder-pattern
 
This PR refactors the Rust SDK generator to use a modern builder pattern for query parameters to improve the developer experience and code readability. The changes replace manual query parameter construction with a type-safe builder pattern API.

## Changes Made
  
- Implemented `QueryBuilder` with method chaining API for query parameters
- Added type-safe methods for common parameter types (`string, int, float, bool, datetime, UUID ...`)
- Refactored query parameter generation in `SubClientGenerator.ts` to use the new builder pattern
- Updated all generated SDK snapshots to use the new `QueryBuilder::new().string().build()` syntax
- Added structured query parsing for complex query patterns with proper error handling

## Extra's

- Created utility module with URL joining functionality and example docs

## Testing

- [x] Unit tests added/updated for QueryParameterGenerator with new snapshot tests
- [x] Manual testing completed