### PR TITLE
fix(go): final fixes for go  dynamic snippets blocking wire test generation

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -957,7 +957,7 @@ export class EndpointSnippetGenerator {
                                   //Exclude optional since it appears that optional query params do not automatically get mocked in the dynamic snippet invocation (for now)
                                   .filter(
                                       (queryParameter: FernIr.dynamic.NamedParameter) =>
-                                          queryParameter.typeReference.type !== "optional"
+                                          !this.context.isOptional(queryParameter.typeReference)
                                   )
                                   .map((queryParameter: FernIr.dynamic.NamedParameter) => ({
                                       method: "WithQueryParam",

--- a/generators/go-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/go-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -388,6 +388,9 @@ func do() {
 					"Second",
 				),
 			},
+			MaybeFile: strings.NewReader(
+				"",
+			),
 		},
 	)
 }
@@ -1215,6 +1218,9 @@ func do() {
 					"Second",
 				),
 			},
+			MaybeFile: strings.NewReader(
+				"",
+			),
 		},
 	)
 }
@@ -2042,6 +2048,9 @@ func do() {
 					"Second",
 				),
 			},
+			MaybeFile: strings.NewReader(
+				"",
+			),
 		},
 	)
 }

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -2,6 +2,7 @@ import {
     AbstractDynamicSnippetsGeneratorContext,
     FernGeneratorExec
 } from "@fern-api/browser-compatible-base-generator";
+import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { BaseGoCustomConfigSchema, go, resolveRootImportPath } from "@fern-api/go-ast";
 
@@ -38,6 +39,25 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
             ir: this.ir,
             config: this.config
         });
+    }
+
+    public isOptional(typeReference: FernIr.dynamic.TypeReference): boolean {
+        switch (typeReference.type) {
+            case "optional":
+            case "map":
+                return true;
+            case "nullable":
+            case "list":
+            case "set":
+                return this.isOptional(typeReference.value);
+            case "named":
+            case "literal":
+            case "primitive":
+            case "unknown":
+                return false;
+            default:
+                assertNever(typeReference);
+        }
     }
 
     public getMethodName(name: FernIr.Name): string {

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
@@ -167,14 +167,8 @@ export class DynamicTypeInstantiationMapper {
         }
     }
 
-    private convertAlias({
-        aliasType,
-        literalValue
-    }: {
-        aliasType: FernIr.dynamic.NamedType.Alias;
-        literalValue: FernIr.dynamic.TypeReference;
-    }): go.TypeInstantiation {
-        switch (literalValue.type) {
+    private convertAlias({ aliasType }: { aliasType: FernIr.dynamic.NamedType.Alias }): go.TypeInstantiation {
+        switch (aliasType.typeReference.type) {
             case "literal":
                 return go.TypeInstantiation.reference(
                     go.invokeFunc({
@@ -182,7 +176,7 @@ export class DynamicTypeInstantiationMapper {
                             name: this.context.getTypeName(aliasType.declaration.name),
                             importPath: this.context.getImportPath(aliasType.declaration.fernFilepath)
                         }),
-                        arguments_: [this.convertLiteralValue(literalValue.value)]
+                        arguments_: [this.convertLiteralValue(aliasType.typeReference.value)]
                     })
                 );
             default:

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
@@ -146,10 +146,10 @@ export class DynamicTypeInstantiationMapper {
     }): go.TypeInstantiation {
         switch (named.type) {
             case "alias":
-                // return this.convert({ typeReference: named.typeReference, value, as });
                 return this.convertAlias({
                     aliasType: named,
-                    literalValue: named.typeReference
+                    value,
+                    as
                 });
             case "discriminatedUnion":
                 return this.convertDiscriminatedUnion({
@@ -167,7 +167,15 @@ export class DynamicTypeInstantiationMapper {
         }
     }
 
-    private convertAlias({ aliasType }: { aliasType: FernIr.dynamic.NamedType.Alias }): go.TypeInstantiation {
+    private convertAlias({
+        aliasType,
+        value,
+        as
+    }: {
+        aliasType: FernIr.dynamic.NamedType.Alias;
+        value: unknown;
+        as?: DynamicTypeInstantiationMapper.ConvertedAs;
+    }): go.TypeInstantiation {
         switch (aliasType.typeReference.type) {
             case "literal":
                 return go.TypeInstantiation.reference(
@@ -180,7 +188,7 @@ export class DynamicTypeInstantiationMapper {
                     })
                 );
             default:
-                return go.TypeInstantiation.nop();
+                return this.convert({ typeReference: aliasType.typeReference, value, as });
         }
     }
 
@@ -191,7 +199,7 @@ export class DynamicTypeInstantiationMapper {
             case "string":
                 return go.TypeInstantiation.string(literal.value);
             default:
-                return go.TypeInstantiation.nop();
+                assertNever(literal);
         }
     }
 

--- a/generators/go-v2/dynamic-snippets/src/context/FilePropertyMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/FilePropertyMapper.ts
@@ -62,11 +62,8 @@ export class FilePropertyMapper {
         property: FernIr.dynamic.FileUploadRequestBodyProperty.File_;
         record: Record<string, unknown>;
     }): go.TypeInstantiation {
-        // TODO: maybe only return a default fileValue if the property is required??
+        // fix(williammcadams): always return a string reader even if no example was provided
         const fileValue = this.context.getSingleFileValue({ property, record }) || "";
-        // if (fileValue == null) {
-        //     return go.TypeInstantiation.nop();
-        // }
         return go.TypeInstantiation.reference(this.context.getNewStringsReaderFunctionInvocation(fileValue));
     }
 

--- a/generators/go-v2/dynamic-snippets/src/context/FilePropertyMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/FilePropertyMapper.ts
@@ -62,10 +62,11 @@ export class FilePropertyMapper {
         property: FernIr.dynamic.FileUploadRequestBodyProperty.File_;
         record: Record<string, unknown>;
     }): go.TypeInstantiation {
-        const fileValue = this.context.getSingleFileValue({ property, record });
-        if (fileValue == null) {
-            return go.TypeInstantiation.nop();
-        }
+        // TODO: maybe only return a default fileValue if the property is required??
+        const fileValue = this.context.getSingleFileValue({ property, record }) || "";
+        // if (fileValue == null) {
+        //     return go.TypeInstantiation.nop();
+        // }
         return go.TypeInstantiation.reference(this.context.getNewStringsReaderFunctionInvocation(fileValue));
     }
 

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.12.2
+  changelogEntry:
+    - summary: |
+        Fix small inconsistencies in dynamic snippets logic blocking wire test generation
+      type: fix
+  createdAt: "2025-09-24"
+  irVersion: 59
+
 - version: 1.12.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: This is the first of several PR's to address "Fix existing dynamic snippets" milestone in the [[SDKs] Go Wire tests](https://linear.app/buildwithfern/project/sdks-go-wire-tests-3609ed54df72/overview) project

Final fixes before we can move on with wire test generation

## Changes Made
- Always include a `strings.NewReader` instance even when the file example is not present in the IR (will reassess if I can fix this from within IR parser)
- For enums (with a single possible value) that are being typed simply as aliases due to the `coerce-enums-to-literals` [config option](https://buildwithfern.com/learn/api-definitions/openapi/generators-yml-reference#coerce-enums-to-literals) correctly instantiate the literal alias
- use correct check to see if a query param type is optional (by essentially copying the logic from the `AbstractGoGeneratorContext` [here](https://github.com/fern-api/fern/blob/af482f14d0fe56bf2719cd4eabc1a5ce7fc46e3e/generators/go-v2/base/src/context/AbstractGoGeneratorContext.ts#L446))

## Testing
- [x] Manual testing using frond against the auth0 sdk
