### PR TITLE
fix(internal): dont spin up seed containers when runnning with skipScripts on seed CLI

### DIFF
--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -41,7 +41,11 @@ export async function runWithCustomFixture({
     );
 
     let testRunner: TestRunner;
-    let scriptRunner: ScriptRunner;
+    let scriptRunner: ScriptRunner | undefined = undefined;
+
+    if (!skipScripts) {
+        scriptRunner = new LocalScriptRunner(workspace, skipScripts, taskContext);
+    }
 
     if (local) {
         if (workspace.workspaceConfig.test.local == null) {
@@ -54,8 +58,6 @@ export async function runWithCustomFixture({
             workspace.workspaceConfig.test.local
         );
 
-        scriptRunner = new LocalScriptRunner(workspace, skipScripts, taskContext);
-
         testRunner = new LocalTestRunner({
             generator: workspace,
             lock,
@@ -66,8 +68,6 @@ export async function runWithCustomFixture({
             inspect
         });
     } else {
-        scriptRunner = new DockerScriptRunner(workspace, skipScripts, taskContext);
-
         testRunner = new DockerTestRunner({
             generator: workspace,
             lock,
@@ -112,7 +112,7 @@ export async function runWithCustomFixture({
         };
         console.log(
             `Running custom fixture for ${workspace.workspaceName} with config:`,
-            JSON.stringify(runFixtureConfig)
+            JSON.stringify(runFixtureConfig, undefined, 2)
         );
 
         await testRunner.build();
@@ -136,7 +136,7 @@ export async function runWithCustomFixture({
         );
     } finally {
         if (!skipScripts) {
-            await scriptRunner.stop();
+            await scriptRunner?.stop();
         }
     }
 }

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -19,7 +19,7 @@ export declare namespace TestRunner {
         lock: Semaphore;
         taskContextFactory: TaskContextFactory;
         skipScripts: boolean;
-        scriptRunner: ScriptRunner;
+        scriptRunner: ScriptRunner | undefined;
         keepDocker: boolean;
         inspect: boolean;
     }
@@ -106,7 +106,7 @@ export abstract class TestRunner {
     protected readonly taskContextFactory: TaskContextFactory;
     private readonly skipScripts: boolean;
     private readonly keepDocker: boolean;
-    private scriptRunner: ScriptRunner;
+    private scriptRunner: ScriptRunner | undefined;
 
     constructor({ generator, lock, taskContextFactory, skipScripts, keepDocker, scriptRunner }: TestRunner.Args) {
         this.generator = generator;
@@ -243,7 +243,7 @@ export abstract class TestRunner {
             const scriptStopwatch = new Stopwatch();
             scriptStopwatch.start();
 
-            const scriptResponse = await this.scriptRunner.run({
+            const scriptResponse = await this.scriptRunner?.run({
                 taskContext,
                 outputDir,
                 id
@@ -252,7 +252,7 @@ export abstract class TestRunner {
             scriptStopwatch.stop();
             metrics.compileTime = scriptStopwatch.duration();
 
-            if (scriptResponse.type === "failure") {
+            if (scriptResponse?.type === "failure") {
                 return {
                     type: "failure",
                     cause: "compile",


### PR DESCRIPTION
Make skipScripts faster by not spinning up script containers.