### PR TITLE
[WIP] fix(cli): OpenRpc tuple types are respected

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,3 +29,7 @@ packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/
 packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/hookdeck.json filter=lfs diff=lfs merge=lfs -text
 packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/paradex.json filter=lfs diff=lfs merge=lfs -text
 packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/nft.json filter=lfs diff=lfs merge=lfs -text
+packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/baseline-docs/openrpc-tuples.json filter=lfs diff=lfs merge=lfs -text
+packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/baseline-sdks/openrpc-tuples.json filter=lfs diff=lfs merge=lfs -text
+packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-docs/openrpc-tuples.json filter=lfs diff=lfs merge=lfs -text
+packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/openrpc-tuples.json filter=lfs diff=lfs merge=lfs -text

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/baseline-docs/openrpc-tuples.json
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/baseline-docs/openrpc-tuples.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e83ccd34e8fd6dacd325fbc79cddb2f99d54bb294fea9765efa44723da208ecc
+size 2091

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/baseline-sdks/openrpc-tuples.json
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/baseline-sdks/openrpc-tuples.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e83ccd34e8fd6dacd325fbc79cddb2f99d54bb294fea9765efa44723da208ecc
+size 2091

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-docs/openrpc-tuples.json
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-docs/openrpc-tuples.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:751a576152bfe8dc35955801061bcef9df80661a8007ca57d33daf8398d022ac
+size 27424

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/openrpc-tuples.json
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/__snapshots__/v3-sdks/openrpc-tuples.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:316e0c8b7b6aef74d10cc8f31e4a62d40eb48084a96664b8807cc1e842c73d9e
+size 57797

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/fixtures/openrpc-tuples/fern/fern.config.json
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/fixtures/openrpc-tuples/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/fixtures/openrpc-tuples/fern/generators.yml
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/fixtures/openrpc-tuples/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openrpc: ../openrpc.yml

--- a/packages/cli/api-importers/v3-importer-tests/src/__test__/fixtures/openrpc-tuples/openrpc.yml
+++ b/packages/cli/api-importers/v3-importer-tests/src/__test__/fixtures/openrpc-tuples/openrpc.yml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://meta.open-rpc.org/
+$schema: https://meta.open-rpc.org/
+openrpc: 1.2.6
+info:
+  title: IMDB API
+  version: 1.0.0
+  description: API for managing movies in the database
+servers:
+  - url: http://localhost:3000
+methods:
+  - name: imdb_searchMovies
+    description: Search for movies with optional filters
+    params:
+      - name: searchRequest
+        required: true
+        schema:
+          $ref: "#/components/schemas/SearchMoviesRequest"
+    result:
+      name: movies
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/Movie"
+    errors:
+      - code: -32600
+        message: Invalid Request
+      - code: -32602
+        message: Invalid params
+      - code: -32603
+        message: Internal error
+    tags:
+      - name: Imdb
+components:
+  schemas:
+    Movie:
+      title: Movie
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        rating:
+          type: number
+          format: double
+          description: The rating scale out of ten stars
+      required:
+        - id
+        - title
+        - rating
+    SearchMoviesRequest:
+      title: SearchMoviesRequest
+      description: Search request that can be either a simple query string or a tuple of query and filters
+      anyOf:
+        - description: Simple search query
+          type: string
+        - description: Search query with genre filters
+          type: array
+          items:
+            - type: string
+              description: Search query
+            - type: array
+              items:
+                type: string
+              description: Genre filters
+          minItems: 2
+          maxItems: 2
+          additionalItems: false


### PR DESCRIPTION
## Description
Linear ticket: [FER-6673](https://linear.app/buildwithfern/issue/FER-6673/)
Before this PR, tuple types in openrpc were parsed incorrectly as undisciminated union types

## Changes Made
- [x] Just added a test case demonstrating the current behavior. No logic changes yet.
Since the new snapshots are hard to see in the diff because of git-lfs. Here is what the array type ends up looking like:
    "SearchMoviesRequestOneOf1Items": {
      "name": {
        "typeId": "SearchMoviesRequestOneOf1Items",
        "fernFilepath": {
          "allParts": [],
          "packagePath": []
        },
        "name": {
          "originalName": "SearchMoviesRequestOneOf1Items",
          "camelCase": {
            "unsafeName": "searchMoviesRequestOneOf1Items",
            "safeName": "searchMoviesRequestOneOf1Items"
          },
          "snakeCase": {
            "unsafeName": "search_movies_request_one_of_1_items",
            "safeName": "search_movies_request_one_of_1_items"
          },
          "screamingSnakeCase": {
            "unsafeName": "SEARCH_MOVIES_REQUEST_ONE_OF_1_ITEMS",
            "safeName": "SEARCH_MOVIES_REQUEST_ONE_OF_1_ITEMS"
          },
          "pascalCase": {
            "unsafeName": "SearchMoviesRequestOneOf1Items",
            "safeName": "SearchMoviesRequestOneOf1Items"
          }
        }
      },
      "shape": {
        "members": [
          {
            "type": {
              "primitive": {
                "v1": "STRING",
                "v2": {
                  "validation": {},
                  "type": "string"
                }
              },
              "type": "primitive"
            },
            "docs": "Search query"
          },
          {
            "type": {
              "container": {
                "list": {
                  "primitive": {
                    "v1": "STRING",
                    "v2": {
                      "validation": {},
                      "type": "string"
                    }
                  },
                  "type": "primitive"
                },
                "type": "list"
              },
              "type": "container"
            },
            "docs": "Genre filters"
          }
        ],
        "type": "undiscriminatedUnion"
      },
      "autogeneratedExamples": [],
      "userProvidedExamples": [],
      "referencedTypes": {},
      "inline": false,
      "v2Examples": {
        "userSpecifiedExamples": {},
        "autogeneratedExamples": {
          "SearchMoviesRequestOneOf1Items_example_autogenerated": "string"
        }
      }
    },
    
    I've also attached an image showing what the docs look like running against this openrpc spec.
    
<img width="578" height="838" alt="image" src="https://github.com/user-attachments/assets/b22ac37e-04cf-4e7d-86d2-76eb1a766706" />


## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
