### PR TITLE
fix(internal): collapse any combination of `optional<T>` and `nullable<T>` to `optional<nullable<T>>`

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildTypeReference.ts
@@ -605,7 +605,7 @@ export function buildNullableTypeReference({
         itemValidation == null &&
         schema.title == null
     ) {
-		return wrapTypeReferenceAsOptional(type);
+        return wrapTypeReferenceAsOptional(type);
     }
     const result: RawSchemas.TypeReferenceSchema =
         typeof type === "string"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsNullable.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsNullable.ts
@@ -8,7 +8,7 @@ export function wrapTypeReferenceAsNullable(
     typeReference: RawSchemas.TypeReferenceSchema
 ): RawSchemas.TypeReferenceSchema {
     const type = getTypeFromTypeReference(typeReference);
-    if (type.includes("nullable<")) {
+    if (type.startsWith("nullable<") || type.startsWith("optional<nullable<")) {
         return typeReference;
     } else if (typeof typeReference === "string") {
         return wrapTypeAsNullable(typeReference);

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsNullable.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsNullable.ts
@@ -1,0 +1,25 @@
+import { RawSchemas } from "@fern-api/fern-definition-schema";
+
+import { getTypeFromTypeReference } from "./getTypeFromTypeReference";
+
+// Converts type => nullable<type> and optional<type> => optional<nullable<type>>.
+// Doesn't allow for nested nullable types.
+export function wrapTypeReferenceAsNullable(
+    typeReference: RawSchemas.TypeReferenceSchema
+): RawSchemas.TypeReferenceSchema {
+    const type = getTypeFromTypeReference(typeReference);
+    if (type.includes("nullable<")) {
+        return typeReference;
+    } else if (typeof typeReference === "string") {
+        return wrapTypeAsNullable(typeReference);
+    } else {
+        return { ...typeReference, type: wrapTypeAsNullable(typeReference.type) };
+    }
+}
+
+function wrapTypeAsNullable(type: string): string {
+    if (type.startsWith("optional<")) {
+        return type.replace("optional<", "optional<nullable<") + ">";
+    }
+    return `nullable<${type}>`;
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsOptional.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsOptional.ts
@@ -8,7 +8,7 @@ export function wrapTypeReferenceAsOptional(
     typeReference: RawSchemas.TypeReferenceSchema
 ): RawSchemas.TypeReferenceSchema {
     const type = getTypeFromTypeReference(typeReference);
-    if (type.includes("optional<")) {
+    if (type.startsWith("optional<")) {
         return typeReference;
     } else if (typeof typeReference === "string") {
         return wrapTypeAsOptional(typeReference);

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsOptional.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/utils/wrapTypeReferenceAsOptional.ts
@@ -2,15 +2,21 @@ import { RawSchemas } from "@fern-api/fern-definition-schema";
 
 import { getTypeFromTypeReference } from "./getTypeFromTypeReference";
 
+// Converts type => optional<type> and nullable<type> => optional<nullable<type>>.
+// Doesn't allow for nested optional types.
 export function wrapTypeReferenceAsOptional(
     typeReference: RawSchemas.TypeReferenceSchema
 ): RawSchemas.TypeReferenceSchema {
     const type = getTypeFromTypeReference(typeReference);
-    if (type.startsWith("optional")) {
+    if (type.includes("optional<")) {
         return typeReference;
     } else if (typeof typeReference === "string") {
-        return `optional<${typeReference}>`;
+        return wrapTypeAsOptional(typeReference);
     } else {
-        return { ...typeReference, type: `optional<${typeReference.type}>` };
+        return { ...typeReference, type: wrapTypeAsOptional(typeReference.type) };
     }
+}
+
+function wrapTypeAsOptional(type: string): string {
+    return `optional<${type}>`;
 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- changelogEntry:
+    - summary: Collapse any combination of optional and nullable to optional<nullable<T>>.
+      type: fix
+  irVersion: 59
+  createdAt: "2025-09-22"
+  version: 0.78.4
 
 - changelogEntry:
     - summary: Support IR v59 in the Rust SDK generator.
@@ -189,8 +195,8 @@
 
 - changelogEntry:
     - summary: |
-        Introduces `group-multi-api-environments` flag for multi-API environment support. SDKs can now handle 
-        multiple API products with per-environment base URLs, featuring automatic environment grouping and 
+        Introduces `group-multi-api-environments` flag for multi-API environment support. SDKs can now handle
+        multiple API products with per-environment base URLs, featuring automatic environment grouping and
         service-aware URL routing.
       type: feat
   irVersion: 59


### PR DESCRIPTION
## Description
Linear ticket: Helps with FER-6680.
The title basically gives it away; if for any reason we would hypothetically generate `optional<optional<` or `nullable<optional<` or `optional<nullable<optional<`, etc. etc., we only ever generate `optional<nullable<>>` via some idempotency checks in the `openapi-ir-to-fern` parser.

## Changes Made
Changes in the `openapi-ir-to-fern` parser.

## Testing
Tested against the current `openapi-ir-to-fern-tests`.
- [X] Unit tests added/updated
- [X] Manual testing completed
