### PR TITLE
fix(java): add null safety to builder collection setters

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/object/BuilderGenerator.java
@@ -574,7 +574,9 @@ public final class BuilderGenerator {
                     .build());
             implSetterConsumer.accept(defaultMethodImplBuilder
                     .addStatement("this.$L.clear()", fieldSpec.name)
+                    .beginControlFlow("if ($L != null)", fieldSpec.name)
                     .addStatement("this.$L.putAll($L)", fieldSpec.name, fieldSpec.name)
+                    .endControlFlow()
                     .addStatement("return this")
                     .build());
             implSetterConsumer.accept(
@@ -608,7 +610,9 @@ public final class BuilderGenerator {
                     .build());
             implSetterConsumer.accept(defaultMethodImplBuilder
                     .addStatement("this.$L.clear()", fieldSpec.name)
+                    .beginControlFlow("if ($L != null)", fieldSpec.name)
                     .addStatement("this.$L.addAll($L)", fieldSpec.name, fieldSpec.name)
+                    .endControlFlow()
                     .addStatement("return this")
                     .build());
             implSetterConsumer.accept(createCollectionItemAppender(
@@ -638,7 +642,9 @@ public final class BuilderGenerator {
                     .build());
             implSetterConsumer.accept(defaultMethodImplBuilder
                     .addStatement("this.$L.clear()", fieldSpec.name)
+                    .beginControlFlow("if ($L != null)", fieldSpec.name)
                     .addStatement("this.$L.addAll($L)", fieldSpec.name, fieldSpec.name)
+                    .endControlFlow()
                     .addStatement("return this")
                     .build());
             implSetterConsumer.accept(createCollectionItemAppender(

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.5.7
+  changelogEntry:
+    - summary: |
+        Fixed NullPointerException in builder setters when collections are null by adding null checks before addAll()/putAll() calls.
+      type: fix
+  createdAt: "2025-09-22"
+  irVersion: 59
+
 - version: 3.5.6
   changelogEntry:
     - summary: |

--- a/seed/java-model/circular-references-advanced/src/main/java/com/seed/api/model/ast/BranchNode.java
+++ b/seed/java-model/circular-references-advanced/src/main/java/com/seed/api/model/ast/BranchNode.java
@@ -66,7 +66,9 @@ public final class BranchNode {
         @JsonSetter(value = "children", nulls = Nulls.SKIP)
         public Builder children(List<Node> children) {
             this.children.clear();
-            this.children.addAll(children);
+            if (children != null) {
+                this.children.addAll(children);
+            }
             return this;
         }
 

--- a/seed/java-model/circular-references-advanced/src/main/java/com/seed/api/model/ast/NodesWrapper.java
+++ b/seed/java-model/circular-references-advanced/src/main/java/com/seed/api/model/ast/NodesWrapper.java
@@ -66,7 +66,9 @@ public final class NodesWrapper {
         @JsonSetter(value = "nodes", nulls = Nulls.SKIP)
         public Builder nodes(List<List<Node>> nodes) {
             this.nodes.clear();
-            this.nodes.addAll(nodes);
+            if (nodes != null) {
+                this.nodes.addAll(nodes);
+            }
             return this;
         }
 

--- a/seed/java-model/client-side-params/src/main/java/com/seed/clientSideParams/model/types/PaginatedClientResponse.java
+++ b/seed/java-model/client-side-params/src/main/java/com/seed/clientSideParams/model/types/PaginatedClientResponse.java
@@ -236,7 +236,9 @@ public final class PaginatedClientResponse {
         @JsonSetter(value = "clients", nulls = Nulls.SKIP)
         public _FinalStage clients(List<Client> clients) {
             this.clients.clear();
-            this.clients.addAll(clients);
+            if (clients != null) {
+                this.clients.addAll(clients);
+            }
             return this;
         }
 

--- a/seed/java-model/client-side-params/src/main/java/com/seed/clientSideParams/model/types/PaginatedUserResponse.java
+++ b/seed/java-model/client-side-params/src/main/java/com/seed/clientSideParams/model/types/PaginatedUserResponse.java
@@ -193,7 +193,9 @@ public final class PaginatedUserResponse {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public _FinalStage users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-model/client-side-params/src/main/java/com/seed/clientSideParams/model/types/SearchResponse.java
+++ b/seed/java-model/client-side-params/src/main/java/com/seed/clientSideParams/model/types/SearchResponse.java
@@ -89,7 +89,9 @@ public final class SearchResponse {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<Resource> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-model/examples/src/main/java/com/seed/examples/model/types/ExtendedMovie.java
+++ b/seed/java-model/examples/src/main/java/com/seed/examples/model/types/ExtendedMovie.java
@@ -332,7 +332,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "cast", nulls = Nulls.SKIP)
         public _FinalStage cast(List<String> cast) {
             this.cast.clear();
-            this.cast.addAll(cast);
+            if (cast != null) {
+                this.cast.addAll(cast);
+            }
             return this;
         }
 
@@ -354,7 +356,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-model/examples/src/main/java/com/seed/examples/model/types/Movie.java
+++ b/seed/java-model/examples/src/main/java/com/seed/examples/model/types/Movie.java
@@ -310,7 +310,9 @@ public final class Movie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-model/examples/src/main/java/com/seed/examples/model/types/Response.java
+++ b/seed/java-model/examples/src/main/java/com/seed/examples/model/types/Response.java
@@ -117,7 +117,9 @@ public final class Response {
         @JsonSetter(value = "identifiers", nulls = Nulls.SKIP)
         public _FinalStage identifiers(List<Identifier> identifiers) {
             this.identifiers.clear();
-            this.identifiers.addAll(identifiers);
+            if (identifiers != null) {
+                this.identifiers.addAll(identifiers);
+            }
             return this;
         }
 

--- a/seed/java-model/exhaustive/src/main/java/com/seed/exhaustive/model/types/object/ObjectWithMapOfMap.java
+++ b/seed/java-model/exhaustive/src/main/java/com/seed/exhaustive/model/types/object/ObjectWithMapOfMap.java
@@ -66,7 +66,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-model/http-head/src/main/java/com/seed/httpHead/model/user/User.java
+++ b/seed/java-model/http-head/src/main/java/com/seed/httpHead/model/user/User.java
@@ -116,7 +116,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithListAliasType.java
+++ b/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithListAliasType.java
@@ -66,7 +66,9 @@ public final class ObjectTypeWithListAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(List<AliasPropertyType> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithMapAliasTypeBoth.java
+++ b/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithMapAliasTypeBoth.java
@@ -66,7 +66,9 @@ public final class ObjectTypeWithMapAliasTypeBoth {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<AliasPropertyType, OtherAliasPropertyType> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithMapAliasTypeKey.java
+++ b/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithMapAliasTypeKey.java
@@ -66,7 +66,9 @@ public final class ObjectTypeWithMapAliasTypeKey {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<AliasPropertyType, String> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithMapAliasTypeValue.java
+++ b/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithMapAliasTypeValue.java
@@ -66,7 +66,9 @@ public final class ObjectTypeWithMapAliasTypeValue {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<String, AliasPropertyType> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithSetAliasType.java
+++ b/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/ObjectTypeWithSetAliasType.java
@@ -66,7 +66,9 @@ public final class ObjectTypeWithSetAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Set<AliasPropertyType> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/RootType1.java
+++ b/seed/java-model/java-inline-types/src/main/java/com/seed/object/model/RootType1.java
@@ -271,7 +271,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooSet", nulls = Nulls.SKIP)
         public _FinalStage fooSet(Set<RootType1FooSetItem> fooSet) {
             this.fooSet.clear();
-            this.fooSet.addAll(fooSet);
+            if (fooSet != null) {
+                this.fooSet.addAll(fooSet);
+            }
             return this;
         }
 
@@ -304,7 +306,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooList", nulls = Nulls.SKIP)
         public _FinalStage fooList(List<RootType1FooListItem> fooList) {
             this.fooList.clear();
-            this.fooList.addAll(fooList);
+            if (fooList != null) {
+                this.fooList.addAll(fooList);
+            }
             return this;
         }
 
@@ -337,7 +341,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooMap", nulls = Nulls.SKIP)
         public _FinalStage fooMap(Map<String, RootType1FooMapValue> fooMap) {
             this.fooMap.clear();
-            this.fooMap.putAll(fooMap);
+            if (fooMap != null) {
+                this.fooMap.putAll(fooMap);
+            }
             return this;
         }
 

--- a/seed/java-model/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/model/deep/cursor/path/IndirectionRequired.java
+++ b/seed/java-model/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/model/deep/cursor/path/IndirectionRequired.java
@@ -89,7 +89,9 @@ public final class IndirectionRequired {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-model/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/model/deep/cursor/path/Response.java
+++ b/seed/java-model/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/model/deep/cursor/path/Response.java
@@ -89,7 +89,9 @@ public final class Response {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-model/literal/src/main/java/com/seed/literal/model/reference/ContainerObject.java
+++ b/seed/java-model/literal/src/main/java/com/seed/literal/model/reference/ContainerObject.java
@@ -66,7 +66,9 @@ public final class ContainerObject {
         @JsonSetter(value = "nestedObjects", nulls = Nulls.SKIP)
         public Builder nestedObjects(List<NestedObjectWithLiterals> nestedObjects) {
             this.nestedObjects.clear();
-            this.nestedObjects.addAll(nestedObjects);
+            if (nestedObjects != null) {
+                this.nestedObjects.addAll(nestedObjects);
+            }
             return this;
         }
 

--- a/seed/java-model/mixed-case/src/main/java/com/seed/mixedCase/model/service/User.java
+++ b/seed/java-model/mixed-case/src/main/java/com/seed/mixedCase/model/service/User.java
@@ -137,7 +137,9 @@ public final class User {
         @JsonSetter(value = "EXTRA_PROPERTIES", nulls = Nulls.SKIP)
         public _FinalStage extraProperties(Map<String, String> extraProperties) {
             this.extraProperties.clear();
-            this.extraProperties.putAll(extraProperties);
+            if (extraProperties != null) {
+                this.extraProperties.putAll(extraProperties);
+            }
             return this;
         }
 
@@ -159,7 +161,9 @@ public final class User {
         @JsonSetter(value = "metadata_tags", nulls = Nulls.SKIP)
         public _FinalStage metadataTags(List<String> metadataTags) {
             this.metadataTags.clear();
-            this.metadataTags.addAll(metadataTags);
+            if (metadataTags != null) {
+                this.metadataTags.addAll(metadataTags);
+            }
             return this;
         }
 

--- a/seed/java-model/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/model/organization/Organization.java
+++ b/seed/java-model/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/model/organization/Organization.java
@@ -139,7 +139,9 @@ public final class Organization {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public _FinalStage users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-model/object/src/main/java/com/seed/object/model/Type.java
+++ b/seed/java-model/object/src/main/java/com/seed/object/model/Type.java
@@ -680,7 +680,9 @@ public final class Type {
         @JsonSetter(value = "seventeen", nulls = Nulls.SKIP)
         public _FinalStage seventeen(List<Optional<UUID>> seventeen) {
             this.seventeen.clear();
-            this.seventeen.addAll(seventeen);
+            if (seventeen != null) {
+                this.seventeen.addAll(seventeen);
+            }
             return this;
         }
 
@@ -702,7 +704,9 @@ public final class Type {
         @JsonSetter(value = "sixteen", nulls = Nulls.SKIP)
         public _FinalStage sixteen(List<Map<String, Integer>> sixteen) {
             this.sixteen.clear();
-            this.sixteen.addAll(sixteen);
+            if (sixteen != null) {
+                this.sixteen.addAll(sixteen);
+            }
             return this;
         }
 
@@ -724,7 +728,9 @@ public final class Type {
         @JsonSetter(value = "fifteen", nulls = Nulls.SKIP)
         public _FinalStage fifteen(List<List<Integer>> fifteen) {
             this.fifteen.clear();
-            this.fifteen.addAll(fifteen);
+            if (fifteen != null) {
+                this.fifteen.addAll(fifteen);
+            }
             return this;
         }
 
@@ -759,7 +765,9 @@ public final class Type {
         @JsonSetter(value = "twelve", nulls = Nulls.SKIP)
         public _FinalStage twelve(Map<String, Boolean> twelve) {
             this.twelve.clear();
-            this.twelve.putAll(twelve);
+            if (twelve != null) {
+                this.twelve.putAll(twelve);
+            }
             return this;
         }
 
@@ -781,7 +789,9 @@ public final class Type {
         @JsonSetter(value = "eleven", nulls = Nulls.SKIP)
         public _FinalStage eleven(Set<Double> eleven) {
             this.eleven.clear();
-            this.eleven.addAll(eleven);
+            if (eleven != null) {
+                this.eleven.addAll(eleven);
+            }
             return this;
         }
 
@@ -803,7 +813,9 @@ public final class Type {
         @JsonSetter(value = "ten", nulls = Nulls.SKIP)
         public _FinalStage ten(List<Integer> ten) {
             this.ten.clear();
-            this.ten.addAll(ten);
+            if (ten != null) {
+                this.ten.addAll(ten);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination-custom/src/main/java/com/seed/pagination/model/UsernamePage.java
+++ b/seed/java-model/pagination-custom/src/main/java/com/seed/pagination/model/UsernamePage.java
@@ -89,7 +89,9 @@ public final class UsernamePage {
         @JsonSetter(value = "data", nulls = Nulls.SKIP)
         public Builder data(List<String> data) {
             this.data.clear();
-            this.data.addAll(data);
+            if (data != null) {
+                this.data.addAll(data);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/UsernamePage.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/UsernamePage.java
@@ -89,7 +89,9 @@ public final class UsernamePage {
         @JsonSetter(value = "data", nulls = Nulls.SKIP)
         public Builder data(List<String> data) {
             this.data.clear();
-            this.data.addAll(data);
+            if (data != null) {
+                this.data.addAll(data);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/complex/PaginatedConversationResponse.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/complex/PaginatedConversationResponse.java
@@ -151,7 +151,9 @@ public final class PaginatedConversationResponse {
         @JsonSetter(value = "conversations", nulls = Nulls.SKIP)
         public _FinalStage conversations(List<Conversation> conversations) {
             this.conversations.clear();
-            this.conversations.addAll(conversations);
+            if (conversations != null) {
+                this.conversations.addAll(conversations);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/inline/users/inline/users/UserListContainer.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/inline/users/inline/users/UserListContainer.java
@@ -66,7 +66,9 @@ public final class UserListContainer {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public Builder users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/inline/users/inline/users/UsernameContainer.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/inline/users/inline/users/UsernameContainer.java
@@ -66,7 +66,9 @@ public final class UsernameContainer {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/inline/users/inline/users/Users.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/inline/users/inline/users/Users.java
@@ -66,7 +66,9 @@ public final class Users {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public Builder users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/ListUsersMixedTypePaginationResponse.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/ListUsersMixedTypePaginationResponse.java
@@ -117,7 +117,9 @@ public final class ListUsersMixedTypePaginationResponse {
         @JsonSetter(value = "data", nulls = Nulls.SKIP)
         public _FinalStage data(List<User> data) {
             this.data.clear();
-            this.data.addAll(data);
+            if (data != null) {
+                this.data.addAll(data);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/ListUsersPaginationResponse.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/ListUsersPaginationResponse.java
@@ -162,7 +162,9 @@ public final class ListUsersPaginationResponse {
         @JsonSetter(value = "data", nulls = Nulls.SKIP)
         public _FinalStage data(List<User> data) {
             this.data.clear();
-            this.data.addAll(data);
+            if (data != null) {
+                this.data.addAll(data);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/UserListContainer.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/UserListContainer.java
@@ -66,7 +66,9 @@ public final class UserListContainer {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public Builder users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/UsernameContainer.java
+++ b/seed/java-model/pagination/src/main/java/com/seed/pagination/model/users/UsernameContainer.java
@@ -66,7 +66,9 @@ public final class UsernameContainer {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-model/path-parameters/src/main/java/com/seed/pathParameters/model/organizations/Organization.java
+++ b/seed/java-model/path-parameters/src/main/java/com/seed/pathParameters/model/organizations/Organization.java
@@ -116,7 +116,9 @@ public final class Organization {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-model/path-parameters/src/main/java/com/seed/pathParameters/model/user/User.java
+++ b/seed/java-model/path-parameters/src/main/java/com/seed/pathParameters/model/user/User.java
@@ -116,7 +116,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-model/query-parameters/src/main/java/com/seed/queryParameters/model/user/User.java
+++ b/seed/java-model/query-parameters/src/main/java/com/seed/queryParameters/model/user/User.java
@@ -116,7 +116,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-model/request-parameters/src/main/java/com/seed/requestParameters/model/user/User.java
+++ b/seed/java-model/request-parameters/src/main/java/com/seed/requestParameters/model/user/User.java
@@ -116,7 +116,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-model/reserved-keywords/src/main/java/com/seed/nurseryApi/model/_package/Record.java
+++ b/seed/java-model/reserved-keywords/src/main/java/com/seed/nurseryApi/model/_package/Record.java
@@ -116,7 +116,9 @@ public final class Record {
         @JsonSetter(value = "foo", nulls = Nulls.SKIP)
         public _FinalStage foo(Map<String, String> foo) {
             this.foo.clear();
-            this.foo.putAll(foo);
+            if (foo != null) {
+                this.foo.putAll(foo);
+            }
             return this;
         }
 

--- a/seed/java-model/response-property/src/main/java/com/seed/responseProperty/model/WithMetadata.java
+++ b/seed/java-model/response-property/src/main/java/com/seed/responseProperty/model/WithMetadata.java
@@ -67,7 +67,9 @@ public final class WithMetadata implements IWithMetadata {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public Builder metadata(Map<String, String> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-model/response-property/src/main/java/com/seed/responseProperty/model/service/Response.java
+++ b/seed/java-model/response-property/src/main/java/com/seed/responseProperty/model/service/Response.java
@@ -141,7 +141,9 @@ public final class Response implements IWithMetadata, IWithDocs {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, String> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Account.java
+++ b/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Account.java
@@ -236,7 +236,9 @@ public final class Account implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/BaseResource.java
+++ b/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/BaseResource.java
@@ -141,7 +141,9 @@ public final class BaseResource implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Patient.java
+++ b/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Patient.java
@@ -189,7 +189,9 @@ public final class Patient implements IBaseResource {
         @JsonSetter(value = "scripts", nulls = Nulls.SKIP)
         public _FinalStage scripts(List<Script> scripts) {
             this.scripts.clear();
-            this.scripts.addAll(scripts);
+            if (scripts != null) {
+                this.scripts.addAll(scripts);
+            }
             return this;
         }
 
@@ -211,7 +213,9 @@ public final class Patient implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Practitioner.java
+++ b/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Practitioner.java
@@ -171,7 +171,9 @@ public final class Practitioner implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Script.java
+++ b/seed/java-model/simple-fhir/src/main/java/com/seed/api/model/Script.java
@@ -171,7 +171,9 @@ public final class Script implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-model/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/model/union/NamedMetadata.java
+++ b/seed/java-model/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/model/union/NamedMetadata.java
@@ -116,7 +116,9 @@ public final class NamedMetadata {
         @JsonSetter(value = "value", nulls = Nulls.SKIP)
         public _FinalStage value(Map<String, Object> value) {
             this.value.clear();
-            this.value.putAll(value);
+            if (value != null) {
+                this.value.putAll(value);
+            }
             return this;
         }
 

--- a/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/resources/ast/types/BranchNode.java
+++ b/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/resources/ast/types/BranchNode.java
@@ -81,7 +81,9 @@ public final class BranchNode {
         @JsonSetter(value = "children", nulls = Nulls.SKIP)
         public Builder children(List<Node> children) {
             this.children.clear();
-            this.children.addAll(children);
+            if (children != null) {
+                this.children.addAll(children);
+            }
             return this;
         }
 

--- a/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/resources/ast/types/NodesWrapper.java
+++ b/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/resources/ast/types/NodesWrapper.java
@@ -81,7 +81,9 @@ public final class NodesWrapper {
         @JsonSetter(value = "nodes", nulls = Nulls.SKIP)
         public Builder nodes(List<List<Node>> nodes) {
             this.nodes.clear();
-            this.nodes.addAll(nodes);
+            if (nodes != null) {
+                this.nodes.addAll(nodes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/types/types/PaginatedClientResponse.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/types/types/PaginatedClientResponse.java
@@ -257,7 +257,9 @@ public final class PaginatedClientResponse {
         @JsonSetter(value = "clients", nulls = Nulls.SKIP)
         public _FinalStage clients(List<Client> clients) {
             this.clients.clear();
-            this.clients.addAll(clients);
+            if (clients != null) {
+                this.clients.addAll(clients);
+            }
             return this;
         }
 

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/types/types/PaginatedUserResponse.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/types/types/PaginatedUserResponse.java
@@ -214,7 +214,9 @@ public final class PaginatedUserResponse {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public _FinalStage users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/types/types/SearchResponse.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/types/types/SearchResponse.java
@@ -108,7 +108,9 @@ public final class SearchResponse {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<Resource> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
+++ b/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
@@ -126,7 +126,9 @@ public final class SendEnumListAsQueryParamRequest {
         @JsonSetter(value = "operand", nulls = Nulls.SKIP)
         public Builder operand(List<Operand> operand) {
             this.operand.clear();
-            this.operand.addAll(operand);
+            if (operand != null) {
+                this.operand.addAll(operand);
+            }
             return this;
         }
 
@@ -166,7 +168,9 @@ public final class SendEnumListAsQueryParamRequest {
         @JsonSetter(value = "operandOrColor", nulls = Nulls.SKIP)
         public Builder operandOrColor(List<ColorOrOperand> operandOrColor) {
             this.operandOrColor.clear();
-            this.operandOrColor.addAll(operandOrColor);
+            if (operandOrColor != null) {
+                this.operandOrColor.addAll(operandOrColor);
+            }
             return this;
         }
 

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
@@ -126,7 +126,9 @@ public final class SendEnumListAsQueryParamRequest {
         @JsonSetter(value = "operand", nulls = Nulls.SKIP)
         public Builder operand(List<Operand> operand) {
             this.operand.clear();
-            this.operand.addAll(operand);
+            if (operand != null) {
+                this.operand.addAll(operand);
+            }
             return this;
         }
 
@@ -166,7 +168,9 @@ public final class SendEnumListAsQueryParamRequest {
         @JsonSetter(value = "operandOrColor", nulls = Nulls.SKIP)
         public Builder operandOrColor(List<ColorOrOperand> operandOrColor) {
             this.operandOrColor.clear();
-            this.operandOrColor.addAll(operandOrColor);
+            if (operandOrColor != null) {
+                this.operandOrColor.addAll(operandOrColor);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
@@ -348,7 +348,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "cast", nulls = Nulls.SKIP)
         public _FinalStage cast(List<String> cast) {
             this.cast.clear();
-            this.cast.addAll(cast);
+            if (cast != null) {
+                this.cast.addAll(cast);
+            }
             return this;
         }
 
@@ -370,7 +372,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/Movie.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/Movie.java
@@ -326,7 +326,9 @@ public final class Movie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/Response.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/types/types/Response.java
@@ -132,7 +132,9 @@ public final class Response {
         @JsonSetter(value = "identifiers", nulls = Nulls.SKIP)
         public _FinalStage identifiers(List<Identifier> identifiers) {
             this.identifiers.clear();
-            this.identifiers.addAll(identifiers);
+            if (identifiers != null) {
+                this.identifiers.addAll(identifiers);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/snippets/Example19.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/snippets/Example19.java
@@ -40,7 +40,7 @@ public class Example19 {
             BigEntity
                 .builder()
                 .castMember(
-                    CastMember.ofActor(
+                    CastMember.of(
                         Actor
                             .builder()
                             .name("name")
@@ -76,7 +76,7 @@ public class Example19 {
                     Entity
                         .builder()
                         .type(
-                            Type.ofBasicType(BasicType.PRIMITIVE)
+                            Type.of(BasicType.PRIMITIVE)
                         )
                         .name("name")
                         .build()

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
@@ -348,7 +348,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "cast", nulls = Nulls.SKIP)
         public _FinalStage cast(List<String> cast) {
             this.cast.clear();
-            this.cast.addAll(cast);
+            if (cast != null) {
+                this.cast.addAll(cast);
+            }
             return this;
         }
 
@@ -370,7 +372,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/Movie.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/Movie.java
@@ -326,7 +326,9 @@ public final class Movie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/Response.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/types/types/Response.java
@@ -132,7 +132,9 @@ public final class Response {
         @JsonSetter(value = "identifiers", nulls = Nulls.SKIP)
         public _FinalStage identifiers(List<Identifier> identifiers) {
             this.identifiers.clear();
-            this.identifiers.addAll(identifiers);
+            if (identifiers != null) {
+                this.identifiers.addAll(identifiers);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/snippets/Example19.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/snippets/Example19.java
@@ -40,7 +40,7 @@ public class Example19 {
             BigEntity
                 .builder()
                 .castMember(
-                    CastMember.ofActor(
+                    CastMember.of(
                         Actor
                             .builder()
                             .name("name")
@@ -76,7 +76,7 @@ public class Example19 {
                     Entity
                         .builder()
                         .type(
-                            Type.ofBasicType(BasicType.PRIMITIVE)
+                            Type.of(BasicType.PRIMITIVE)
                         )
                         .name("name")
                         .build()

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
@@ -348,7 +348,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "cast", nulls = Nulls.SKIP)
         public _FinalStage cast(List<String> cast) {
             this.cast.clear();
-            this.cast.addAll(cast);
+            if (cast != null) {
+                this.cast.addAll(cast);
+            }
             return this;
         }
 
@@ -370,7 +372,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/Movie.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/Movie.java
@@ -326,7 +326,9 @@ public final class Movie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/Response.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/types/types/Response.java
@@ -132,7 +132,9 @@ public final class Response {
         @JsonSetter(value = "identifiers", nulls = Nulls.SKIP)
         public _FinalStage identifiers(List<Identifier> identifiers) {
             this.identifiers.clear();
-            this.identifiers.addAll(identifiers);
+            if (identifiers != null) {
+                this.identifiers.addAll(identifiers);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/snippets/Example19.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/snippets/Example19.java
@@ -40,7 +40,7 @@ public class Example19 {
             BigEntity
                 .builder()
                 .castMember(
-                    CastMember.ofActor(
+                    CastMember.of(
                         Actor
                             .builder()
                             .name("name")
@@ -76,7 +76,7 @@ public class Example19 {
                     Entity
                         .builder()
                         .type(
-                            Type.ofBasicType(BasicType.PRIMITIVE)
+                            Type.of(BasicType.PRIMITIVE)
                         )
                         .name("name")
                         .build()

--- a/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
+++ b/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/ExtendedMovie.java
@@ -348,7 +348,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "cast", nulls = Nulls.SKIP)
         public _FinalStage cast(List<String> cast) {
             this.cast.clear();
-            this.cast.addAll(cast);
+            if (cast != null) {
+                this.cast.addAll(cast);
+            }
             return this;
         }
 
@@ -370,7 +372,9 @@ public final class ExtendedMovie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/Movie.java
+++ b/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/Movie.java
@@ -326,7 +326,9 @@ public final class Movie implements IMovie {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, Object> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/Response.java
+++ b/seed/java-sdk/examples/wire-tests/src/main/java/com/seed/examples/resources/types/types/Response.java
@@ -132,7 +132,9 @@ public final class Response {
         @JsonSetter(value = "identifiers", nulls = Nulls.SKIP)
         public _FinalStage identifiers(List<Identifier> identifiers) {
             this.identifiers.clear();
-            this.identifiers.addAll(identifiers);
+            if (identifiers != null) {
+                this.identifiers.addAll(identifiers);
+            }
             return this;
         }
 

--- a/seed/java-sdk/examples/wire-tests/src/main/java/com/snippets/Example19.java
+++ b/seed/java-sdk/examples/wire-tests/src/main/java/com/snippets/Example19.java
@@ -40,7 +40,7 @@ public class Example19 {
             BigEntity
                 .builder()
                 .castMember(
-                    CastMember.ofActor(
+                    CastMember.of(
                         Actor
                             .builder()
                             .name("name")
@@ -76,7 +76,7 @@ public class Example19 {
                     Entity
                         .builder()
                         .type(
-                            Type.ofBasicType(BasicType.PRIMITIVE)
+                            Type.of(BasicType.PRIMITIVE)
                         )
                         .name("name")
                         .build()

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/types/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/local-files/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -106,7 +106,9 @@ public final class GetWithMultipleQuery {
     )
     public Builder query(List<String> query) {
       this.query.clear();
-      this.query.addAll(query);
+      if (query != null) {
+        this.query.addAll(query);
+      }
       return this;
     }
 
@@ -133,7 +135,9 @@ public final class GetWithMultipleQuery {
     )
     public Builder number(List<Integer> number) {
       this.number.clear();
-      this.number.addAll(number);
+      if (number != null) {
+        this.number.addAll(number);
+      }
       return this;
     }
 

--- a/seed/java-sdk/exhaustive/local-files/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/local-files/resources/types/object/types/ObjectWithMapOfMap.java
@@ -92,7 +92,9 @@ public final class ObjectWithMapOfMap {
     )
     public Builder map(Map<String, Map<String, String>> map) {
       this.map.clear();
-      this.map.putAll(map);
+      if (map != null) {
+        this.map.putAll(map);
+      }
       return this;
     }
 

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/wire-tests/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/wire-tests/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -93,7 +93,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "query", nulls = Nulls.SKIP)
         public Builder query(List<String> query) {
             this.query.clear();
-            this.query.addAll(query);
+            if (query != null) {
+                this.query.addAll(query);
+            }
             return this;
         }
 
@@ -117,7 +119,9 @@ public final class GetWithMultipleQuery {
         @JsonSetter(value = "number", nulls = Nulls.SKIP)
         public Builder number(List<Integer> number) {
             this.number.clear();
-            this.number.addAll(number);
+            if (number != null) {
+                this.number.addAll(number);
+            }
             return this;
         }
 

--- a/seed/java-sdk/exhaustive/wire-tests/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-sdk/exhaustive/wire-tests/src/main/java/com/seed/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -80,7 +80,9 @@ public final class ObjectWithMapOfMap {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, Map<String, String>> map) {
             this.map.clear();
-            this.map.putAll(map);
+            if (map != null) {
+                this.map.putAll(map);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
@@ -275,7 +275,9 @@ public final class JustFileWithQueryParamsRequest {
         @JsonSetter(value = "listOfStrings", nulls = Nulls.SKIP)
         public _FinalStage listOfStrings(List<String> listOfStrings) {
             this.listOfStrings.clear();
-            this.listOfStrings.addAll(listOfStrings);
+            if (listOfStrings != null) {
+                this.listOfStrings.addAll(listOfStrings);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/MyOtherRequest.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/MyOtherRequest.java
@@ -422,7 +422,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "alias_list_of_object", nulls = Nulls.SKIP)
         public _FinalStage aliasListOfObject(List<MyObject> aliasListOfObject) {
             this.aliasListOfObject.clear();
-            this.aliasListOfObject.addAll(aliasListOfObject);
+            if (aliasListOfObject != null) {
+                this.aliasListOfObject.addAll(aliasListOfObject);
+            }
             return this;
         }
 
@@ -444,7 +446,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_alias_object", nulls = Nulls.SKIP)
         public _FinalStage listOfAliasObject(List<MyObject> listOfAliasObject) {
             this.listOfAliasObject.clear();
-            this.listOfAliasObject.addAll(listOfAliasObject);
+            if (listOfAliasObject != null) {
+                this.listOfAliasObject.addAll(listOfAliasObject);
+            }
             return this;
         }
 
@@ -466,7 +470,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_objects_with_optionals", nulls = Nulls.SKIP)
         public _FinalStage listOfObjectsWithOptionals(List<MyObjectWithOptional> listOfObjectsWithOptionals) {
             this.listOfObjectsWithOptionals.clear();
-            this.listOfObjectsWithOptionals.addAll(listOfObjectsWithOptionals);
+            if (listOfObjectsWithOptionals != null) {
+                this.listOfObjectsWithOptionals.addAll(listOfObjectsWithOptionals);
+            }
             return this;
         }
 
@@ -527,7 +533,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_objects", nulls = Nulls.SKIP)
         public _FinalStage listOfObjects(List<MyObject> listOfObjects) {
             this.listOfObjects.clear();
-            this.listOfObjects.addAll(listOfObjects);
+            if (listOfObjects != null) {
+                this.listOfObjects.addAll(listOfObjects);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/MyRequest.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/MyRequest.java
@@ -401,7 +401,9 @@ public final class MyRequest {
         @JsonSetter(value = "alias_list_of_object", nulls = Nulls.SKIP)
         public _FinalStage aliasListOfObject(List<MyObject> aliasListOfObject) {
             this.aliasListOfObject.clear();
-            this.aliasListOfObject.addAll(aliasListOfObject);
+            if (aliasListOfObject != null) {
+                this.aliasListOfObject.addAll(aliasListOfObject);
+            }
             return this;
         }
 
@@ -423,7 +425,9 @@ public final class MyRequest {
         @JsonSetter(value = "list_of_alias_object", nulls = Nulls.SKIP)
         public _FinalStage listOfAliasObject(List<MyObject> listOfAliasObject) {
             this.listOfAliasObject.clear();
-            this.listOfAliasObject.addAll(listOfAliasObject);
+            if (listOfAliasObject != null) {
+                this.listOfAliasObject.addAll(listOfAliasObject);
+            }
             return this;
         }
 
@@ -484,7 +488,9 @@ public final class MyRequest {
         @JsonSetter(value = "list_of_objects", nulls = Nulls.SKIP)
         public _FinalStage listOfObjects(List<MyObject> listOfObjects) {
             this.listOfObjects.clear();
-            this.listOfObjects.addAll(listOfObjects);
+            if (listOfObjects != null) {
+                this.listOfObjects.addAll(listOfObjects);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
@@ -244,7 +244,9 @@ public final class JustFileWithQueryParamsRequest {
         @JsonSetter(value = "listOfStrings", nulls = Nulls.SKIP)
         public _FinalStage listOfStrings(List<String> listOfStrings) {
             this.listOfStrings.clear();
-            this.listOfStrings.addAll(listOfStrings);
+            if (listOfStrings != null) {
+                this.listOfStrings.addAll(listOfStrings);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/MyOtherRequest.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/MyOtherRequest.java
@@ -335,7 +335,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "alias_list_of_object", nulls = Nulls.SKIP)
         public _FinalStage aliasListOfObject(List<MyObject> aliasListOfObject) {
             this.aliasListOfObject.clear();
-            this.aliasListOfObject.addAll(aliasListOfObject);
+            if (aliasListOfObject != null) {
+                this.aliasListOfObject.addAll(aliasListOfObject);
+            }
             return this;
         }
 
@@ -357,7 +359,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_alias_object", nulls = Nulls.SKIP)
         public _FinalStage listOfAliasObject(List<MyObject> listOfAliasObject) {
             this.listOfAliasObject.clear();
-            this.listOfAliasObject.addAll(listOfAliasObject);
+            if (listOfAliasObject != null) {
+                this.listOfAliasObject.addAll(listOfAliasObject);
+            }
             return this;
         }
 
@@ -379,7 +383,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_objects_with_optionals", nulls = Nulls.SKIP)
         public _FinalStage listOfObjectsWithOptionals(List<MyObjectWithOptional> listOfObjectsWithOptionals) {
             this.listOfObjectsWithOptionals.clear();
-            this.listOfObjectsWithOptionals.addAll(listOfObjectsWithOptionals);
+            if (listOfObjectsWithOptionals != null) {
+                this.listOfObjectsWithOptionals.addAll(listOfObjectsWithOptionals);
+            }
             return this;
         }
 
@@ -440,7 +446,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_objects", nulls = Nulls.SKIP)
         public _FinalStage listOfObjects(List<MyObject> listOfObjects) {
             this.listOfObjects.clear();
-            this.listOfObjects.addAll(listOfObjects);
+            if (listOfObjects != null) {
+                this.listOfObjects.addAll(listOfObjects);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/MyRequest.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/MyRequest.java
@@ -314,7 +314,9 @@ public final class MyRequest {
         @JsonSetter(value = "alias_list_of_object", nulls = Nulls.SKIP)
         public _FinalStage aliasListOfObject(List<MyObject> aliasListOfObject) {
             this.aliasListOfObject.clear();
-            this.aliasListOfObject.addAll(aliasListOfObject);
+            if (aliasListOfObject != null) {
+                this.aliasListOfObject.addAll(aliasListOfObject);
+            }
             return this;
         }
 
@@ -336,7 +338,9 @@ public final class MyRequest {
         @JsonSetter(value = "list_of_alias_object", nulls = Nulls.SKIP)
         public _FinalStage listOfAliasObject(List<MyObject> listOfAliasObject) {
             this.listOfAliasObject.clear();
-            this.listOfAliasObject.addAll(listOfAliasObject);
+            if (listOfAliasObject != null) {
+                this.listOfAliasObject.addAll(listOfAliasObject);
+            }
             return this;
         }
 
@@ -397,7 +401,9 @@ public final class MyRequest {
         @JsonSetter(value = "list_of_objects", nulls = Nulls.SKIP)
         public _FinalStage listOfObjects(List<MyObject> listOfObjects) {
             this.listOfObjects.clear();
-            this.listOfObjects.addAll(listOfObjects);
+            if (listOfObjects != null) {
+                this.listOfObjects.addAll(listOfObjects);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
@@ -244,7 +244,9 @@ public final class JustFileWithQueryParamsRequest {
         @JsonSetter(value = "listOfStrings", nulls = Nulls.SKIP)
         public _FinalStage listOfStrings(List<String> listOfStrings) {
             this.listOfStrings.clear();
-            this.listOfStrings.addAll(listOfStrings);
+            if (listOfStrings != null) {
+                this.listOfStrings.addAll(listOfStrings);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/MyOtherRequest.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/MyOtherRequest.java
@@ -343,7 +343,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_alias_object", nulls = Nulls.SKIP)
         public _FinalStage listOfAliasObject(List<MyAliasObject> listOfAliasObject) {
             this.listOfAliasObject.clear();
-            this.listOfAliasObject.addAll(listOfAliasObject);
+            if (listOfAliasObject != null) {
+                this.listOfAliasObject.addAll(listOfAliasObject);
+            }
             return this;
         }
 
@@ -365,7 +367,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_objects_with_optionals", nulls = Nulls.SKIP)
         public _FinalStage listOfObjectsWithOptionals(List<MyObjectWithOptional> listOfObjectsWithOptionals) {
             this.listOfObjectsWithOptionals.clear();
-            this.listOfObjectsWithOptionals.addAll(listOfObjectsWithOptionals);
+            if (listOfObjectsWithOptionals != null) {
+                this.listOfObjectsWithOptionals.addAll(listOfObjectsWithOptionals);
+            }
             return this;
         }
 
@@ -426,7 +430,9 @@ public final class MyOtherRequest {
         @JsonSetter(value = "list_of_objects", nulls = Nulls.SKIP)
         public _FinalStage listOfObjects(List<MyObject> listOfObjects) {
             this.listOfObjects.clear();
-            this.listOfObjects.addAll(listOfObjects);
+            if (listOfObjects != null) {
+                this.listOfObjects.addAll(listOfObjects);
+            }
             return this;
         }
 

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/MyRequest.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/MyRequest.java
@@ -322,7 +322,9 @@ public final class MyRequest {
         @JsonSetter(value = "list_of_alias_object", nulls = Nulls.SKIP)
         public _FinalStage listOfAliasObject(List<MyAliasObject> listOfAliasObject) {
             this.listOfAliasObject.clear();
-            this.listOfAliasObject.addAll(listOfAliasObject);
+            if (listOfAliasObject != null) {
+                this.listOfAliasObject.addAll(listOfAliasObject);
+            }
             return this;
         }
 
@@ -383,7 +385,9 @@ public final class MyRequest {
         @JsonSetter(value = "list_of_objects", nulls = Nulls.SKIP)
         public _FinalStage listOfObjects(List<MyObject> listOfObjects) {
             this.listOfObjects.clear();
-            this.listOfObjects.addAll(listOfObjects);
+            if (listOfObjects != null) {
+                this.listOfObjects.addAll(listOfObjects);
+            }
             return this;
         }
 

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/types/User.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/types/User.java
@@ -132,7 +132,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
@@ -82,7 +82,9 @@ public final class ObjectTypeWithListAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(List<PropItem> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeBoth {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<PropKey, PropValue> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeKey {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<PropKey, String> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeValue {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<String, PropValue> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
@@ -82,7 +82,9 @@ public final class ObjectTypeWithSetAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Set<PropItem> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/RootType1.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/types/RootType1.java
@@ -289,7 +289,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooSet", nulls = Nulls.SKIP)
         public _FinalStage fooSet(Set<FooSetItem> fooSet) {
             this.fooSet.clear();
-            this.fooSet.addAll(fooSet);
+            if (fooSet != null) {
+                this.fooSet.addAll(fooSet);
+            }
             return this;
         }
 
@@ -322,7 +324,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooList", nulls = Nulls.SKIP)
         public _FinalStage fooList(List<FooListItem> fooList) {
             this.fooList.clear();
-            this.fooList.addAll(fooList);
+            if (fooList != null) {
+                this.fooList.addAll(fooList);
+            }
             return this;
         }
 
@@ -355,7 +359,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooMap", nulls = Nulls.SKIP)
         public _FinalStage fooMap(Map<String, FooMapValue> fooMap) {
             this.fooMap.clear();
-            this.fooMap.putAll(fooMap);
+            if (fooMap != null) {
+                this.fooMap.putAll(fooMap);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithListAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(List<AliasProperty> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeBoth {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<AliasProperty, OtherAliasProperty> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
@@ -80,7 +80,9 @@ public final class ObjectTypeWithMapAliasTypeKey {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<AliasProperty, String> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
@@ -80,7 +80,9 @@ public final class ObjectTypeWithMapAliasTypeValue {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<String, AliasProperty> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithSetAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Set<AliasProperty> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/RootType1.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/types/RootType1.java
@@ -289,7 +289,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooSet", nulls = Nulls.SKIP)
         public _FinalStage fooSet(Set<FooSetItem> fooSet) {
             this.fooSet.clear();
-            this.fooSet.addAll(fooSet);
+            if (fooSet != null) {
+                this.fooSet.addAll(fooSet);
+            }
             return this;
         }
 
@@ -322,7 +324,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooList", nulls = Nulls.SKIP)
         public _FinalStage fooList(List<FooListItem> fooList) {
             this.fooList.clear();
-            this.fooList.addAll(fooList);
+            if (fooList != null) {
+                this.fooList.addAll(fooList);
+            }
             return this;
         }
 
@@ -355,7 +359,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooMap", nulls = Nulls.SKIP)
         public _FinalStage fooMap(Map<String, FooMapValue> fooMap) {
             this.fooMap.clear();
-            this.fooMap.putAll(fooMap);
+            if (fooMap != null) {
+                this.fooMap.putAll(fooMap);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithListAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(List<AliasProperty> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeBoth {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<AliasProperty, OtherAliasProperty> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
@@ -80,7 +80,9 @@ public final class ObjectTypeWithMapAliasTypeKey {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<AliasProperty, String> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
@@ -80,7 +80,9 @@ public final class ObjectTypeWithMapAliasTypeValue {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<String, AliasProperty> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithSetAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Set<AliasProperty> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/RootType1.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/types/RootType1.java
@@ -287,7 +287,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooSet", nulls = Nulls.SKIP)
         public _FinalStage fooSet(Set<RootType1FooSetItem> fooSet) {
             this.fooSet.clear();
-            this.fooSet.addAll(fooSet);
+            if (fooSet != null) {
+                this.fooSet.addAll(fooSet);
+            }
             return this;
         }
 
@@ -320,7 +322,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooList", nulls = Nulls.SKIP)
         public _FinalStage fooList(List<RootType1FooListItem> fooList) {
             this.fooList.clear();
-            this.fooList.addAll(fooList);
+            if (fooList != null) {
+                this.fooList.addAll(fooList);
+            }
             return this;
         }
 
@@ -353,7 +357,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooMap", nulls = Nulls.SKIP)
         public _FinalStage fooMap(Map<String, RootType1FooMapValue> fooMap) {
             this.fooMap.clear();
-            this.fooMap.putAll(fooMap);
+            if (fooMap != null) {
+                this.fooMap.putAll(fooMap);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithListAliasType.java
@@ -82,7 +82,9 @@ public final class ObjectTypeWithListAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(List<PropItem> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeBoth.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeBoth {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<PropKey, PropValue> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeKey.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeKey {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<PropKey, String> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithMapAliasTypeValue.java
@@ -81,7 +81,9 @@ public final class ObjectTypeWithMapAliasTypeValue {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Map<String, PropValue> prop) {
             this.prop.clear();
-            this.prop.putAll(prop);
+            if (prop != null) {
+                this.prop.putAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/ObjectTypeWithSetAliasType.java
@@ -82,7 +82,9 @@ public final class ObjectTypeWithSetAliasType {
         @JsonSetter(value = "prop", nulls = Nulls.SKIP)
         public Builder prop(Set<PropItem> prop) {
             this.prop.clear();
-            this.prop.addAll(prop);
+            if (prop != null) {
+                this.prop.addAll(prop);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/RootType1.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/types/RootType1.java
@@ -289,7 +289,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooSet", nulls = Nulls.SKIP)
         public _FinalStage fooSet(Set<FooSetItem> fooSet) {
             this.fooSet.clear();
-            this.fooSet.addAll(fooSet);
+            if (fooSet != null) {
+                this.fooSet.addAll(fooSet);
+            }
             return this;
         }
 
@@ -322,7 +324,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooList", nulls = Nulls.SKIP)
         public _FinalStage fooList(List<FooListItem> fooList) {
             this.fooList.clear();
-            this.fooList.addAll(fooList);
+            if (fooList != null) {
+                this.fooList.addAll(fooList);
+            }
             return this;
         }
 
@@ -355,7 +359,9 @@ public final class RootType1 {
         @JsonSetter(value = "fooMap", nulls = Nulls.SKIP)
         public _FinalStage fooMap(Map<String, FooMapValue> fooMap) {
             this.fooMap.clear();
-            this.fooMap.putAll(fooMap);
+            if (fooMap != null) {
+                this.fooMap.putAll(fooMap);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/IndirectionRequired.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/IndirectionRequired.java
@@ -105,7 +105,9 @@ public final class IndirectionRequired {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/Response.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/Response.java
@@ -104,7 +104,9 @@ public final class Response {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/IndirectionRequired.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/IndirectionRequired.java
@@ -105,7 +105,9 @@ public final class IndirectionRequired {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/Response.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/resources/deepcursorpath/types/Response.java
@@ -104,7 +104,9 @@ public final class Response {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/test/java/com/seed/deepCursorPath/DeepCursorPathWireTest.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/test/java/com/seed/deepCursorPath/DeepCursorPathWireTest.java
@@ -3,6 +3,7 @@ package com.seed.deepCursorPath;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.deepCursorPath.SeedDeepCursorPathClient;
+import com.seed.deepCursorPath.core.pagination.SyncPagingIterable;
 import com.seed.deepCursorPath.resources.deepcursorpath.types.A;
 import com.seed.deepCursorPath.resources.deepcursorpath.types.B;
 import com.seed.deepCursorPath.resources.deepcursorpath.types.C;
@@ -13,7 +14,6 @@ import com.seed.deepCursorPath.resources.deepcursorpath.types.InlineB;
 import com.seed.deepCursorPath.resources.deepcursorpath.types.InlineC;
 import com.seed.deepCursorPath.resources.deepcursorpath.types.InlineD;
 import com.seed.deepCursorPath.resources.deepcursorpath.types.MainRequired;
-import com.seed.deepCursorPath.resources.deepcursorpath.types.Response;
 import java.util.Arrays;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -44,7 +44,7 @@ public class DeepCursorPathWireTest {
         server.enqueue(new MockResponse()
             .setResponseCode(200)
             .setBody("{\"starting_after\":\"starting_after\",\"results\":[\"results\",\"results\"]}"));
-        Response response = client.deepCursorPath().doThing(
+        SyncPagingIterable<String> response = client.deepCursorPath().doThing(
             A
                 .builder()
                 .b(
@@ -150,7 +150,7 @@ public class DeepCursorPathWireTest {
         server.enqueue(new MockResponse()
             .setResponseCode(200)
             .setBody("{\"starting_after\":\"starting_after\",\"results\":[\"results\",\"results\"]}"));
-        Response response = client.deepCursorPath().doThingRequired(
+        SyncPagingIterable<String> response = client.deepCursorPath().doThingRequired(
             MainRequired
                 .builder()
                 .indirection(
@@ -249,7 +249,7 @@ public class DeepCursorPathWireTest {
         server.enqueue(new MockResponse()
             .setResponseCode(200)
             .setBody("{\"starting_after\":\"starting_after\",\"results\":[\"results\",\"results\"]}"));
-        Response response = client.deepCursorPath().doThingInline(
+        SyncPagingIterable<String> response = client.deepCursorPath().doThingInline(
             InlineA
                 .builder()
                 .b(

--- a/seed/java-sdk/literal/src/main/java/com/seed/literal/resources/reference/types/ContainerObject.java
+++ b/seed/java-sdk/literal/src/main/java/com/seed/literal/resources/reference/types/ContainerObject.java
@@ -81,7 +81,9 @@ public final class ContainerObject {
         @JsonSetter(value = "nestedObjects", nulls = Nulls.SKIP)
         public Builder nestedObjects(List<NestedObjectWithLiterals> nestedObjects) {
             this.nestedObjects.clear();
-            this.nestedObjects.addAll(nestedObjects);
+            if (nestedObjects != null) {
+                this.nestedObjects.addAll(nestedObjects);
+            }
             return this;
         }
 

--- a/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/resources/service/types/User.java
+++ b/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/resources/service/types/User.java
@@ -156,7 +156,9 @@ public final class User {
         @JsonSetter(value = "EXTRA_PROPERTIES", nulls = Nulls.SKIP)
         public _FinalStage extraProperties(Map<String, String> extraProperties) {
             this.extraProperties.clear();
-            this.extraProperties.putAll(extraProperties);
+            if (extraProperties != null) {
+                this.extraProperties.putAll(extraProperties);
+            }
             return this;
         }
 
@@ -178,7 +180,9 @@ public final class User {
         @JsonSetter(value = "metadata_tags", nulls = Nulls.SKIP)
         public _FinalStage metadataTags(List<String> metadataTags) {
             this.metadataTags.clear();
-            this.metadataTags.addAll(metadataTags);
+            if (metadataTags != null) {
+                this.metadataTags.addAll(metadataTags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/organization/types/Organization.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/organization/types/Organization.java
@@ -155,7 +155,9 @@ public final class Organization {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public _FinalStage users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchRequest.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchRequest.java
@@ -162,7 +162,9 @@ public final class SearchRequest {
         @JsonSetter(value = "includeTypes", nulls = Nulls.SKIP)
         public _FinalStage includeTypes(List<String> includeTypes) {
             this.includeTypes.clear();
-            this.includeTypes.addAll(includeTypes);
+            if (includeTypes != null) {
+                this.includeTypes.addAll(includeTypes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/UpdateTagsRequest.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/UpdateTagsRequest.java
@@ -127,7 +127,9 @@ public final class UpdateTagsRequest {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public Builder tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/ComplexProfile.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/ComplexProfile.java
@@ -562,7 +562,9 @@ public final class ComplexProfile {
         @JsonSetter(value = "nullableListOfUnions", nulls = Nulls.SKIP)
         public _FinalStage nullableListOfUnions(List<NotificationMethod> nullableListOfUnions) {
             this.nullableListOfUnions.clear();
-            this.nullableListOfUnions.addAll(nullableListOfUnions);
+            if (nullableListOfUnions != null) {
+                this.nullableListOfUnions.addAll(nullableListOfUnions);
+            }
             return this;
         }
 
@@ -584,7 +586,9 @@ public final class ComplexProfile {
         @JsonSetter(value = "nullableMapOfNullables", nulls = Nulls.SKIP)
         public _FinalStage nullableMapOfNullables(Map<String, Address> nullableMapOfNullables) {
             this.nullableMapOfNullables.clear();
-            this.nullableMapOfNullables.putAll(nullableMapOfNullables);
+            if (nullableMapOfNullables != null) {
+                this.nullableMapOfNullables.putAll(nullableMapOfNullables);
+            }
             return this;
         }
 
@@ -606,7 +610,9 @@ public final class ComplexProfile {
         @JsonSetter(value = "nullableListOfNullables", nulls = Nulls.SKIP)
         public _FinalStage nullableListOfNullables(List<String> nullableListOfNullables) {
             this.nullableListOfNullables.clear();
-            this.nullableListOfNullables.addAll(nullableListOfNullables);
+            if (nullableListOfNullables != null) {
+                this.nullableListOfNullables.addAll(nullableListOfNullables);
+            }
             return this;
         }
 
@@ -667,7 +673,9 @@ public final class ComplexProfile {
         @JsonSetter(value = "nullableArray", nulls = Nulls.SKIP)
         public _FinalStage nullableArray(List<String> nullableArray) {
             this.nullableArray.clear();
-            this.nullableArray.addAll(nullableArray);
+            if (nullableArray != null) {
+                this.nullableArray.addAll(nullableArray);
+            }
             return this;
         }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/DeserializationTestRequest.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/DeserializationTestRequest.java
@@ -390,7 +390,9 @@ public final class DeserializationTestRequest {
         @JsonSetter(value = "nullableMap", nulls = Nulls.SKIP)
         public _FinalStage nullableMap(Map<String, Integer> nullableMap) {
             this.nullableMap.clear();
-            this.nullableMap.putAll(nullableMap);
+            if (nullableMap != null) {
+                this.nullableMap.putAll(nullableMap);
+            }
             return this;
         }
 
@@ -412,7 +414,9 @@ public final class DeserializationTestRequest {
         @JsonSetter(value = "nullableList", nulls = Nulls.SKIP)
         public _FinalStage nullableList(List<String> nullableList) {
             this.nullableList.clear();
-            this.nullableList.addAll(nullableList);
+            if (nullableList != null) {
+                this.nullableList.addAll(nullableList);
+            }
             return this;
         }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserProfile.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/types/UserProfile.java
@@ -645,7 +645,9 @@ public final class UserProfile {
         @JsonSetter(value = "nullableMap", nulls = Nulls.SKIP)
         public _FinalStage nullableMap(Map<String, String> nullableMap) {
             this.nullableMap.clear();
-            this.nullableMap.putAll(nullableMap);
+            if (nullableMap != null) {
+                this.nullableMap.putAll(nullableMap);
+            }
             return this;
         }
 
@@ -667,7 +669,9 @@ public final class UserProfile {
         @JsonSetter(value = "nullableList", nulls = Nulls.SKIP)
         public _FinalStage nullableList(List<String> nullableList) {
             this.nullableList.clear();
-            this.nullableList.addAll(nullableList);
+            if (nullableList != null) {
+                this.nullableList.addAll(nullableList);
+            }
             return this;
         }
 

--- a/seed/java-sdk/object/src/main/java/com/seed/object/types/Type.java
+++ b/seed/java-sdk/object/src/main/java/com/seed/object/types/Type.java
@@ -696,7 +696,9 @@ public final class Type {
         @JsonSetter(value = "seventeen", nulls = Nulls.SKIP)
         public _FinalStage seventeen(List<Optional<UUID>> seventeen) {
             this.seventeen.clear();
-            this.seventeen.addAll(seventeen);
+            if (seventeen != null) {
+                this.seventeen.addAll(seventeen);
+            }
             return this;
         }
 
@@ -718,7 +720,9 @@ public final class Type {
         @JsonSetter(value = "sixteen", nulls = Nulls.SKIP)
         public _FinalStage sixteen(List<Map<String, Integer>> sixteen) {
             this.sixteen.clear();
-            this.sixteen.addAll(sixteen);
+            if (sixteen != null) {
+                this.sixteen.addAll(sixteen);
+            }
             return this;
         }
 
@@ -740,7 +744,9 @@ public final class Type {
         @JsonSetter(value = "fifteen", nulls = Nulls.SKIP)
         public _FinalStage fifteen(List<List<Integer>> fifteen) {
             this.fifteen.clear();
-            this.fifteen.addAll(fifteen);
+            if (fifteen != null) {
+                this.fifteen.addAll(fifteen);
+            }
             return this;
         }
 
@@ -775,7 +781,9 @@ public final class Type {
         @JsonSetter(value = "twelve", nulls = Nulls.SKIP)
         public _FinalStage twelve(Map<String, Boolean> twelve) {
             this.twelve.clear();
-            this.twelve.putAll(twelve);
+            if (twelve != null) {
+                this.twelve.putAll(twelve);
+            }
             return this;
         }
 
@@ -797,7 +805,9 @@ public final class Type {
         @JsonSetter(value = "eleven", nulls = Nulls.SKIP)
         public _FinalStage eleven(Set<Double> eleven) {
             this.eleven.clear();
-            this.eleven.addAll(eleven);
+            if (eleven != null) {
+                this.eleven.addAll(eleven);
+            }
             return this;
         }
 
@@ -819,7 +829,9 @@ public final class Type {
         @JsonSetter(value = "ten", nulls = Nulls.SKIP)
         public _FinalStage ten(List<Integer> ten) {
             this.ten.clear();
-            this.ten.addAll(ten);
+            if (ten != null) {
+                this.ten.addAll(ten);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/complex/types/PaginatedConversationResponse.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/complex/types/PaginatedConversationResponse.java
@@ -169,7 +169,9 @@ public final class PaginatedConversationResponse {
         @JsonSetter(value = "conversations", nulls = Nulls.SKIP)
         public _FinalStage conversations(List<Conversation> conversations) {
             this.conversations.clear();
-            this.conversations.addAll(conversations);
+            if (conversations != null) {
+                this.conversations.addAll(conversations);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/types/UserListContainer.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/types/UserListContainer.java
@@ -81,7 +81,9 @@ public final class UserListContainer {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public Builder users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/types/UsernameContainer.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/types/UsernameContainer.java
@@ -81,7 +81,9 @@ public final class UsernameContainer {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/types/Users.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/types/Users.java
@@ -81,7 +81,9 @@ public final class Users {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public Builder users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/ListUsersMixedTypePaginationResponse.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/ListUsersMixedTypePaginationResponse.java
@@ -134,7 +134,9 @@ public final class ListUsersMixedTypePaginationResponse {
         @JsonSetter(value = "data", nulls = Nulls.SKIP)
         public _FinalStage data(List<User> data) {
             this.data.clear();
-            this.data.addAll(data);
+            if (data != null) {
+                this.data.addAll(data);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/ListUsersPaginationResponse.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/ListUsersPaginationResponse.java
@@ -181,7 +181,9 @@ public final class ListUsersPaginationResponse {
         @JsonSetter(value = "data", nulls = Nulls.SKIP)
         public _FinalStage data(List<User> data) {
             this.data.clear();
-            this.data.addAll(data);
+            if (data != null) {
+                this.data.addAll(data);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/UserListContainer.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/UserListContainer.java
@@ -81,7 +81,9 @@ public final class UserListContainer {
         @JsonSetter(value = "users", nulls = Nulls.SKIP)
         public Builder users(List<User> users) {
             this.users.clear();
-            this.users.addAll(users);
+            if (users != null) {
+                this.users.addAll(users);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/UsernameContainer.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/resources/users/types/UsernameContainer.java
@@ -81,7 +81,9 @@ public final class UsernameContainer {
         @JsonSetter(value = "results", nulls = Nulls.SKIP)
         public Builder results(List<String> results) {
             this.results.clear();
-            this.results.addAll(results);
+            if (results != null) {
+                this.results.addAll(results);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/types/UsernamePage.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/seed/pagination/types/UsernamePage.java
@@ -104,7 +104,9 @@ public final class UsernamePage {
         @JsonSetter(value = "data", nulls = Nulls.SKIP)
         public Builder data(List<String> data) {
             this.data.clear();
-            this.data.addAll(data);
+            if (data != null) {
+                this.data.addAll(data);
+            }
             return this;
         }
 

--- a/seed/java-sdk/pagination/wire-tests/src/main/java/com/snippets/Example0.java
+++ b/seed/java-sdk/pagination/wire-tests/src/main/java/com/snippets/Example0.java
@@ -20,7 +20,7 @@ public class Example0 {
             SearchRequest
                 .builder()
                 .query(
-                    SearchRequestQuery.ofSingleFilterSearchRequest(
+                    SearchRequestQuery.of(
                         SingleFilterSearchRequest
                             .builder()
                             .field("field")

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/organizations/types/Organization.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/organizations/types/Organization.java
@@ -132,7 +132,9 @@ public final class Organization {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/user/types/User.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/user/types/User.java
@@ -132,7 +132,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/resources/user/requests/GetUsersRequest.java
+++ b/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/resources/user/requests/GetUsersRequest.java
@@ -447,7 +447,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "keyValue", nulls = Nulls.SKIP)
         public _FinalStage keyValue(Map<String, String> keyValue) {
             this.keyValue.clear();
-            this.keyValue.putAll(keyValue);
+            if (keyValue != null) {
+                this.keyValue.putAll(keyValue);
+            }
             return this;
         }
 
@@ -482,7 +484,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "userList", nulls = Nulls.SKIP)
         public _FinalStage userList(List<User> userList) {
             this.userList.clear();
-            this.userList.addAll(userList);
+            if (userList != null) {
+                this.userList.addAll(userList);
+            }
             return this;
         }
 
@@ -510,7 +514,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "filter", nulls = Nulls.SKIP)
         public _FinalStage filter(List<String> filter) {
             this.filter.clear();
-            this.filter.addAll(filter);
+            if (filter != null) {
+                this.filter.addAll(filter);
+            }
             return this;
         }
 
@@ -538,7 +544,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "excludeUser", nulls = Nulls.SKIP)
         public _FinalStage excludeUser(List<User> excludeUser) {
             this.excludeUser.clear();
-            this.excludeUser.addAll(excludeUser);
+            if (excludeUser != null) {
+                this.excludeUser.addAll(excludeUser);
+            }
             return this;
         }
 

--- a/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/resources/user/types/User.java
+++ b/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/resources/user/types/User.java
@@ -132,7 +132,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/CreateUsernameReferencedRequest.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/CreateUsernameReferencedRequest.java
@@ -134,7 +134,9 @@ public final class CreateUsernameReferencedRequest {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/CreateUsernameRequest.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/CreateUsernameRequest.java
@@ -184,7 +184,9 @@ public final class CreateUsernameRequest {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/GetUsersRequest.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/GetUsersRequest.java
@@ -500,7 +500,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "keyValue", nulls = Nulls.SKIP)
         public _FinalStage keyValue(Map<String, String> keyValue) {
             this.keyValue.clear();
-            this.keyValue.putAll(keyValue);
+            if (keyValue != null) {
+                this.keyValue.putAll(keyValue);
+            }
             return this;
         }
 
@@ -535,7 +537,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "userList", nulls = Nulls.SKIP)
         public _FinalStage userList(List<User> userList) {
             this.userList.clear();
-            this.userList.addAll(userList);
+            if (userList != null) {
+                this.userList.addAll(userList);
+            }
             return this;
         }
 
@@ -563,7 +567,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "filter", nulls = Nulls.SKIP)
         public _FinalStage filter(List<String> filter) {
             this.filter.clear();
-            this.filter.addAll(filter);
+            if (filter != null) {
+                this.filter.addAll(filter);
+            }
             return this;
         }
 
@@ -591,7 +597,9 @@ public final class GetUsersRequest {
         @JsonSetter(value = "excludeUser", nulls = Nulls.SKIP)
         public _FinalStage excludeUser(List<User> excludeUser) {
             this.excludeUser.clear();
-            this.excludeUser.addAll(excludeUser);
+            if (excludeUser != null) {
+                this.excludeUser.addAll(excludeUser);
+            }
             return this;
         }
 

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/types/User.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/types/User.java
@@ -132,7 +132,9 @@ public final class User {
         @JsonSetter(value = "tags", nulls = Nulls.SKIP)
         public _FinalStage tags(List<String> tags) {
             this.tags.clear();
-            this.tags.addAll(tags);
+            if (tags != null) {
+                this.tags.addAll(tags);
+            }
             return this;
         }
 

--- a/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/resources/package_/types/Record.java
+++ b/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/resources/package_/types/Record.java
@@ -130,7 +130,9 @@ public final class Record {
         @JsonSetter(value = "foo", nulls = Nulls.SKIP)
         public _FinalStage foo(Map<String, String> foo) {
             this.foo.clear();
-            this.foo.putAll(foo);
+            if (foo != null) {
+                this.foo.putAll(foo);
+            }
             return this;
         }
 

--- a/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/resources/service/types/Response.java
+++ b/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/resources/service/types/Response.java
@@ -156,7 +156,9 @@ public final class Response implements IWithMetadata, IWithDocs {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public _FinalStage metadata(Map<String, String> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/types/WithMetadata.java
+++ b/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/types/WithMetadata.java
@@ -81,7 +81,9 @@ public final class WithMetadata implements IWithMetadata {
         @JsonSetter(value = "metadata", nulls = Nulls.SKIP)
         public Builder metadata(Map<String, String> metadata) {
             this.metadata.clear();
-            this.metadata.putAll(metadata);
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
+            }
             return this;
         }
 

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Account.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Account.java
@@ -253,7 +253,9 @@ public final class Account implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/BaseResource.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/BaseResource.java
@@ -158,7 +158,9 @@ public final class BaseResource implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Patient.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Patient.java
@@ -211,7 +211,9 @@ public final class Patient implements IBaseResource {
         @JsonSetter(value = "scripts", nulls = Nulls.SKIP)
         public _FinalStage scripts(List<Script> scripts) {
             this.scripts.clear();
-            this.scripts.addAll(scripts);
+            if (scripts != null) {
+                this.scripts.addAll(scripts);
+            }
             return this;
         }
 
@@ -233,7 +235,9 @@ public final class Patient implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Practitioner.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Practitioner.java
@@ -192,7 +192,9 @@ public final class Practitioner implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Script.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/types/Script.java
@@ -192,7 +192,9 @@ public final class Script implements IBaseResource {
         @JsonSetter(value = "related_resources", nulls = Nulls.SKIP)
         public _FinalStage relatedResources(List<ResourceList> relatedResources) {
             this.relatedResources.clear();
-            this.relatedResources.addAll(relatedResources);
+            if (relatedResources != null) {
+                this.relatedResources.addAll(relatedResources);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/admin/requests/StoreTracedTestCaseRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/admin/requests/StoreTracedTestCaseRequest.java
@@ -137,7 +137,9 @@ public final class StoreTracedTestCaseRequest {
         @JsonSetter(value = "traceResponses", nulls = Nulls.SKIP)
         public _FinalStage traceResponses(List<TraceResponse> traceResponses) {
             this.traceResponses.clear();
-            this.traceResponses.addAll(traceResponses);
+            if (traceResponses != null) {
+                this.traceResponses.addAll(traceResponses);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/admin/requests/StoreTracedWorkspaceRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/admin/requests/StoreTracedWorkspaceRequest.java
@@ -138,7 +138,9 @@ public final class StoreTracedWorkspaceRequest {
         @JsonSetter(value = "traceResponses", nulls = Nulls.SKIP)
         public _FinalStage traceResponses(List<TraceResponse> traceResponses) {
             this.traceResponses.clear();
-            this.traceResponses.addAll(traceResponses);
+            if (traceResponses != null) {
+                this.traceResponses.addAll(traceResponses);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/BinaryTreeValue.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/BinaryTreeValue.java
@@ -104,7 +104,9 @@ public final class BinaryTreeValue {
         @JsonSetter(value = "nodes", nulls = Nulls.SKIP)
         public Builder nodes(Map<String, BinaryTreeNodeValue> nodes) {
             this.nodes.clear();
-            this.nodes.putAll(nodes);
+            if (nodes != null) {
+                this.nodes.putAll(nodes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/DebugMapValue.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/DebugMapValue.java
@@ -81,7 +81,9 @@ public final class DebugMapValue {
         @JsonSetter(value = "keyValuePairs", nulls = Nulls.SKIP)
         public Builder keyValuePairs(List<DebugKeyValuePairs> keyValuePairs) {
             this.keyValuePairs.clear();
-            this.keyValuePairs.addAll(keyValuePairs);
+            if (keyValuePairs != null) {
+                this.keyValuePairs.addAll(keyValuePairs);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/DoublyLinkedListValue.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/DoublyLinkedListValue.java
@@ -106,7 +106,9 @@ public final class DoublyLinkedListValue {
         @JsonSetter(value = "nodes", nulls = Nulls.SKIP)
         public Builder nodes(Map<String, DoublyLinkedListNodeValue> nodes) {
             this.nodes.clear();
-            this.nodes.putAll(nodes);
+            if (nodes != null) {
+                this.nodes.putAll(nodes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/MapValue.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/MapValue.java
@@ -81,7 +81,9 @@ public final class MapValue {
         @JsonSetter(value = "keyValuePairs", nulls = Nulls.SKIP)
         public Builder keyValuePairs(List<KeyValuePair> keyValuePairs) {
             this.keyValuePairs.clear();
-            this.keyValuePairs.addAll(keyValuePairs);
+            if (keyValuePairs != null) {
+                this.keyValuePairs.addAll(keyValuePairs);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/SinglyLinkedListValue.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/SinglyLinkedListValue.java
@@ -106,7 +106,9 @@ public final class SinglyLinkedListValue {
         @JsonSetter(value = "nodes", nulls = Nulls.SKIP)
         public Builder nodes(Map<String, SinglyLinkedListNodeValue> nodes) {
             this.nodes.clear();
-            this.nodes.putAll(nodes);
+            if (nodes != null) {
+                this.nodes.putAll(nodes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/TestCase.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/commons/types/TestCase.java
@@ -132,7 +132,9 @@ public final class TestCase {
         @JsonSetter(value = "params", nulls = Nulls.SKIP)
         public _FinalStage params(List<VariableValue> params) {
             this.params.clear();
-            this.params.addAll(params);
+            if (params != null) {
+                this.params.addAll(params);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/requests/GetPlaylistsRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/requests/GetPlaylistsRequest.java
@@ -246,7 +246,9 @@ public final class GetPlaylistsRequest {
         @JsonSetter(value = "multipleField", nulls = Nulls.SKIP)
         public _FinalStage multipleField(List<String> multipleField) {
             this.multipleField.clear();
-            this.multipleField.addAll(multipleField);
+            if (multipleField != null) {
+                this.multipleField.addAll(multipleField);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/Playlist.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/Playlist.java
@@ -186,7 +186,9 @@ public final class Playlist implements IPlaylistCreateRequest {
         @JsonSetter(value = "problems", nulls = Nulls.SKIP)
         public _FinalStage problems(List<String> problems) {
             this.problems.clear();
-            this.problems.addAll(problems);
+            if (problems != null) {
+                this.problems.addAll(problems);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/PlaylistCreateRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/PlaylistCreateRequest.java
@@ -134,7 +134,9 @@ public final class PlaylistCreateRequest implements IPlaylistCreateRequest {
         @JsonSetter(value = "problems", nulls = Nulls.SKIP)
         public _FinalStage problems(List<String> problems) {
             this.problems.clear();
-            this.problems.addAll(problems);
+            if (problems != null) {
+                this.problems.addAll(problems);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/UpdatePlaylistRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/types/UpdatePlaylistRequest.java
@@ -149,7 +149,9 @@ public final class UpdatePlaylistRequest {
         @JsonSetter(value = "problems", nulls = Nulls.SKIP)
         public _FinalStage problems(List<String> problems) {
             this.problems.clear();
-            this.problems.addAll(problems);
+            if (problems != null) {
+                this.problems.addAll(problems);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/requests/GetDefaultStarterFilesRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/requests/GetDefaultStarterFilesRequest.java
@@ -201,7 +201,9 @@ public final class GetDefaultStarterFilesRequest {
         @JsonSetter(value = "inputParams", nulls = Nulls.SKIP)
         public _FinalStage inputParams(List<VariableTypeAndName> inputParams) {
             this.inputParams.clear();
-            this.inputParams.addAll(inputParams);
+            if (inputParams != null) {
+                this.inputParams.addAll(inputParams);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/CreateProblemRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/CreateProblemRequest.java
@@ -258,7 +258,9 @@ public final class CreateProblemRequest {
         @JsonSetter(value = "testcases", nulls = Nulls.SKIP)
         public _FinalStage testcases(List<TestCaseWithExpectedResult> testcases) {
             this.testcases.clear();
-            this.testcases.addAll(testcases);
+            if (testcases != null) {
+                this.testcases.addAll(testcases);
+            }
             return this;
         }
 
@@ -280,7 +282,9 @@ public final class CreateProblemRequest {
         @JsonSetter(value = "inputParams", nulls = Nulls.SKIP)
         public _FinalStage inputParams(List<VariableTypeAndName> inputParams) {
             this.inputParams.clear();
-            this.inputParams.addAll(inputParams);
+            if (inputParams != null) {
+                this.inputParams.addAll(inputParams);
+            }
             return this;
         }
 
@@ -302,7 +306,9 @@ public final class CreateProblemRequest {
         @JsonSetter(value = "files", nulls = Nulls.SKIP)
         public _FinalStage files(Map<Language, ProblemFiles> files) {
             this.files.clear();
-            this.files.putAll(files);
+            if (files != null) {
+                this.files.putAll(files);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/GetDefaultStarterFilesResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/GetDefaultStarterFilesResponse.java
@@ -82,7 +82,9 @@ public final class GetDefaultStarterFilesResponse {
         @JsonSetter(value = "files", nulls = Nulls.SKIP)
         public Builder files(Map<Language, ProblemFiles> files) {
             this.files.clear();
-            this.files.putAll(files);
+            if (files != null) {
+                this.files.putAll(files);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/ProblemDescription.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/ProblemDescription.java
@@ -81,7 +81,9 @@ public final class ProblemDescription {
         @JsonSetter(value = "boards", nulls = Nulls.SKIP)
         public Builder boards(List<ProblemDescriptionBoard> boards) {
             this.boards.clear();
-            this.boards.addAll(boards);
+            if (boards != null) {
+                this.boards.addAll(boards);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/ProblemFiles.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/ProblemFiles.java
@@ -134,7 +134,9 @@ public final class ProblemFiles {
         @JsonSetter(value = "readOnlyFiles", nulls = Nulls.SKIP)
         public _FinalStage readOnlyFiles(List<FileInfo> readOnlyFiles) {
             this.readOnlyFiles.clear();
-            this.readOnlyFiles.addAll(readOnlyFiles);
+            if (readOnlyFiles != null) {
+                this.readOnlyFiles.addAll(readOnlyFiles);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/ProblemInfo.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/problem/types/ProblemInfo.java
@@ -340,7 +340,9 @@ public final class ProblemInfo {
         @JsonSetter(value = "testcases", nulls = Nulls.SKIP)
         public _FinalStage testcases(List<TestCaseWithExpectedResult> testcases) {
             this.testcases.clear();
-            this.testcases.addAll(testcases);
+            if (testcases != null) {
+                this.testcases.addAll(testcases);
+            }
             return this;
         }
 
@@ -362,7 +364,9 @@ public final class ProblemInfo {
         @JsonSetter(value = "inputParams", nulls = Nulls.SKIP)
         public _FinalStage inputParams(List<VariableTypeAndName> inputParams) {
             this.inputParams.clear();
-            this.inputParams.addAll(inputParams);
+            if (inputParams != null) {
+                this.inputParams.addAll(inputParams);
+            }
             return this;
         }
 
@@ -384,7 +388,9 @@ public final class ProblemInfo {
         @JsonSetter(value = "files", nulls = Nulls.SKIP)
         public _FinalStage files(Map<Language, ProblemFiles> files) {
             this.files.clear();
-            this.files.putAll(files);
+            if (files != null) {
+                this.files.putAll(files);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/GetExecutionSessionStateResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/GetExecutionSessionStateResponse.java
@@ -111,7 +111,9 @@ public final class GetExecutionSessionStateResponse {
         @JsonSetter(value = "states", nulls = Nulls.SKIP)
         public Builder states(Map<String, ExecutionSessionState> states) {
             this.states.clear();
-            this.states.putAll(states);
+            if (states != null) {
+                this.states.putAll(states);
+            }
             return this;
         }
 
@@ -141,7 +143,9 @@ public final class GetExecutionSessionStateResponse {
         @JsonSetter(value = "warmingSessionIds", nulls = Nulls.SKIP)
         public Builder warmingSessionIds(List<String> warmingSessionIds) {
             this.warmingSessionIds.clear();
-            this.warmingSessionIds.addAll(warmingSessionIds);
+            if (warmingSessionIds != null) {
+                this.warmingSessionIds.addAll(warmingSessionIds);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/GradedResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/GradedResponse.java
@@ -135,7 +135,9 @@ public final class GradedResponse {
         @JsonSetter(value = "testCases", nulls = Nulls.SKIP)
         public _FinalStage testCases(Map<String, TestCaseResultWithStdout> testCases) {
             this.testCases.clear();
-            this.testCases.putAll(testCases);
+            if (testCases != null) {
+                this.testCases.putAll(testCases);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/GradedResponseV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/GradedResponseV2.java
@@ -133,7 +133,9 @@ public final class GradedResponseV2 {
         @JsonSetter(value = "testCases", nulls = Nulls.SKIP)
         public _FinalStage testCases(Map<String, TestCaseGrade> testCases) {
             this.testCases.clear();
-            this.testCases.putAll(testCases);
+            if (testCases != null) {
+                this.testCases.putAll(testCases);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/Scope.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/Scope.java
@@ -81,7 +81,9 @@ public final class Scope {
         @JsonSetter(value = "variables", nulls = Nulls.SKIP)
         public Builder variables(Map<String, DebugVariableValue> variables) {
             this.variables.clear();
-            this.variables.putAll(variables);
+            if (variables != null) {
+                this.variables.putAll(variables);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/StackFrame.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/StackFrame.java
@@ -155,7 +155,9 @@ public final class StackFrame {
         @JsonSetter(value = "scopes", nulls = Nulls.SKIP)
         public _FinalStage scopes(List<Scope> scopes) {
             this.scopes.clear();
-            this.scopes.addAll(scopes);
+            if (scopes != null) {
+                this.scopes.addAll(scopes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/SubmitRequestV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/SubmitRequestV2.java
@@ -253,7 +253,9 @@ public final class SubmitRequestV2 {
         @JsonSetter(value = "submissionFiles", nulls = Nulls.SKIP)
         public _FinalStage submissionFiles(List<SubmissionFileInfo> submissionFiles) {
             this.submissionFiles.clear();
-            this.submissionFiles.addAll(submissionFiles);
+            if (submissionFiles != null) {
+                this.submissionFiles.addAll(submissionFiles);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TestSubmissionState.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TestSubmissionState.java
@@ -180,7 +180,9 @@ public final class TestSubmissionState {
         @JsonSetter(value = "customTestCases", nulls = Nulls.SKIP)
         public _FinalStage customTestCases(List<TestCase> customTestCases) {
             this.customTestCases.clear();
-            this.customTestCases.addAll(customTestCases);
+            if (customTestCases != null) {
+                this.customTestCases.addAll(customTestCases);
+            }
             return this;
         }
 
@@ -202,7 +204,9 @@ public final class TestSubmissionState {
         @JsonSetter(value = "defaultTestCases", nulls = Nulls.SKIP)
         public _FinalStage defaultTestCases(List<TestCase> defaultTestCases) {
             this.defaultTestCases.clear();
-            this.defaultTestCases.addAll(defaultTestCases);
+            if (defaultTestCases != null) {
+                this.defaultTestCases.addAll(defaultTestCases);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TestSubmissionStatusV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TestSubmissionStatusV2.java
@@ -185,7 +185,9 @@ public final class TestSubmissionStatusV2 {
         @JsonSetter(value = "updates", nulls = Nulls.SKIP)
         public _FinalStage updates(List<TestSubmissionUpdate> updates) {
             this.updates.clear();
-            this.updates.addAll(updates);
+            if (updates != null) {
+                this.updates.addAll(updates);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TraceResponsesPage.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TraceResponsesPage.java
@@ -113,7 +113,9 @@ public final class TraceResponsesPage {
         @JsonSetter(value = "traceResponses", nulls = Nulls.SKIP)
         public Builder traceResponses(List<TraceResponse> traceResponses) {
             this.traceResponses.clear();
-            this.traceResponses.addAll(traceResponses);
+            if (traceResponses != null) {
+                this.traceResponses.addAll(traceResponses);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TraceResponsesPageV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/TraceResponsesPageV2.java
@@ -113,7 +113,9 @@ public final class TraceResponsesPageV2 {
         @JsonSetter(value = "traceResponses", nulls = Nulls.SKIP)
         public Builder traceResponses(List<TraceResponseV2> traceResponses) {
             this.traceResponses.clear();
-            this.traceResponses.addAll(traceResponses);
+            if (traceResponses != null) {
+                this.traceResponses.addAll(traceResponses);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceFiles.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceFiles.java
@@ -133,7 +133,9 @@ public final class WorkspaceFiles {
         @JsonSetter(value = "readOnlyFiles", nulls = Nulls.SKIP)
         public _FinalStage readOnlyFiles(List<FileInfo> readOnlyFiles) {
             this.readOnlyFiles.clear();
-            this.readOnlyFiles.addAll(readOnlyFiles);
+            if (readOnlyFiles != null) {
+                this.readOnlyFiles.addAll(readOnlyFiles);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceStarterFilesResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceStarterFilesResponse.java
@@ -82,7 +82,9 @@ public final class WorkspaceStarterFilesResponse {
         @JsonSetter(value = "files", nulls = Nulls.SKIP)
         public Builder files(Map<Language, WorkspaceFiles> files) {
             this.files.clear();
-            this.files.putAll(files);
+            if (files != null) {
+                this.files.putAll(files);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceStarterFilesResponseV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceStarterFilesResponseV2.java
@@ -83,7 +83,9 @@ public final class WorkspaceStarterFilesResponseV2 {
         @JsonSetter(value = "filesByLanguage", nulls = Nulls.SKIP)
         public Builder filesByLanguage(Map<Language, Files> filesByLanguage) {
             this.filesByLanguage.clear();
-            this.filesByLanguage.putAll(filesByLanguage);
+            if (filesByLanguage != null) {
+                this.filesByLanguage.putAll(filesByLanguage);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceSubmissionStatusV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceSubmissionStatusV2.java
@@ -82,7 +82,9 @@ public final class WorkspaceSubmissionStatusV2 {
         @JsonSetter(value = "updates", nulls = Nulls.SKIP)
         public Builder updates(List<WorkspaceSubmissionUpdate> updates) {
             this.updates.clear();
-            this.updates.addAll(updates);
+            if (updates != null) {
+                this.updates.addAll(updates);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceSubmitRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/submission/types/WorkspaceSubmitRequest.java
@@ -193,7 +193,9 @@ public final class WorkspaceSubmitRequest {
         @JsonSetter(value = "submissionFiles", nulls = Nulls.SKIP)
         public _FinalStage submissionFiles(List<SubmissionFileInfo> submissionFiles) {
             this.submissionFiles.clear();
-            this.submissionFiles.addAll(submissionFiles);
+            if (submissionFiles != null) {
+                this.submissionFiles.addAll(submissionFiles);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/BasicCustomFiles.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/BasicCustomFiles.java
@@ -186,7 +186,9 @@ public final class BasicCustomFiles {
         @JsonSetter(value = "additionalFiles", nulls = Nulls.SKIP)
         public _FinalStage additionalFiles(Map<Language, Files> additionalFiles) {
             this.additionalFiles.clear();
-            this.additionalFiles.putAll(additionalFiles);
+            if (additionalFiles != null) {
+                this.additionalFiles.putAll(additionalFiles);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/CreateProblemRequestV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/CreateProblemRequestV2.java
@@ -258,7 +258,9 @@ public final class CreateProblemRequestV2 {
         @JsonSetter(value = "supportedLanguages", nulls = Nulls.SKIP)
         public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
             this.supportedLanguages.clear();
-            this.supportedLanguages.addAll(supportedLanguages);
+            if (supportedLanguages != null) {
+                this.supportedLanguages.addAll(supportedLanguages);
+            }
             return this;
         }
 
@@ -280,7 +282,9 @@ public final class CreateProblemRequestV2 {
         @JsonSetter(value = "testcases", nulls = Nulls.SKIP)
         public _FinalStage testcases(List<TestCaseV2> testcases) {
             this.testcases.clear();
-            this.testcases.addAll(testcases);
+            if (testcases != null) {
+                this.testcases.addAll(testcases);
+            }
             return this;
         }
 
@@ -302,7 +306,9 @@ public final class CreateProblemRequestV2 {
         @JsonSetter(value = "customTestCaseTemplates", nulls = Nulls.SKIP)
         public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
             this.customTestCaseTemplates.clear();
-            this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            if (customTestCaseTemplates != null) {
+                this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/DefaultProvidedFile.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/DefaultProvidedFile.java
@@ -134,7 +134,9 @@ public final class DefaultProvidedFile {
         @JsonSetter(value = "relatedTypes", nulls = Nulls.SKIP)
         public _FinalStage relatedTypes(List<VariableType> relatedTypes) {
             this.relatedTypes.clear();
-            this.relatedTypes.addAll(relatedTypes);
+            if (relatedTypes != null) {
+                this.relatedTypes.addAll(relatedTypes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/Files.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/Files.java
@@ -81,7 +81,9 @@ public final class Files {
         @JsonSetter(value = "files", nulls = Nulls.SKIP)
         public Builder files(List<FileInfoV2> files) {
             this.files.clear();
-            this.files.addAll(files);
+            if (files != null) {
+                this.files.addAll(files);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/FunctionImplementationForMultipleLanguages.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/FunctionImplementationForMultipleLanguages.java
@@ -83,7 +83,9 @@ public final class FunctionImplementationForMultipleLanguages {
         @JsonSetter(value = "codeByLanguage", nulls = Nulls.SKIP)
         public Builder codeByLanguage(Map<Language, FunctionImplementation> codeByLanguage) {
             this.codeByLanguage.clear();
-            this.codeByLanguage.putAll(codeByLanguage);
+            if (codeByLanguage != null) {
+                this.codeByLanguage.putAll(codeByLanguage);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/GeneratedFiles.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/GeneratedFiles.java
@@ -109,7 +109,9 @@ public final class GeneratedFiles {
         @JsonSetter(value = "generatedTestCaseFiles", nulls = Nulls.SKIP)
         public Builder generatedTestCaseFiles(Map<Language, Files> generatedTestCaseFiles) {
             this.generatedTestCaseFiles.clear();
-            this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+            if (generatedTestCaseFiles != null) {
+                this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+            }
             return this;
         }
 
@@ -128,7 +130,9 @@ public final class GeneratedFiles {
         @JsonSetter(value = "generatedTemplateFiles", nulls = Nulls.SKIP)
         public Builder generatedTemplateFiles(Map<Language, Files> generatedTemplateFiles) {
             this.generatedTemplateFiles.clear();
-            this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+            if (generatedTemplateFiles != null) {
+                this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+            }
             return this;
         }
 
@@ -147,7 +151,9 @@ public final class GeneratedFiles {
         @JsonSetter(value = "other", nulls = Nulls.SKIP)
         public Builder other(Map<Language, Files> other) {
             this.other.clear();
-            this.other.putAll(other);
+            if (other != null) {
+                this.other.putAll(other);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/GetBasicSolutionFileResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/GetBasicSolutionFileResponse.java
@@ -82,7 +82,9 @@ public final class GetBasicSolutionFileResponse {
         @JsonSetter(value = "solutionFileByLanguage", nulls = Nulls.SKIP)
         public Builder solutionFileByLanguage(Map<Language, FileInfoV2> solutionFileByLanguage) {
             this.solutionFileByLanguage.clear();
-            this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+            if (solutionFileByLanguage != null) {
+                this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/GetFunctionSignatureResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/GetFunctionSignatureResponse.java
@@ -82,7 +82,9 @@ public final class GetFunctionSignatureResponse {
         @JsonSetter(value = "functionByLanguage", nulls = Nulls.SKIP)
         public Builder functionByLanguage(Map<Language, String> functionByLanguage) {
             this.functionByLanguage.clear();
-            this.functionByLanguage.putAll(functionByLanguage);
+            if (functionByLanguage != null) {
+                this.functionByLanguage.putAll(functionByLanguage);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/LightweightProblemInfoV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/LightweightProblemInfoV2.java
@@ -185,7 +185,9 @@ public final class LightweightProblemInfoV2 {
         @JsonSetter(value = "variableTypes", nulls = Nulls.SKIP)
         public _FinalStage variableTypes(Set<VariableType> variableTypes) {
             this.variableTypes.clear();
-            this.variableTypes.addAll(variableTypes);
+            if (variableTypes != null) {
+                this.variableTypes.addAll(variableTypes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/NonVoidFunctionSignature.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/NonVoidFunctionSignature.java
@@ -134,7 +134,9 @@ public final class NonVoidFunctionSignature {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public _FinalStage parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/ProblemInfoV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/ProblemInfoV2.java
@@ -340,7 +340,9 @@ public final class ProblemInfoV2 {
         @JsonSetter(value = "testcases", nulls = Nulls.SKIP)
         public _FinalStage testcases(List<TestCaseV2> testcases) {
             this.testcases.clear();
-            this.testcases.addAll(testcases);
+            if (testcases != null) {
+                this.testcases.addAll(testcases);
+            }
             return this;
         }
 
@@ -362,7 +364,9 @@ public final class ProblemInfoV2 {
         @JsonSetter(value = "customTestCaseTemplates", nulls = Nulls.SKIP)
         public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
             this.customTestCaseTemplates.clear();
-            this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            if (customTestCaseTemplates != null) {
+                this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            }
             return this;
         }
 
@@ -384,7 +388,9 @@ public final class ProblemInfoV2 {
         @JsonSetter(value = "supportedLanguages", nulls = Nulls.SKIP)
         public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
             this.supportedLanguages.clear();
-            this.supportedLanguages.addAll(supportedLanguages);
+            if (supportedLanguages != null) {
+                this.supportedLanguages.addAll(supportedLanguages);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/TestCaseImplementationDescription.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/TestCaseImplementationDescription.java
@@ -82,7 +82,9 @@ public final class TestCaseImplementationDescription {
         @JsonSetter(value = "boards", nulls = Nulls.SKIP)
         public Builder boards(List<TestCaseImplementationDescriptionBoard> boards) {
             this.boards.clear();
-            this.boards.addAll(boards);
+            if (boards != null) {
+                this.boards.addAll(boards);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/TestCaseV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/TestCaseV2.java
@@ -191,7 +191,9 @@ public final class TestCaseV2 {
         @JsonSetter(value = "arguments", nulls = Nulls.SKIP)
         public _FinalStage arguments(Map<String, VariableValue> arguments) {
             this.arguments.clear();
-            this.arguments.putAll(arguments);
+            if (arguments != null) {
+                this.arguments.putAll(arguments);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionDefinition.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionDefinition.java
@@ -135,7 +135,9 @@ public final class VoidFunctionDefinition {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public _FinalStage parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
@@ -136,7 +136,9 @@ public final class VoidFunctionDefinitionThatTakesActualResult {
         @JsonSetter(value = "additionalParameters", nulls = Nulls.SKIP)
         public _FinalStage additionalParameters(List<Parameter> additionalParameters) {
             this.additionalParameters.clear();
-            this.additionalParameters.addAll(additionalParameters);
+            if (additionalParameters != null) {
+                this.additionalParameters.addAll(additionalParameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionSignature.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionSignature.java
@@ -81,7 +81,9 @@ public final class VoidFunctionSignature {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public Builder parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionSignatureThatTakesActualResult.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/problem/types/VoidFunctionSignatureThatTakesActualResult.java
@@ -135,7 +135,9 @@ public final class VoidFunctionSignatureThatTakesActualResult {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public _FinalStage parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/BasicCustomFiles.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/BasicCustomFiles.java
@@ -186,7 +186,9 @@ public final class BasicCustomFiles {
         @JsonSetter(value = "additionalFiles", nulls = Nulls.SKIP)
         public _FinalStage additionalFiles(Map<Language, Files> additionalFiles) {
             this.additionalFiles.clear();
-            this.additionalFiles.putAll(additionalFiles);
+            if (additionalFiles != null) {
+                this.additionalFiles.putAll(additionalFiles);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/CreateProblemRequestV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/CreateProblemRequestV2.java
@@ -258,7 +258,9 @@ public final class CreateProblemRequestV2 {
         @JsonSetter(value = "supportedLanguages", nulls = Nulls.SKIP)
         public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
             this.supportedLanguages.clear();
-            this.supportedLanguages.addAll(supportedLanguages);
+            if (supportedLanguages != null) {
+                this.supportedLanguages.addAll(supportedLanguages);
+            }
             return this;
         }
 
@@ -280,7 +282,9 @@ public final class CreateProblemRequestV2 {
         @JsonSetter(value = "testcases", nulls = Nulls.SKIP)
         public _FinalStage testcases(List<TestCaseV2> testcases) {
             this.testcases.clear();
-            this.testcases.addAll(testcases);
+            if (testcases != null) {
+                this.testcases.addAll(testcases);
+            }
             return this;
         }
 
@@ -302,7 +306,9 @@ public final class CreateProblemRequestV2 {
         @JsonSetter(value = "customTestCaseTemplates", nulls = Nulls.SKIP)
         public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
             this.customTestCaseTemplates.clear();
-            this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            if (customTestCaseTemplates != null) {
+                this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/DefaultProvidedFile.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/DefaultProvidedFile.java
@@ -134,7 +134,9 @@ public final class DefaultProvidedFile {
         @JsonSetter(value = "relatedTypes", nulls = Nulls.SKIP)
         public _FinalStage relatedTypes(List<VariableType> relatedTypes) {
             this.relatedTypes.clear();
-            this.relatedTypes.addAll(relatedTypes);
+            if (relatedTypes != null) {
+                this.relatedTypes.addAll(relatedTypes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/Files.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/Files.java
@@ -81,7 +81,9 @@ public final class Files {
         @JsonSetter(value = "files", nulls = Nulls.SKIP)
         public Builder files(List<FileInfoV2> files) {
             this.files.clear();
-            this.files.addAll(files);
+            if (files != null) {
+                this.files.addAll(files);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/FunctionImplementationForMultipleLanguages.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/FunctionImplementationForMultipleLanguages.java
@@ -83,7 +83,9 @@ public final class FunctionImplementationForMultipleLanguages {
         @JsonSetter(value = "codeByLanguage", nulls = Nulls.SKIP)
         public Builder codeByLanguage(Map<Language, FunctionImplementation> codeByLanguage) {
             this.codeByLanguage.clear();
-            this.codeByLanguage.putAll(codeByLanguage);
+            if (codeByLanguage != null) {
+                this.codeByLanguage.putAll(codeByLanguage);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/GeneratedFiles.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/GeneratedFiles.java
@@ -109,7 +109,9 @@ public final class GeneratedFiles {
         @JsonSetter(value = "generatedTestCaseFiles", nulls = Nulls.SKIP)
         public Builder generatedTestCaseFiles(Map<Language, Files> generatedTestCaseFiles) {
             this.generatedTestCaseFiles.clear();
-            this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+            if (generatedTestCaseFiles != null) {
+                this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+            }
             return this;
         }
 
@@ -128,7 +130,9 @@ public final class GeneratedFiles {
         @JsonSetter(value = "generatedTemplateFiles", nulls = Nulls.SKIP)
         public Builder generatedTemplateFiles(Map<Language, Files> generatedTemplateFiles) {
             this.generatedTemplateFiles.clear();
-            this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+            if (generatedTemplateFiles != null) {
+                this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+            }
             return this;
         }
 
@@ -147,7 +151,9 @@ public final class GeneratedFiles {
         @JsonSetter(value = "other", nulls = Nulls.SKIP)
         public Builder other(Map<Language, Files> other) {
             this.other.clear();
-            this.other.putAll(other);
+            if (other != null) {
+                this.other.putAll(other);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/GetBasicSolutionFileResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/GetBasicSolutionFileResponse.java
@@ -82,7 +82,9 @@ public final class GetBasicSolutionFileResponse {
         @JsonSetter(value = "solutionFileByLanguage", nulls = Nulls.SKIP)
         public Builder solutionFileByLanguage(Map<Language, FileInfoV2> solutionFileByLanguage) {
             this.solutionFileByLanguage.clear();
-            this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+            if (solutionFileByLanguage != null) {
+                this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/GetFunctionSignatureResponse.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/GetFunctionSignatureResponse.java
@@ -82,7 +82,9 @@ public final class GetFunctionSignatureResponse {
         @JsonSetter(value = "functionByLanguage", nulls = Nulls.SKIP)
         public Builder functionByLanguage(Map<Language, String> functionByLanguage) {
             this.functionByLanguage.clear();
-            this.functionByLanguage.putAll(functionByLanguage);
+            if (functionByLanguage != null) {
+                this.functionByLanguage.putAll(functionByLanguage);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/LightweightProblemInfoV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/LightweightProblemInfoV2.java
@@ -185,7 +185,9 @@ public final class LightweightProblemInfoV2 {
         @JsonSetter(value = "variableTypes", nulls = Nulls.SKIP)
         public _FinalStage variableTypes(Set<VariableType> variableTypes) {
             this.variableTypes.clear();
-            this.variableTypes.addAll(variableTypes);
+            if (variableTypes != null) {
+                this.variableTypes.addAll(variableTypes);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/NonVoidFunctionSignature.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/NonVoidFunctionSignature.java
@@ -134,7 +134,9 @@ public final class NonVoidFunctionSignature {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public _FinalStage parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/ProblemInfoV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/ProblemInfoV2.java
@@ -340,7 +340,9 @@ public final class ProblemInfoV2 {
         @JsonSetter(value = "testcases", nulls = Nulls.SKIP)
         public _FinalStage testcases(List<TestCaseV2> testcases) {
             this.testcases.clear();
-            this.testcases.addAll(testcases);
+            if (testcases != null) {
+                this.testcases.addAll(testcases);
+            }
             return this;
         }
 
@@ -362,7 +364,9 @@ public final class ProblemInfoV2 {
         @JsonSetter(value = "customTestCaseTemplates", nulls = Nulls.SKIP)
         public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
             this.customTestCaseTemplates.clear();
-            this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            if (customTestCaseTemplates != null) {
+                this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+            }
             return this;
         }
 
@@ -384,7 +388,9 @@ public final class ProblemInfoV2 {
         @JsonSetter(value = "supportedLanguages", nulls = Nulls.SKIP)
         public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
             this.supportedLanguages.clear();
-            this.supportedLanguages.addAll(supportedLanguages);
+            if (supportedLanguages != null) {
+                this.supportedLanguages.addAll(supportedLanguages);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/TestCaseImplementationDescription.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/TestCaseImplementationDescription.java
@@ -82,7 +82,9 @@ public final class TestCaseImplementationDescription {
         @JsonSetter(value = "boards", nulls = Nulls.SKIP)
         public Builder boards(List<TestCaseImplementationDescriptionBoard> boards) {
             this.boards.clear();
-            this.boards.addAll(boards);
+            if (boards != null) {
+                this.boards.addAll(boards);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/TestCaseV2.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/TestCaseV2.java
@@ -191,7 +191,9 @@ public final class TestCaseV2 {
         @JsonSetter(value = "arguments", nulls = Nulls.SKIP)
         public _FinalStage arguments(Map<String, VariableValue> arguments) {
             this.arguments.clear();
-            this.arguments.putAll(arguments);
+            if (arguments != null) {
+                this.arguments.putAll(arguments);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionDefinition.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionDefinition.java
@@ -135,7 +135,9 @@ public final class VoidFunctionDefinition {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public _FinalStage parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
@@ -136,7 +136,9 @@ public final class VoidFunctionDefinitionThatTakesActualResult {
         @JsonSetter(value = "additionalParameters", nulls = Nulls.SKIP)
         public _FinalStage additionalParameters(List<Parameter> additionalParameters) {
             this.additionalParameters.clear();
-            this.additionalParameters.addAll(additionalParameters);
+            if (additionalParameters != null) {
+                this.additionalParameters.addAll(additionalParameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionSignature.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionSignature.java
@@ -81,7 +81,9 @@ public final class VoidFunctionSignature {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public Builder parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionSignatureThatTakesActualResult.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/v2/v3/problem/types/VoidFunctionSignatureThatTakesActualResult.java
@@ -135,7 +135,9 @@ public final class VoidFunctionSignatureThatTakesActualResult {
         @JsonSetter(value = "parameters", nulls = Nulls.SKIP)
         public _FinalStage parameters(List<Parameter> parameters) {
             this.parameters.clear();
-            this.parameters.addAll(parameters);
+            if (parameters != null) {
+                this.parameters.addAll(parameters);
+            }
             return this;
         }
 

--- a/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/resources/union/types/NamedMetadata.java
+++ b/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/resources/union/types/NamedMetadata.java
@@ -131,7 +131,9 @@ public final class NamedMetadata {
         @JsonSetter(value = "value", nulls = Nulls.SKIP)
         public _FinalStage value(Map<String, Object> value) {
             this.value.clear();
-            this.value.putAll(value);
+            if (value != null) {
+                this.value.putAll(value);
+            }
             return this;
         }
 

--- a/seed/java-spring/circular-references-advanced/resources/ast/types/BranchNode.java
+++ b/seed/java-spring/circular-references-advanced/resources/ast/types/BranchNode.java
@@ -77,7 +77,9 @@ public final class BranchNode {
     )
     public Builder children(List<Node> children) {
       this.children.clear();
-      this.children.addAll(children);
+      if (children != null) {
+        this.children.addAll(children);
+      }
       return this;
     }
 

--- a/seed/java-spring/circular-references-advanced/resources/ast/types/NodesWrapper.java
+++ b/seed/java-spring/circular-references-advanced/resources/ast/types/NodesWrapper.java
@@ -77,7 +77,9 @@ public final class NodesWrapper {
     )
     public Builder nodes(List<List<Node>> nodes) {
       this.nodes.clear();
-      this.nodes.addAll(nodes);
+      if (nodes != null) {
+        this.nodes.addAll(nodes);
+      }
       return this;
     }
 

--- a/seed/java-spring/client-side-params/resources/types/types/PaginatedClientResponse.java
+++ b/seed/java-spring/client-side-params/resources/types/types/PaginatedClientResponse.java
@@ -245,7 +245,9 @@ public final class PaginatedClientResponse {
     )
     public _FinalStage clients(List<Client> clients) {
       this.clients.clear();
-      this.clients.addAll(clients);
+      if (clients != null) {
+        this.clients.addAll(clients);
+      }
       return this;
     }
 

--- a/seed/java-spring/client-side-params/resources/types/types/PaginatedUserResponse.java
+++ b/seed/java-spring/client-side-params/resources/types/types/PaginatedUserResponse.java
@@ -205,7 +205,9 @@ public final class PaginatedUserResponse {
     )
     public _FinalStage users(List<User> users) {
       this.users.clear();
-      this.users.addAll(users);
+      if (users != null) {
+        this.users.addAll(users);
+      }
       return this;
     }
 

--- a/seed/java-spring/client-side-params/resources/types/types/SearchResponse.java
+++ b/seed/java-spring/client-side-params/resources/types/types/SearchResponse.java
@@ -102,7 +102,9 @@ public final class SearchResponse {
     )
     public Builder results(List<Resource> results) {
       this.results.clear();
-      this.results.addAll(results);
+      if (results != null) {
+        this.results.addAll(results);
+      }
       return this;
     }
 

--- a/seed/java-spring/examples/resources/types/types/ExtendedMovie.java
+++ b/seed/java-spring/examples/resources/types/types/ExtendedMovie.java
@@ -317,7 +317,9 @@ public final class ExtendedMovie implements IMovie {
     )
     public _FinalStage cast(List<String> cast) {
       this.cast.clear();
-      this.cast.addAll(cast);
+      if (cast != null) {
+        this.cast.addAll(cast);
+      }
       return this;
     }
 
@@ -342,7 +344,9 @@ public final class ExtendedMovie implements IMovie {
     )
     public _FinalStage metadata(Map<String, Object> metadata) {
       this.metadata.clear();
-      this.metadata.putAll(metadata);
+      if (metadata != null) {
+        this.metadata.putAll(metadata);
+      }
       return this;
     }
 

--- a/seed/java-spring/examples/resources/types/types/Movie.java
+++ b/seed/java-spring/examples/resources/types/types/Movie.java
@@ -297,7 +297,9 @@ public final class Movie implements IMovie {
     )
     public _FinalStage metadata(Map<String, Object> metadata) {
       this.metadata.clear();
-      this.metadata.putAll(metadata);
+      if (metadata != null) {
+        this.metadata.putAll(metadata);
+      }
       return this;
     }
 

--- a/seed/java-spring/examples/resources/types/types/Response.java
+++ b/seed/java-spring/examples/resources/types/types/Response.java
@@ -128,7 +128,9 @@ public final class Response {
     )
     public _FinalStage identifiers(List<Identifier> identifiers) {
       this.identifiers.clear();
-      this.identifiers.addAll(identifiers);
+      if (identifiers != null) {
+        this.identifiers.addAll(identifiers);
+      }
       return this;
     }
 

--- a/seed/java-spring/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
+++ b/seed/java-spring/exhaustive/resources/types/object/types/ObjectWithMapOfMap.java
@@ -77,7 +77,9 @@ public final class ObjectWithMapOfMap {
     )
     public Builder map(Map<String, Map<String, String>> map) {
       this.map.clear();
-      this.map.putAll(map);
+      if (map != null) {
+        this.map.putAll(map);
+      }
       return this;
     }
 

--- a/seed/java-spring/http-head/resources/user/types/User.java
+++ b/seed/java-spring/http-head/resources/user/types/User.java
@@ -128,7 +128,9 @@ public final class User {
     )
     public _FinalStage tags(List<String> tags) {
       this.tags.clear();
-      this.tags.addAll(tags);
+      if (tags != null) {
+        this.tags.addAll(tags);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-inline-types/types/ObjectTypeWithListAliasType.java
+++ b/seed/java-spring/java-inline-types/types/ObjectTypeWithListAliasType.java
@@ -77,7 +77,9 @@ public final class ObjectTypeWithListAliasType {
     )
     public Builder prop(List<AliasProperty> prop) {
       this.prop.clear();
-      this.prop.addAll(prop);
+      if (prop != null) {
+        this.prop.addAll(prop);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-inline-types/types/ObjectTypeWithMapAliasTypeBoth.java
+++ b/seed/java-spring/java-inline-types/types/ObjectTypeWithMapAliasTypeBoth.java
@@ -77,7 +77,9 @@ public final class ObjectTypeWithMapAliasTypeBoth {
     )
     public Builder prop(Map<AliasProperty, OtherAliasProperty> prop) {
       this.prop.clear();
-      this.prop.putAll(prop);
+      if (prop != null) {
+        this.prop.putAll(prop);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-inline-types/types/ObjectTypeWithMapAliasTypeKey.java
+++ b/seed/java-spring/java-inline-types/types/ObjectTypeWithMapAliasTypeKey.java
@@ -77,7 +77,9 @@ public final class ObjectTypeWithMapAliasTypeKey {
     )
     public Builder prop(Map<AliasProperty, String> prop) {
       this.prop.clear();
-      this.prop.putAll(prop);
+      if (prop != null) {
+        this.prop.putAll(prop);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-inline-types/types/ObjectTypeWithMapAliasTypeValue.java
+++ b/seed/java-spring/java-inline-types/types/ObjectTypeWithMapAliasTypeValue.java
@@ -77,7 +77,9 @@ public final class ObjectTypeWithMapAliasTypeValue {
     )
     public Builder prop(Map<String, AliasProperty> prop) {
       this.prop.clear();
-      this.prop.putAll(prop);
+      if (prop != null) {
+        this.prop.putAll(prop);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-inline-types/types/ObjectTypeWithSetAliasType.java
+++ b/seed/java-spring/java-inline-types/types/ObjectTypeWithSetAliasType.java
@@ -77,7 +77,9 @@ public final class ObjectTypeWithSetAliasType {
     )
     public Builder prop(Set<AliasProperty> prop) {
       this.prop.clear();
-      this.prop.addAll(prop);
+      if (prop != null) {
+        this.prop.addAll(prop);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-inline-types/types/RootType1.java
+++ b/seed/java-spring/java-inline-types/types/RootType1.java
@@ -273,7 +273,9 @@ public final class RootType1 {
     )
     public _FinalStage fooSet(Set<RootType1FooSetItem> fooSet) {
       this.fooSet.clear();
-      this.fooSet.addAll(fooSet);
+      if (fooSet != null) {
+        this.fooSet.addAll(fooSet);
+      }
       return this;
     }
 
@@ -309,7 +311,9 @@ public final class RootType1 {
     )
     public _FinalStage fooList(List<RootType1FooListItem> fooList) {
       this.fooList.clear();
-      this.fooList.addAll(fooList);
+      if (fooList != null) {
+        this.fooList.addAll(fooList);
+      }
       return this;
     }
 
@@ -345,7 +349,9 @@ public final class RootType1 {
     )
     public _FinalStage fooMap(Map<String, RootType1FooMapValue> fooMap) {
       this.fooMap.clear();
-      this.fooMap.putAll(fooMap);
+      if (fooMap != null) {
+        this.fooMap.putAll(fooMap);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-pagination-deep-cursor-path/resources/deepcursorpath/types/IndirectionRequired.java
+++ b/seed/java-spring/java-pagination-deep-cursor-path/resources/deepcursorpath/types/IndirectionRequired.java
@@ -103,7 +103,9 @@ public final class IndirectionRequired {
     )
     public Builder results(List<String> results) {
       this.results.clear();
-      this.results.addAll(results);
+      if (results != null) {
+        this.results.addAll(results);
+      }
       return this;
     }
 

--- a/seed/java-spring/java-pagination-deep-cursor-path/resources/deepcursorpath/types/Response.java
+++ b/seed/java-spring/java-pagination-deep-cursor-path/resources/deepcursorpath/types/Response.java
@@ -103,7 +103,9 @@ public final class Response {
     )
     public Builder results(List<String> results) {
       this.results.clear();
-      this.results.addAll(results);
+      if (results != null) {
+        this.results.addAll(results);
+      }
       return this;
     }
 

--- a/seed/java-spring/literal/resources/reference/types/ContainerObject.java
+++ b/seed/java-spring/literal/resources/reference/types/ContainerObject.java
@@ -77,7 +77,9 @@ public final class ContainerObject {
     )
     public Builder nestedObjects(List<NestedObjectWithLiterals> nestedObjects) {
       this.nestedObjects.clear();
-      this.nestedObjects.addAll(nestedObjects);
+      if (nestedObjects != null) {
+        this.nestedObjects.addAll(nestedObjects);
+      }
       return this;
     }
 

--- a/seed/java-spring/mixed-case/resources/service/types/User.java
+++ b/seed/java-spring/mixed-case/resources/service/types/User.java
@@ -147,7 +147,9 @@ public final class User {
     )
     public _FinalStage extraProperties(Map<String, String> extraProperties) {
       this.extraProperties.clear();
-      this.extraProperties.putAll(extraProperties);
+      if (extraProperties != null) {
+        this.extraProperties.putAll(extraProperties);
+      }
       return this;
     }
 
@@ -172,7 +174,9 @@ public final class User {
     )
     public _FinalStage metadataTags(List<String> metadataTags) {
       this.metadataTags.clear();
-      this.metadataTags.addAll(metadataTags);
+      if (metadataTags != null) {
+        this.metadataTags.addAll(metadataTags);
+      }
       return this;
     }
 

--- a/seed/java-spring/mixed-file-directory/resources/organization/types/Organization.java
+++ b/seed/java-spring/mixed-file-directory/resources/organization/types/Organization.java
@@ -152,7 +152,9 @@ public final class Organization {
     )
     public _FinalStage users(List<User> users) {
       this.users.clear();
-      this.users.addAll(users);
+      if (users != null) {
+        this.users.addAll(users);
+      }
       return this;
     }
 

--- a/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/requests/SearchRequest.java
+++ b/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/requests/SearchRequest.java
@@ -159,7 +159,9 @@ public final class SearchRequest {
     )
     public _FinalStage includeTypes(List<String> includeTypes) {
       this.includeTypes.clear();
-      this.includeTypes.addAll(includeTypes);
+      if (includeTypes != null) {
+        this.includeTypes.addAll(includeTypes);
+      }
       return this;
     }
 

--- a/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/requests/UpdateTagsRequest.java
+++ b/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/requests/UpdateTagsRequest.java
@@ -114,7 +114,9 @@ public final class UpdateTagsRequest {
     )
     public Builder tags(List<String> tags) {
       this.tags.clear();
-      this.tags.addAll(tags);
+      if (tags != null) {
+        this.tags.addAll(tags);
+      }
       return this;
     }
 

--- a/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/types/ComplexProfile.java
+++ b/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/types/ComplexProfile.java
@@ -493,7 +493,9 @@ public final class ComplexProfile {
     )
     public _FinalStage nullableListOfUnions(List<NotificationMethod> nullableListOfUnions) {
       this.nullableListOfUnions.clear();
-      this.nullableListOfUnions.addAll(nullableListOfUnions);
+      if (nullableListOfUnions != null) {
+        this.nullableListOfUnions.addAll(nullableListOfUnions);
+      }
       return this;
     }
 
@@ -518,7 +520,9 @@ public final class ComplexProfile {
     )
     public _FinalStage nullableMapOfNullables(Map<String, Address> nullableMapOfNullables) {
       this.nullableMapOfNullables.clear();
-      this.nullableMapOfNullables.putAll(nullableMapOfNullables);
+      if (nullableMapOfNullables != null) {
+        this.nullableMapOfNullables.putAll(nullableMapOfNullables);
+      }
       return this;
     }
 
@@ -543,7 +547,9 @@ public final class ComplexProfile {
     )
     public _FinalStage nullableListOfNullables(List<String> nullableListOfNullables) {
       this.nullableListOfNullables.clear();
-      this.nullableListOfNullables.addAll(nullableListOfNullables);
+      if (nullableListOfNullables != null) {
+        this.nullableListOfNullables.addAll(nullableListOfNullables);
+      }
       return this;
     }
 
@@ -600,7 +606,9 @@ public final class ComplexProfile {
     )
     public _FinalStage nullableArray(List<String> nullableArray) {
       this.nullableArray.clear();
-      this.nullableArray.addAll(nullableArray);
+      if (nullableArray != null) {
+        this.nullableArray.addAll(nullableArray);
+      }
       return this;
     }
 

--- a/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/types/DeserializationTestRequest.java
+++ b/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/types/DeserializationTestRequest.java
@@ -367,7 +367,9 @@ public final class DeserializationTestRequest {
     )
     public _FinalStage nullableMap(Map<String, Integer> nullableMap) {
       this.nullableMap.clear();
-      this.nullableMap.putAll(nullableMap);
+      if (nullableMap != null) {
+        this.nullableMap.putAll(nullableMap);
+      }
       return this;
     }
 
@@ -392,7 +394,9 @@ public final class DeserializationTestRequest {
     )
     public _FinalStage nullableList(List<String> nullableList) {
       this.nullableList.clear();
-      this.nullableList.addAll(nullableList);
+      if (nullableList != null) {
+        this.nullableList.addAll(nullableList);
+      }
       return this;
     }
 

--- a/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/types/UserProfile.java
+++ b/seed/java-spring/nullable-optional/with-nullable-annotation/resources/nullableoptional/types/UserProfile.java
@@ -596,7 +596,9 @@ public final class UserProfile {
     )
     public _FinalStage nullableMap(Map<String, String> nullableMap) {
       this.nullableMap.clear();
-      this.nullableMap.putAll(nullableMap);
+      if (nullableMap != null) {
+        this.nullableMap.putAll(nullableMap);
+      }
       return this;
     }
 
@@ -621,7 +623,9 @@ public final class UserProfile {
     )
     public _FinalStage nullableList(List<String> nullableList) {
       this.nullableList.clear();
-      this.nullableList.addAll(nullableList);
+      if (nullableList != null) {
+        this.nullableList.addAll(nullableList);
+      }
       return this;
     }
 

--- a/seed/java-spring/object/types/Type.java
+++ b/seed/java-spring/object/types/Type.java
@@ -620,7 +620,9 @@ public final class Type {
     )
     public _FinalStage seventeen(List<Optional<UUID>> seventeen) {
       this.seventeen.clear();
-      this.seventeen.addAll(seventeen);
+      if (seventeen != null) {
+        this.seventeen.addAll(seventeen);
+      }
       return this;
     }
 
@@ -645,7 +647,9 @@ public final class Type {
     )
     public _FinalStage sixteen(List<Map<String, Integer>> sixteen) {
       this.sixteen.clear();
-      this.sixteen.addAll(sixteen);
+      if (sixteen != null) {
+        this.sixteen.addAll(sixteen);
+      }
       return this;
     }
 
@@ -670,7 +674,9 @@ public final class Type {
     )
     public _FinalStage fifteen(List<List<Integer>> fifteen) {
       this.fifteen.clear();
-      this.fifteen.addAll(fifteen);
+      if (fifteen != null) {
+        this.fifteen.addAll(fifteen);
+      }
       return this;
     }
 
@@ -711,7 +717,9 @@ public final class Type {
     )
     public _FinalStage twelve(Map<String, Boolean> twelve) {
       this.twelve.clear();
-      this.twelve.putAll(twelve);
+      if (twelve != null) {
+        this.twelve.putAll(twelve);
+      }
       return this;
     }
 
@@ -736,7 +744,9 @@ public final class Type {
     )
     public _FinalStage eleven(Set<Double> eleven) {
       this.eleven.clear();
-      this.eleven.addAll(eleven);
+      if (eleven != null) {
+        this.eleven.addAll(eleven);
+      }
       return this;
     }
 
@@ -761,7 +771,9 @@ public final class Type {
     )
     public _FinalStage ten(List<Integer> ten) {
       this.ten.clear();
-      this.ten.addAll(ten);
+      if (ten != null) {
+        this.ten.addAll(ten);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination-custom/types/UsernamePage.java
+++ b/seed/java-spring/pagination-custom/types/UsernamePage.java
@@ -103,7 +103,9 @@ public final class UsernamePage {
     )
     public Builder data(List<String> data) {
       this.data.clear();
-      this.data.addAll(data);
+      if (data != null) {
+        this.data.addAll(data);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/complex/types/PaginatedConversationResponse.java
+++ b/seed/java-spring/pagination/resources/complex/types/PaginatedConversationResponse.java
@@ -165,7 +165,9 @@ public final class PaginatedConversationResponse {
     )
     public _FinalStage conversations(List<Conversation> conversations) {
       this.conversations.clear();
-      this.conversations.addAll(conversations);
+      if (conversations != null) {
+        this.conversations.addAll(conversations);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/inlineusers/inlineusers/types/UserListContainer.java
+++ b/seed/java-spring/pagination/resources/inlineusers/inlineusers/types/UserListContainer.java
@@ -77,7 +77,9 @@ public final class UserListContainer {
     )
     public Builder users(List<User> users) {
       this.users.clear();
-      this.users.addAll(users);
+      if (users != null) {
+        this.users.addAll(users);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/inlineusers/inlineusers/types/UsernameContainer.java
+++ b/seed/java-spring/pagination/resources/inlineusers/inlineusers/types/UsernameContainer.java
@@ -77,7 +77,9 @@ public final class UsernameContainer {
     )
     public Builder results(List<String> results) {
       this.results.clear();
-      this.results.addAll(results);
+      if (results != null) {
+        this.results.addAll(results);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/inlineusers/inlineusers/types/Users.java
+++ b/seed/java-spring/pagination/resources/inlineusers/inlineusers/types/Users.java
@@ -77,7 +77,9 @@ public final class Users {
     )
     public Builder users(List<User> users) {
       this.users.clear();
-      this.users.addAll(users);
+      if (users != null) {
+        this.users.addAll(users);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/users/types/ListUsersMixedTypePaginationResponse.java
+++ b/seed/java-spring/pagination/resources/users/types/ListUsersMixedTypePaginationResponse.java
@@ -128,7 +128,9 @@ public final class ListUsersMixedTypePaginationResponse {
     )
     public _FinalStage data(List<User> data) {
       this.data.clear();
-      this.data.addAll(data);
+      if (data != null) {
+        this.data.addAll(data);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/users/types/ListUsersPaginationResponse.java
+++ b/seed/java-spring/pagination/resources/users/types/ListUsersPaginationResponse.java
@@ -171,7 +171,9 @@ public final class ListUsersPaginationResponse {
     )
     public _FinalStage data(List<User> data) {
       this.data.clear();
-      this.data.addAll(data);
+      if (data != null) {
+        this.data.addAll(data);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/users/types/UserListContainer.java
+++ b/seed/java-spring/pagination/resources/users/types/UserListContainer.java
@@ -77,7 +77,9 @@ public final class UserListContainer {
     )
     public Builder users(List<User> users) {
       this.users.clear();
-      this.users.addAll(users);
+      if (users != null) {
+        this.users.addAll(users);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/resources/users/types/UsernameContainer.java
+++ b/seed/java-spring/pagination/resources/users/types/UsernameContainer.java
@@ -77,7 +77,9 @@ public final class UsernameContainer {
     )
     public Builder results(List<String> results) {
       this.results.clear();
-      this.results.addAll(results);
+      if (results != null) {
+        this.results.addAll(results);
+      }
       return this;
     }
 

--- a/seed/java-spring/pagination/types/UsernamePage.java
+++ b/seed/java-spring/pagination/types/UsernamePage.java
@@ -103,7 +103,9 @@ public final class UsernamePage {
     )
     public Builder data(List<String> data) {
       this.data.clear();
-      this.data.addAll(data);
+      if (data != null) {
+        this.data.addAll(data);
+      }
       return this;
     }
 

--- a/seed/java-spring/path-parameters/resources/organizations/types/Organization.java
+++ b/seed/java-spring/path-parameters/resources/organizations/types/Organization.java
@@ -128,7 +128,9 @@ public final class Organization {
     )
     public _FinalStage tags(List<String> tags) {
       this.tags.clear();
-      this.tags.addAll(tags);
+      if (tags != null) {
+        this.tags.addAll(tags);
+      }
       return this;
     }
 

--- a/seed/java-spring/path-parameters/resources/user/types/User.java
+++ b/seed/java-spring/path-parameters/resources/user/types/User.java
@@ -128,7 +128,9 @@ public final class User {
     )
     public _FinalStage tags(List<String> tags) {
       this.tags.clear();
-      this.tags.addAll(tags);
+      if (tags != null) {
+        this.tags.addAll(tags);
+      }
       return this;
     }
 

--- a/seed/java-spring/query-parameters/resources/user/types/User.java
+++ b/seed/java-spring/query-parameters/resources/user/types/User.java
@@ -128,7 +128,9 @@ public final class User {
     )
     public _FinalStage tags(List<String> tags) {
       this.tags.clear();
-      this.tags.addAll(tags);
+      if (tags != null) {
+        this.tags.addAll(tags);
+      }
       return this;
     }
 

--- a/seed/java-spring/request-parameters/resources/user/types/User.java
+++ b/seed/java-spring/request-parameters/resources/user/types/User.java
@@ -128,7 +128,9 @@ public final class User {
     )
     public _FinalStage tags(List<String> tags) {
       this.tags.clear();
-      this.tags.addAll(tags);
+      if (tags != null) {
+        this.tags.addAll(tags);
+      }
       return this;
     }
 

--- a/seed/java-spring/reserved-keywords/resources/package_/types/Record.java
+++ b/seed/java-spring/reserved-keywords/resources/package_/types/Record.java
@@ -127,7 +127,9 @@ public final class Record {
     )
     public _FinalStage foo(Map<String, String> foo) {
       this.foo.clear();
-      this.foo.putAll(foo);
+      if (foo != null) {
+        this.foo.putAll(foo);
+      }
       return this;
     }
 

--- a/seed/java-spring/simple-fhir/types/Account.java
+++ b/seed/java-spring/simple-fhir/types/Account.java
@@ -244,7 +244,9 @@ public final class Account implements IBaseResource {
     )
     public _FinalStage relatedResources(List<ResourceList> relatedResources) {
       this.relatedResources.clear();
-      this.relatedResources.addAll(relatedResources);
+      if (relatedResources != null) {
+        this.relatedResources.addAll(relatedResources);
+      }
       return this;
     }
 

--- a/seed/java-spring/simple-fhir/types/BaseResource.java
+++ b/seed/java-spring/simple-fhir/types/BaseResource.java
@@ -153,7 +153,9 @@ public final class BaseResource implements IBaseResource {
     )
     public _FinalStage relatedResources(List<ResourceList> relatedResources) {
       this.relatedResources.clear();
-      this.relatedResources.addAll(relatedResources);
+      if (relatedResources != null) {
+        this.relatedResources.addAll(relatedResources);
+      }
       return this;
     }
 

--- a/seed/java-spring/simple-fhir/types/Patient.java
+++ b/seed/java-spring/simple-fhir/types/Patient.java
@@ -198,7 +198,9 @@ public final class Patient implements IBaseResource {
     )
     public _FinalStage scripts(List<Script> scripts) {
       this.scripts.clear();
-      this.scripts.addAll(scripts);
+      if (scripts != null) {
+        this.scripts.addAll(scripts);
+      }
       return this;
     }
 
@@ -223,7 +225,9 @@ public final class Patient implements IBaseResource {
     )
     public _FinalStage relatedResources(List<ResourceList> relatedResources) {
       this.relatedResources.clear();
-      this.relatedResources.addAll(relatedResources);
+      if (relatedResources != null) {
+        this.relatedResources.addAll(relatedResources);
+      }
       return this;
     }
 

--- a/seed/java-spring/simple-fhir/types/Practitioner.java
+++ b/seed/java-spring/simple-fhir/types/Practitioner.java
@@ -180,7 +180,9 @@ public final class Practitioner implements IBaseResource {
     )
     public _FinalStage relatedResources(List<ResourceList> relatedResources) {
       this.relatedResources.clear();
-      this.relatedResources.addAll(relatedResources);
+      if (relatedResources != null) {
+        this.relatedResources.addAll(relatedResources);
+      }
       return this;
     }
 

--- a/seed/java-spring/simple-fhir/types/Script.java
+++ b/seed/java-spring/simple-fhir/types/Script.java
@@ -180,7 +180,9 @@ public final class Script implements IBaseResource {
     )
     public _FinalStage relatedResources(List<ResourceList> relatedResources) {
       this.relatedResources.clear();
-      this.relatedResources.addAll(relatedResources);
+      if (relatedResources != null) {
+        this.relatedResources.addAll(relatedResources);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/admin/requests/StoreTracedTestCaseRequest.java
+++ b/seed/java-spring/trace/resources/admin/requests/StoreTracedTestCaseRequest.java
@@ -131,7 +131,9 @@ public final class StoreTracedTestCaseRequest {
     )
     public _FinalStage traceResponses(List<TraceResponse> traceResponses) {
       this.traceResponses.clear();
-      this.traceResponses.addAll(traceResponses);
+      if (traceResponses != null) {
+        this.traceResponses.addAll(traceResponses);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/admin/requests/StoreTracedWorkspaceRequest.java
+++ b/seed/java-spring/trace/resources/admin/requests/StoreTracedWorkspaceRequest.java
@@ -131,7 +131,9 @@ public final class StoreTracedWorkspaceRequest {
     )
     public _FinalStage traceResponses(List<TraceResponse> traceResponses) {
       this.traceResponses.clear();
-      this.traceResponses.addAll(traceResponses);
+      if (traceResponses != null) {
+        this.traceResponses.addAll(traceResponses);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/commons/types/BinaryTreeValue.java
+++ b/seed/java-spring/trace/resources/commons/types/BinaryTreeValue.java
@@ -103,7 +103,9 @@ public final class BinaryTreeValue {
     )
     public Builder nodes(Map<NodeId, BinaryTreeNodeValue> nodes) {
       this.nodes.clear();
-      this.nodes.putAll(nodes);
+      if (nodes != null) {
+        this.nodes.putAll(nodes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/commons/types/DebugMapValue.java
+++ b/seed/java-spring/trace/resources/commons/types/DebugMapValue.java
@@ -77,7 +77,9 @@ public final class DebugMapValue {
     )
     public Builder keyValuePairs(List<DebugKeyValuePairs> keyValuePairs) {
       this.keyValuePairs.clear();
-      this.keyValuePairs.addAll(keyValuePairs);
+      if (keyValuePairs != null) {
+        this.keyValuePairs.addAll(keyValuePairs);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/commons/types/DoublyLinkedListValue.java
+++ b/seed/java-spring/trace/resources/commons/types/DoublyLinkedListValue.java
@@ -104,7 +104,9 @@ public final class DoublyLinkedListValue {
     )
     public Builder nodes(Map<NodeId, DoublyLinkedListNodeValue> nodes) {
       this.nodes.clear();
-      this.nodes.putAll(nodes);
+      if (nodes != null) {
+        this.nodes.putAll(nodes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/commons/types/MapValue.java
+++ b/seed/java-spring/trace/resources/commons/types/MapValue.java
@@ -77,7 +77,9 @@ public final class MapValue {
     )
     public Builder keyValuePairs(List<KeyValuePair> keyValuePairs) {
       this.keyValuePairs.clear();
-      this.keyValuePairs.addAll(keyValuePairs);
+      if (keyValuePairs != null) {
+        this.keyValuePairs.addAll(keyValuePairs);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/commons/types/SinglyLinkedListValue.java
+++ b/seed/java-spring/trace/resources/commons/types/SinglyLinkedListValue.java
@@ -104,7 +104,9 @@ public final class SinglyLinkedListValue {
     )
     public Builder nodes(Map<NodeId, SinglyLinkedListNodeValue> nodes) {
       this.nodes.clear();
-      this.nodes.putAll(nodes);
+      if (nodes != null) {
+        this.nodes.putAll(nodes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/commons/types/TestCase.java
+++ b/seed/java-spring/trace/resources/commons/types/TestCase.java
@@ -128,7 +128,9 @@ public final class TestCase {
     )
     public _FinalStage params(List<VariableValue> params) {
       this.params.clear();
-      this.params.addAll(params);
+      if (params != null) {
+        this.params.addAll(params);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/playlist/types/Playlist.java
+++ b/seed/java-spring/trace/resources/playlist/types/Playlist.java
@@ -176,7 +176,9 @@ public final class Playlist implements IPlaylistCreateRequest {
     )
     public _FinalStage problems(List<ProblemId> problems) {
       this.problems.clear();
-      this.problems.addAll(problems);
+      if (problems != null) {
+        this.problems.addAll(problems);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/playlist/types/PlaylistCreateRequest.java
+++ b/seed/java-spring/trace/resources/playlist/types/PlaylistCreateRequest.java
@@ -131,7 +131,9 @@ public final class PlaylistCreateRequest implements IPlaylistCreateRequest {
     )
     public _FinalStage problems(List<ProblemId> problems) {
       this.problems.clear();
-      this.problems.addAll(problems);
+      if (problems != null) {
+        this.problems.addAll(problems);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/playlist/types/UpdatePlaylistRequest.java
+++ b/seed/java-spring/trace/resources/playlist/types/UpdatePlaylistRequest.java
@@ -146,7 +146,9 @@ public final class UpdatePlaylistRequest {
     )
     public _FinalStage problems(List<ProblemId> problems) {
       this.problems.clear();
-      this.problems.addAll(problems);
+      if (problems != null) {
+        this.problems.addAll(problems);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/problem/requests/GetDefaultStarterFilesRequest.java
+++ b/seed/java-spring/trace/resources/problem/requests/GetDefaultStarterFilesRequest.java
@@ -192,7 +192,9 @@ public final class GetDefaultStarterFilesRequest {
     )
     public _FinalStage inputParams(List<VariableTypeAndName> inputParams) {
       this.inputParams.clear();
-      this.inputParams.addAll(inputParams);
+      if (inputParams != null) {
+        this.inputParams.addAll(inputParams);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/problem/types/CreateProblemRequest.java
+++ b/seed/java-spring/trace/resources/problem/types/CreateProblemRequest.java
@@ -235,7 +235,9 @@ public final class CreateProblemRequest {
     )
     public _FinalStage testcases(List<TestCaseWithExpectedResult> testcases) {
       this.testcases.clear();
-      this.testcases.addAll(testcases);
+      if (testcases != null) {
+        this.testcases.addAll(testcases);
+      }
       return this;
     }
 
@@ -260,7 +262,9 @@ public final class CreateProblemRequest {
     )
     public _FinalStage inputParams(List<VariableTypeAndName> inputParams) {
       this.inputParams.clear();
-      this.inputParams.addAll(inputParams);
+      if (inputParams != null) {
+        this.inputParams.addAll(inputParams);
+      }
       return this;
     }
 
@@ -285,7 +289,9 @@ public final class CreateProblemRequest {
     )
     public _FinalStage files(Map<Language, ProblemFiles> files) {
       this.files.clear();
-      this.files.putAll(files);
+      if (files != null) {
+        this.files.putAll(files);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/problem/types/GetDefaultStarterFilesResponse.java
+++ b/seed/java-spring/trace/resources/problem/types/GetDefaultStarterFilesResponse.java
@@ -78,7 +78,9 @@ public final class GetDefaultStarterFilesResponse {
     )
     public Builder files(Map<Language, ProblemFiles> files) {
       this.files.clear();
-      this.files.putAll(files);
+      if (files != null) {
+        this.files.putAll(files);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/problem/types/ProblemDescription.java
+++ b/seed/java-spring/trace/resources/problem/types/ProblemDescription.java
@@ -77,7 +77,9 @@ public final class ProblemDescription {
     )
     public Builder boards(List<ProblemDescriptionBoard> boards) {
       this.boards.clear();
-      this.boards.addAll(boards);
+      if (boards != null) {
+        this.boards.addAll(boards);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/problem/types/ProblemFiles.java
+++ b/seed/java-spring/trace/resources/problem/types/ProblemFiles.java
@@ -129,7 +129,9 @@ public final class ProblemFiles {
     )
     public _FinalStage readOnlyFiles(List<FileInfo> readOnlyFiles) {
       this.readOnlyFiles.clear();
-      this.readOnlyFiles.addAll(readOnlyFiles);
+      if (readOnlyFiles != null) {
+        this.readOnlyFiles.addAll(readOnlyFiles);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/problem/types/ProblemInfo.java
+++ b/seed/java-spring/trace/resources/problem/types/ProblemInfo.java
@@ -304,7 +304,9 @@ public final class ProblemInfo {
     )
     public _FinalStage testcases(List<TestCaseWithExpectedResult> testcases) {
       this.testcases.clear();
-      this.testcases.addAll(testcases);
+      if (testcases != null) {
+        this.testcases.addAll(testcases);
+      }
       return this;
     }
 
@@ -329,7 +331,9 @@ public final class ProblemInfo {
     )
     public _FinalStage inputParams(List<VariableTypeAndName> inputParams) {
       this.inputParams.clear();
-      this.inputParams.addAll(inputParams);
+      if (inputParams != null) {
+        this.inputParams.addAll(inputParams);
+      }
       return this;
     }
 
@@ -354,7 +358,9 @@ public final class ProblemInfo {
     )
     public _FinalStage files(Map<Language, ProblemFiles> files) {
       this.files.clear();
-      this.files.putAll(files);
+      if (files != null) {
+        this.files.putAll(files);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/GetExecutionSessionStateResponse.java
+++ b/seed/java-spring/trace/resources/submission/types/GetExecutionSessionStateResponse.java
@@ -104,7 +104,9 @@ public final class GetExecutionSessionStateResponse {
     )
     public Builder states(Map<String, ExecutionSessionState> states) {
       this.states.clear();
-      this.states.putAll(states);
+      if (states != null) {
+        this.states.putAll(states);
+      }
       return this;
     }
 
@@ -140,7 +142,9 @@ public final class GetExecutionSessionStateResponse {
     )
     public Builder warmingSessionIds(List<String> warmingSessionIds) {
       this.warmingSessionIds.clear();
-      this.warmingSessionIds.addAll(warmingSessionIds);
+      if (warmingSessionIds != null) {
+        this.warmingSessionIds.addAll(warmingSessionIds);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/GradedResponse.java
+++ b/seed/java-spring/trace/resources/submission/types/GradedResponse.java
@@ -129,7 +129,9 @@ public final class GradedResponse {
     )
     public _FinalStage testCases(Map<String, TestCaseResultWithStdout> testCases) {
       this.testCases.clear();
-      this.testCases.putAll(testCases);
+      if (testCases != null) {
+        this.testCases.putAll(testCases);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/GradedResponseV2.java
+++ b/seed/java-spring/trace/resources/submission/types/GradedResponseV2.java
@@ -129,7 +129,9 @@ public final class GradedResponseV2 {
     )
     public _FinalStage testCases(Map<TestCaseId, TestCaseGrade> testCases) {
       this.testCases.clear();
-      this.testCases.putAll(testCases);
+      if (testCases != null) {
+        this.testCases.putAll(testCases);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/Scope.java
+++ b/seed/java-spring/trace/resources/submission/types/Scope.java
@@ -78,7 +78,9 @@ public final class Scope {
     )
     public Builder variables(Map<String, DebugVariableValue> variables) {
       this.variables.clear();
-      this.variables.putAll(variables);
+      if (variables != null) {
+        this.variables.putAll(variables);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/StackFrame.java
+++ b/seed/java-spring/trace/resources/submission/types/StackFrame.java
@@ -150,7 +150,9 @@ public final class StackFrame {
     )
     public _FinalStage scopes(List<Scope> scopes) {
       this.scopes.clear();
-      this.scopes.addAll(scopes);
+      if (scopes != null) {
+        this.scopes.addAll(scopes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/SubmitRequestV2.java
+++ b/seed/java-spring/trace/resources/submission/types/SubmitRequestV2.java
@@ -240,7 +240,9 @@ public final class SubmitRequestV2 {
     )
     public _FinalStage submissionFiles(List<SubmissionFileInfo> submissionFiles) {
       this.submissionFiles.clear();
-      this.submissionFiles.addAll(submissionFiles);
+      if (submissionFiles != null) {
+        this.submissionFiles.addAll(submissionFiles);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/TestSubmissionState.java
+++ b/seed/java-spring/trace/resources/submission/types/TestSubmissionState.java
@@ -170,7 +170,9 @@ public final class TestSubmissionState {
     )
     public _FinalStage customTestCases(List<TestCase> customTestCases) {
       this.customTestCases.clear();
-      this.customTestCases.addAll(customTestCases);
+      if (customTestCases != null) {
+        this.customTestCases.addAll(customTestCases);
+      }
       return this;
     }
 
@@ -195,7 +197,9 @@ public final class TestSubmissionState {
     )
     public _FinalStage defaultTestCases(List<TestCase> defaultTestCases) {
       this.defaultTestCases.clear();
-      this.defaultTestCases.addAll(defaultTestCases);
+      if (defaultTestCases != null) {
+        this.defaultTestCases.addAll(defaultTestCases);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/TestSubmissionStatusV2.java
+++ b/seed/java-spring/trace/resources/submission/types/TestSubmissionStatusV2.java
@@ -175,7 +175,9 @@ public final class TestSubmissionStatusV2 {
     )
     public _FinalStage updates(List<TestSubmissionUpdate> updates) {
       this.updates.clear();
-      this.updates.addAll(updates);
+      if (updates != null) {
+        this.updates.addAll(updates);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/TraceResponsesPage.java
+++ b/seed/java-spring/trace/resources/submission/types/TraceResponsesPage.java
@@ -112,7 +112,9 @@ public final class TraceResponsesPage {
     )
     public Builder traceResponses(List<TraceResponse> traceResponses) {
       this.traceResponses.clear();
-      this.traceResponses.addAll(traceResponses);
+      if (traceResponses != null) {
+        this.traceResponses.addAll(traceResponses);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/TraceResponsesPageV2.java
+++ b/seed/java-spring/trace/resources/submission/types/TraceResponsesPageV2.java
@@ -112,7 +112,9 @@ public final class TraceResponsesPageV2 {
     )
     public Builder traceResponses(List<TraceResponseV2> traceResponses) {
       this.traceResponses.clear();
-      this.traceResponses.addAll(traceResponses);
+      if (traceResponses != null) {
+        this.traceResponses.addAll(traceResponses);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/WorkspaceFiles.java
+++ b/seed/java-spring/trace/resources/submission/types/WorkspaceFiles.java
@@ -129,7 +129,9 @@ public final class WorkspaceFiles {
     )
     public _FinalStage readOnlyFiles(List<FileInfo> readOnlyFiles) {
       this.readOnlyFiles.clear();
-      this.readOnlyFiles.addAll(readOnlyFiles);
+      if (readOnlyFiles != null) {
+        this.readOnlyFiles.addAll(readOnlyFiles);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/WorkspaceStarterFilesResponse.java
+++ b/seed/java-spring/trace/resources/submission/types/WorkspaceStarterFilesResponse.java
@@ -78,7 +78,9 @@ public final class WorkspaceStarterFilesResponse {
     )
     public Builder files(Map<Language, WorkspaceFiles> files) {
       this.files.clear();
-      this.files.putAll(files);
+      if (files != null) {
+        this.files.putAll(files);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/WorkspaceStarterFilesResponseV2.java
+++ b/seed/java-spring/trace/resources/submission/types/WorkspaceStarterFilesResponseV2.java
@@ -79,7 +79,9 @@ public final class WorkspaceStarterFilesResponseV2 {
     )
     public Builder filesByLanguage(Map<Language, Files> filesByLanguage) {
       this.filesByLanguage.clear();
-      this.filesByLanguage.putAll(filesByLanguage);
+      if (filesByLanguage != null) {
+        this.filesByLanguage.putAll(filesByLanguage);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/WorkspaceSubmissionStatusV2.java
+++ b/seed/java-spring/trace/resources/submission/types/WorkspaceSubmissionStatusV2.java
@@ -77,7 +77,9 @@ public final class WorkspaceSubmissionStatusV2 {
     )
     public Builder updates(List<WorkspaceSubmissionUpdate> updates) {
       this.updates.clear();
-      this.updates.addAll(updates);
+      if (updates != null) {
+        this.updates.addAll(updates);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/submission/types/WorkspaceSubmitRequest.java
+++ b/seed/java-spring/trace/resources/submission/types/WorkspaceSubmitRequest.java
@@ -184,7 +184,9 @@ public final class WorkspaceSubmitRequest {
     )
     public _FinalStage submissionFiles(List<SubmissionFileInfo> submissionFiles) {
       this.submissionFiles.clear();
-      this.submissionFiles.addAll(submissionFiles);
+      if (submissionFiles != null) {
+        this.submissionFiles.addAll(submissionFiles);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/BasicCustomFiles.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/BasicCustomFiles.java
@@ -174,7 +174,9 @@ public final class BasicCustomFiles {
     )
     public _FinalStage additionalFiles(Map<Language, Files> additionalFiles) {
       this.additionalFiles.clear();
-      this.additionalFiles.putAll(additionalFiles);
+      if (additionalFiles != null) {
+        this.additionalFiles.putAll(additionalFiles);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/CreateProblemRequestV2.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/CreateProblemRequestV2.java
@@ -234,7 +234,9 @@ public final class CreateProblemRequestV2 {
     )
     public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
       this.supportedLanguages.clear();
-      this.supportedLanguages.addAll(supportedLanguages);
+      if (supportedLanguages != null) {
+        this.supportedLanguages.addAll(supportedLanguages);
+      }
       return this;
     }
 
@@ -259,7 +261,9 @@ public final class CreateProblemRequestV2 {
     )
     public _FinalStage testcases(List<TestCaseV2> testcases) {
       this.testcases.clear();
-      this.testcases.addAll(testcases);
+      if (testcases != null) {
+        this.testcases.addAll(testcases);
+      }
       return this;
     }
 
@@ -285,7 +289,9 @@ public final class CreateProblemRequestV2 {
     )
     public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
       this.customTestCaseTemplates.clear();
-      this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      if (customTestCaseTemplates != null) {
+        this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/DefaultProvidedFile.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/DefaultProvidedFile.java
@@ -129,7 +129,9 @@ public final class DefaultProvidedFile {
     )
     public _FinalStage relatedTypes(List<VariableType> relatedTypes) {
       this.relatedTypes.clear();
-      this.relatedTypes.addAll(relatedTypes);
+      if (relatedTypes != null) {
+        this.relatedTypes.addAll(relatedTypes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/Files.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/Files.java
@@ -77,7 +77,9 @@ public final class Files {
     )
     public Builder files(List<FileInfoV2> files) {
       this.files.clear();
-      this.files.addAll(files);
+      if (files != null) {
+        this.files.addAll(files);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/FunctionImplementationForMultipleLanguages.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/FunctionImplementationForMultipleLanguages.java
@@ -79,7 +79,9 @@ public final class FunctionImplementationForMultipleLanguages {
     )
     public Builder codeByLanguage(Map<Language, FunctionImplementation> codeByLanguage) {
       this.codeByLanguage.clear();
-      this.codeByLanguage.putAll(codeByLanguage);
+      if (codeByLanguage != null) {
+        this.codeByLanguage.putAll(codeByLanguage);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/GeneratedFiles.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/GeneratedFiles.java
@@ -101,7 +101,9 @@ public final class GeneratedFiles {
     )
     public Builder generatedTestCaseFiles(Map<Language, Files> generatedTestCaseFiles) {
       this.generatedTestCaseFiles.clear();
-      this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+      if (generatedTestCaseFiles != null) {
+        this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+      }
       return this;
     }
 
@@ -123,7 +125,9 @@ public final class GeneratedFiles {
     )
     public Builder generatedTemplateFiles(Map<Language, Files> generatedTemplateFiles) {
       this.generatedTemplateFiles.clear();
-      this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+      if (generatedTemplateFiles != null) {
+        this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+      }
       return this;
     }
 
@@ -145,7 +149,9 @@ public final class GeneratedFiles {
     )
     public Builder other(Map<Language, Files> other) {
       this.other.clear();
-      this.other.putAll(other);
+      if (other != null) {
+        this.other.putAll(other);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/GetBasicSolutionFileResponse.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/GetBasicSolutionFileResponse.java
@@ -78,7 +78,9 @@ public final class GetBasicSolutionFileResponse {
     )
     public Builder solutionFileByLanguage(Map<Language, FileInfoV2> solutionFileByLanguage) {
       this.solutionFileByLanguage.clear();
-      this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+      if (solutionFileByLanguage != null) {
+        this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/GetFunctionSignatureResponse.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/GetFunctionSignatureResponse.java
@@ -78,7 +78,9 @@ public final class GetFunctionSignatureResponse {
     )
     public Builder functionByLanguage(Map<Language, String> functionByLanguage) {
       this.functionByLanguage.clear();
-      this.functionByLanguage.putAll(functionByLanguage);
+      if (functionByLanguage != null) {
+        this.functionByLanguage.putAll(functionByLanguage);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/LightweightProblemInfoV2.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/LightweightProblemInfoV2.java
@@ -175,7 +175,9 @@ public final class LightweightProblemInfoV2 {
     )
     public _FinalStage variableTypes(Set<VariableType> variableTypes) {
       this.variableTypes.clear();
-      this.variableTypes.addAll(variableTypes);
+      if (variableTypes != null) {
+        this.variableTypes.addAll(variableTypes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/NonVoidFunctionSignature.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/NonVoidFunctionSignature.java
@@ -129,7 +129,9 @@ public final class NonVoidFunctionSignature {
     )
     public _FinalStage parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/ProblemInfoV2.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/ProblemInfoV2.java
@@ -303,7 +303,9 @@ public final class ProblemInfoV2 {
     )
     public _FinalStage testcases(List<TestCaseV2> testcases) {
       this.testcases.clear();
-      this.testcases.addAll(testcases);
+      if (testcases != null) {
+        this.testcases.addAll(testcases);
+      }
       return this;
     }
 
@@ -329,7 +331,9 @@ public final class ProblemInfoV2 {
     )
     public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
       this.customTestCaseTemplates.clear();
-      this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      if (customTestCaseTemplates != null) {
+        this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      }
       return this;
     }
 
@@ -354,7 +358,9 @@ public final class ProblemInfoV2 {
     )
     public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
       this.supportedLanguages.clear();
-      this.supportedLanguages.addAll(supportedLanguages);
+      if (supportedLanguages != null) {
+        this.supportedLanguages.addAll(supportedLanguages);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/TestCaseImplementationDescription.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/TestCaseImplementationDescription.java
@@ -77,7 +77,9 @@ public final class TestCaseImplementationDescription {
     )
     public Builder boards(List<TestCaseImplementationDescriptionBoard> boards) {
       this.boards.clear();
-      this.boards.addAll(boards);
+      if (boards != null) {
+        this.boards.addAll(boards);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/TestCaseV2.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/TestCaseV2.java
@@ -184,7 +184,9 @@ public final class TestCaseV2 {
     )
     public _FinalStage arguments(Map<ParameterId, VariableValue> arguments) {
       this.arguments.clear();
-      this.arguments.putAll(arguments);
+      if (arguments != null) {
+        this.arguments.putAll(arguments);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionDefinition.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionDefinition.java
@@ -129,7 +129,9 @@ public final class VoidFunctionDefinition {
     )
     public _FinalStage parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
@@ -129,7 +129,9 @@ public final class VoidFunctionDefinitionThatTakesActualResult {
     )
     public _FinalStage additionalParameters(List<Parameter> additionalParameters) {
       this.additionalParameters.clear();
-      this.additionalParameters.addAll(additionalParameters);
+      if (additionalParameters != null) {
+        this.additionalParameters.addAll(additionalParameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionSignature.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionSignature.java
@@ -77,7 +77,9 @@ public final class VoidFunctionSignature {
     )
     public Builder parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionSignatureThatTakesActualResult.java
+++ b/seed/java-spring/trace/resources/v2/problem/types/VoidFunctionSignatureThatTakesActualResult.java
@@ -130,7 +130,9 @@ public final class VoidFunctionSignatureThatTakesActualResult {
     )
     public _FinalStage parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/BasicCustomFiles.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/BasicCustomFiles.java
@@ -174,7 +174,9 @@ public final class BasicCustomFiles {
     )
     public _FinalStage additionalFiles(Map<Language, Files> additionalFiles) {
       this.additionalFiles.clear();
-      this.additionalFiles.putAll(additionalFiles);
+      if (additionalFiles != null) {
+        this.additionalFiles.putAll(additionalFiles);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/CreateProblemRequestV2.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/CreateProblemRequestV2.java
@@ -234,7 +234,9 @@ public final class CreateProblemRequestV2 {
     )
     public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
       this.supportedLanguages.clear();
-      this.supportedLanguages.addAll(supportedLanguages);
+      if (supportedLanguages != null) {
+        this.supportedLanguages.addAll(supportedLanguages);
+      }
       return this;
     }
 
@@ -259,7 +261,9 @@ public final class CreateProblemRequestV2 {
     )
     public _FinalStage testcases(List<TestCaseV2> testcases) {
       this.testcases.clear();
-      this.testcases.addAll(testcases);
+      if (testcases != null) {
+        this.testcases.addAll(testcases);
+      }
       return this;
     }
 
@@ -285,7 +289,9 @@ public final class CreateProblemRequestV2 {
     )
     public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
       this.customTestCaseTemplates.clear();
-      this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      if (customTestCaseTemplates != null) {
+        this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/DefaultProvidedFile.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/DefaultProvidedFile.java
@@ -129,7 +129,9 @@ public final class DefaultProvidedFile {
     )
     public _FinalStage relatedTypes(List<VariableType> relatedTypes) {
       this.relatedTypes.clear();
-      this.relatedTypes.addAll(relatedTypes);
+      if (relatedTypes != null) {
+        this.relatedTypes.addAll(relatedTypes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/Files.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/Files.java
@@ -77,7 +77,9 @@ public final class Files {
     )
     public Builder files(List<FileInfoV2> files) {
       this.files.clear();
-      this.files.addAll(files);
+      if (files != null) {
+        this.files.addAll(files);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/FunctionImplementationForMultipleLanguages.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/FunctionImplementationForMultipleLanguages.java
@@ -79,7 +79,9 @@ public final class FunctionImplementationForMultipleLanguages {
     )
     public Builder codeByLanguage(Map<Language, FunctionImplementation> codeByLanguage) {
       this.codeByLanguage.clear();
-      this.codeByLanguage.putAll(codeByLanguage);
+      if (codeByLanguage != null) {
+        this.codeByLanguage.putAll(codeByLanguage);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/GeneratedFiles.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/GeneratedFiles.java
@@ -101,7 +101,9 @@ public final class GeneratedFiles {
     )
     public Builder generatedTestCaseFiles(Map<Language, Files> generatedTestCaseFiles) {
       this.generatedTestCaseFiles.clear();
-      this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+      if (generatedTestCaseFiles != null) {
+        this.generatedTestCaseFiles.putAll(generatedTestCaseFiles);
+      }
       return this;
     }
 
@@ -123,7 +125,9 @@ public final class GeneratedFiles {
     )
     public Builder generatedTemplateFiles(Map<Language, Files> generatedTemplateFiles) {
       this.generatedTemplateFiles.clear();
-      this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+      if (generatedTemplateFiles != null) {
+        this.generatedTemplateFiles.putAll(generatedTemplateFiles);
+      }
       return this;
     }
 
@@ -145,7 +149,9 @@ public final class GeneratedFiles {
     )
     public Builder other(Map<Language, Files> other) {
       this.other.clear();
-      this.other.putAll(other);
+      if (other != null) {
+        this.other.putAll(other);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/GetBasicSolutionFileResponse.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/GetBasicSolutionFileResponse.java
@@ -78,7 +78,9 @@ public final class GetBasicSolutionFileResponse {
     )
     public Builder solutionFileByLanguage(Map<Language, FileInfoV2> solutionFileByLanguage) {
       this.solutionFileByLanguage.clear();
-      this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+      if (solutionFileByLanguage != null) {
+        this.solutionFileByLanguage.putAll(solutionFileByLanguage);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/GetFunctionSignatureResponse.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/GetFunctionSignatureResponse.java
@@ -78,7 +78,9 @@ public final class GetFunctionSignatureResponse {
     )
     public Builder functionByLanguage(Map<Language, String> functionByLanguage) {
       this.functionByLanguage.clear();
-      this.functionByLanguage.putAll(functionByLanguage);
+      if (functionByLanguage != null) {
+        this.functionByLanguage.putAll(functionByLanguage);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/LightweightProblemInfoV2.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/LightweightProblemInfoV2.java
@@ -175,7 +175,9 @@ public final class LightweightProblemInfoV2 {
     )
     public _FinalStage variableTypes(Set<VariableType> variableTypes) {
       this.variableTypes.clear();
-      this.variableTypes.addAll(variableTypes);
+      if (variableTypes != null) {
+        this.variableTypes.addAll(variableTypes);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/NonVoidFunctionSignature.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/NonVoidFunctionSignature.java
@@ -129,7 +129,9 @@ public final class NonVoidFunctionSignature {
     )
     public _FinalStage parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/ProblemInfoV2.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/ProblemInfoV2.java
@@ -303,7 +303,9 @@ public final class ProblemInfoV2 {
     )
     public _FinalStage testcases(List<TestCaseV2> testcases) {
       this.testcases.clear();
-      this.testcases.addAll(testcases);
+      if (testcases != null) {
+        this.testcases.addAll(testcases);
+      }
       return this;
     }
 
@@ -329,7 +331,9 @@ public final class ProblemInfoV2 {
     )
     public _FinalStage customTestCaseTemplates(List<TestCaseTemplate> customTestCaseTemplates) {
       this.customTestCaseTemplates.clear();
-      this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      if (customTestCaseTemplates != null) {
+        this.customTestCaseTemplates.addAll(customTestCaseTemplates);
+      }
       return this;
     }
 
@@ -354,7 +358,9 @@ public final class ProblemInfoV2 {
     )
     public _FinalStage supportedLanguages(Set<Language> supportedLanguages) {
       this.supportedLanguages.clear();
-      this.supportedLanguages.addAll(supportedLanguages);
+      if (supportedLanguages != null) {
+        this.supportedLanguages.addAll(supportedLanguages);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/TestCaseImplementationDescription.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/TestCaseImplementationDescription.java
@@ -77,7 +77,9 @@ public final class TestCaseImplementationDescription {
     )
     public Builder boards(List<TestCaseImplementationDescriptionBoard> boards) {
       this.boards.clear();
-      this.boards.addAll(boards);
+      if (boards != null) {
+        this.boards.addAll(boards);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/TestCaseV2.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/TestCaseV2.java
@@ -184,7 +184,9 @@ public final class TestCaseV2 {
     )
     public _FinalStage arguments(Map<ParameterId, VariableValue> arguments) {
       this.arguments.clear();
-      this.arguments.putAll(arguments);
+      if (arguments != null) {
+        this.arguments.putAll(arguments);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionDefinition.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionDefinition.java
@@ -129,7 +129,9 @@ public final class VoidFunctionDefinition {
     )
     public _FinalStage parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionDefinitionThatTakesActualResult.java
@@ -129,7 +129,9 @@ public final class VoidFunctionDefinitionThatTakesActualResult {
     )
     public _FinalStage additionalParameters(List<Parameter> additionalParameters) {
       this.additionalParameters.clear();
-      this.additionalParameters.addAll(additionalParameters);
+      if (additionalParameters != null) {
+        this.additionalParameters.addAll(additionalParameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionSignature.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionSignature.java
@@ -77,7 +77,9 @@ public final class VoidFunctionSignature {
     )
     public Builder parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionSignatureThatTakesActualResult.java
+++ b/seed/java-spring/trace/resources/v2/v3/problem/types/VoidFunctionSignatureThatTakesActualResult.java
@@ -130,7 +130,9 @@ public final class VoidFunctionSignatureThatTakesActualResult {
     )
     public _FinalStage parameters(List<Parameter> parameters) {
       this.parameters.clear();
-      this.parameters.addAll(parameters);
+      if (parameters != null) {
+        this.parameters.addAll(parameters);
+      }
       return this;
     }
 

--- a/seed/java-spring/undiscriminated-unions/resources/union/types/NamedMetadata.java
+++ b/seed/java-spring/undiscriminated-unions/resources/union/types/NamedMetadata.java
@@ -128,7 +128,9 @@ public final class NamedMetadata {
     )
     public _FinalStage value(Map<String, Object> value) {
       this.value.clear();
-      this.value.putAll(value);
+      if (value != null) {
+        this.value.putAll(value);
+      }
       return this;
     }
 


### PR DESCRIPTION
## Description
Linear ticket: Resolves [FER-6621: \[Mavenagi, java\] Null pointer exception in EventsRequest builder](https://linear.app/buildwithfern/issue/FER-6621/mavenagi-java-null-pointer-exception-in-eventsrequest-builder)

Prevents `NullPointerException` in generated Java builders when collections (List, Set, Map) are null. Adds null checks before calling `addAll()` and `putAll()` in default setter methods. 



## Changes Made
- See files

## Testing
<!-- Describe how you tested these changes -->
- [X] Unit tests added/updated
