### PR TITLE
fix(python): Namespace imports reference the submodule instead of .

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.29.2
+  changelogEntry:
+    - summary: |
+        Exports in init files always reference the submodule instead of the current module.
+        This should fix infinite recursion in libraries that inspect getattr, like freezegun.
+      type: fix
+  createdAt: "2025-09-22"
+  irVersion: 59
+
 - version: 4.29.1
   changelogEntry:
     - summary: Fixes issue where colliding classes were not lazily imported correctly.

--- a/generators/python/src/fern_python/codegen/module_manager.py
+++ b/generators/python/src/fern_python/codegen/module_manager.py
@@ -94,7 +94,6 @@ class ModuleManager:
         module_being_exported_from: AST.ModulePath = tuple(
             directory.module_name for directory in filepath.directories
         ) + (filepath.file.module_name,)
-
         is_exporting_from_file = True
 
         while len(module_being_exported_from) > 0:
@@ -121,7 +120,7 @@ class ModuleManager:
                 module_info.exports[relative_module_being_exported_from].update(exports)
             if export_strategy.export_as_namespace:
                 namespace_export = set(relative_module_being_exported_from)
-                module_info.exports[()].update(namespace_export)
+                module_info.exports[relative_module_being_exported_from].update(namespace_export)
                 new_exports.update(namespace_export)
             exports = new_exports
 

--- a/seed/fastapi/accept-header/resources/__init__.py
+++ b/seed/fastapi/accept-header/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import NotFoundError
+from .service import NotFoundError, service
 
 __all__ = ["NotFoundError", "service"]

--- a/seed/fastapi/audiences/resources/__init__.py
+++ b/seed/fastapi/audiences/resources/__init__.py
@@ -2,9 +2,12 @@
 
 # isort: skip_file
 
-from . import commons, folder_a, folder_b, folder_c, folder_d, foo
-from .commons import Imported
-from .foo import FilteredType, FindRequest, ImportingType, OptionalString
+from .commons import Imported, commons
+from .folder_a import folder_a
+from .folder_b import folder_b
+from .folder_c import folder_c
+from .folder_d import folder_d
+from .foo import FilteredType, FindRequest, ImportingType, OptionalString, foo
 
 __all__ = [
     "FilteredType",

--- a/seed/fastapi/audiences/resources/folder_a/resources/__init__.py
+++ b/seed/fastapi/audiences/resources/folder_a/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/fastapi/audiences/resources/folder_b/resources/__init__.py
+++ b/seed/fastapi/audiences/resources/folder_b/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import Foo
+from .common import Foo, common
 
 __all__ = ["Foo", "common"]

--- a/seed/fastapi/audiences/resources/folder_c/resources/__init__.py
+++ b/seed/fastapi/audiences/resources/folder_c/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import FolderCFoo
+from .common import FolderCFoo, common
 
 __all__ = ["FolderCFoo", "common"]

--- a/seed/fastapi/audiences/resources/folder_d/resources/__init__.py
+++ b/seed/fastapi/audiences/resources/folder_d/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/fastapi/basic-auth-environment-variables/resources/__init__.py
+++ b/seed/fastapi/basic-auth-environment-variables/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody
+from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody, errors
 
 __all__ = ["BadRequest", "UnauthorizedRequest", "UnauthorizedRequestErrorBody", "errors"]

--- a/seed/fastapi/basic-auth/resources/__init__.py
+++ b/seed/fastapi/basic-auth/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody
+from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody, errors
 
 __all__ = ["BadRequest", "UnauthorizedRequest", "UnauthorizedRequestErrorBody", "errors"]

--- a/seed/fastapi/circular-references-advanced/no-custom-config/resources/__init__.py
+++ b/seed/fastapi/circular-references-advanced/no-custom-config/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
+from .a import A, a
 from .ast import (
     Acai,
     Animal,
@@ -22,6 +21,7 @@ from .ast import (
     ObjectFieldValue,
     ObjectValue,
     PrimitiveValue,
+    ast,
 )
 
 __all__ = [

--- a/seed/fastapi/circular-references-advanced/no-inheritance-for-extended-models/resources/__init__.py
+++ b/seed/fastapi/circular-references-advanced/no-inheritance-for-extended-models/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
+from .a import A, a
 from .ast import (
     Acai,
     Animal,
@@ -22,6 +21,7 @@ from .ast import (
     ObjectFieldValue,
     ObjectValue,
     PrimitiveValue,
+    ast,
 )
 
 __all__ = [

--- a/seed/fastapi/circular-references/no-custom-config/resources/__init__.py
+++ b/seed/fastapi/circular-references/no-custom-config/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
-from .ast import ContainerValue, FieldValue, JsonLike, ObjectValue, PrimitiveValue, T, TorU, U
+from .a import A, a
+from .ast import ContainerValue, FieldValue, JsonLike, ObjectValue, PrimitiveValue, T, TorU, U, ast
 
 __all__ = [
     "A",

--- a/seed/fastapi/circular-references/no-inheritance-for-extended-models/resources/__init__.py
+++ b/seed/fastapi/circular-references/no-inheritance-for-extended-models/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
-from .ast import ContainerValue, FieldValue, JsonLike, ObjectValue, PrimitiveValue, T, TorU, U
+from .a import A, a
+from .ast import ContainerValue, FieldValue, JsonLike, ObjectValue, PrimitiveValue, T, TorU, U, ast
 
 __all__ = [
     "A",

--- a/seed/fastapi/content-type/resources/__init__.py
+++ b/seed/fastapi/content-type/resources/__init__.py
@@ -2,13 +2,13 @@
 
 # isort: skip_file
 
-from . import service
 from .service import (
     NamedMixedPatchRequest,
     OptionalMergePatchRequest,
     PatchComplexRequest,
     PatchProxyRequest,
     RegularPatchRequest,
+    service,
 )
 
 __all__ = [

--- a/seed/fastapi/cross-package-type-names/resources/__init__.py
+++ b/seed/fastapi/cross-package-type-names/resources/__init__.py
@@ -2,9 +2,12 @@
 
 # isort: skip_file
 
-from . import commons, folder_a, folder_b, folder_c, folder_d, foo
-from .commons import Imported
-from .foo import FindRequest, ImportingType, OptionalString
+from .commons import Imported, commons
+from .folder_a import folder_a
+from .folder_b import folder_b
+from .folder_c import folder_c
+from .folder_d import folder_d
+from .foo import FindRequest, ImportingType, OptionalString, foo
 
 __all__ = [
     "FindRequest",

--- a/seed/fastapi/cross-package-type-names/resources/folder_a/resources/__init__.py
+++ b/seed/fastapi/cross-package-type-names/resources/folder_a/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/fastapi/cross-package-type-names/resources/folder_b/resources/__init__.py
+++ b/seed/fastapi/cross-package-type-names/resources/folder_b/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import Foo
+from .common import Foo, common
 
 __all__ = ["Foo", "common"]

--- a/seed/fastapi/cross-package-type-names/resources/folder_c/resources/__init__.py
+++ b/seed/fastapi/cross-package-type-names/resources/folder_c/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import Foo
+from .common import Foo, common
 
 __all__ = ["Foo", "common"]

--- a/seed/fastapi/cross-package-type-names/resources/folder_d/resources/__init__.py
+++ b/seed/fastapi/cross-package-type-names/resources/folder_d/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/fastapi/custom-auth/resources/__init__.py
+++ b/seed/fastapi/custom-auth/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody
+from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody, errors
 
 __all__ = ["BadRequest", "UnauthorizedRequest", "UnauthorizedRequestErrorBody", "errors"]

--- a/seed/fastapi/empty-clients/resources/__init__.py
+++ b/seed/fastapi/empty-clients/resources/__init__.py
@@ -2,6 +2,6 @@
 
 # isort: skip_file
 
-from . import level_1
+from .level_1 import level_1
 
 __all__ = ["level_1"]

--- a/seed/fastapi/empty-clients/resources/level_1/resources/__init__.py
+++ b/seed/fastapi/empty-clients/resources/level_1/resources/__init__.py
@@ -2,7 +2,7 @@
 
 # isort: skip_file
 
-from . import level_2, types
-from .types import Address, Person
+from .level_2 import level_2
+from .types import Address, Person, types
 
 __all__ = ["Address", "Person", "level_2", "types"]

--- a/seed/fastapi/empty-clients/resources/level_1/resources/level_2/resources/__init__.py
+++ b/seed/fastapi/empty-clients/resources/level_1/resources/level_2/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import types
-from .types import Address, Person
+from .types import Address, Person, types
 
 __all__ = ["Address", "Person", "types"]

--- a/seed/fastapi/error-property/resources/__init__.py
+++ b/seed/fastapi/error-property/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import PropertyBasedErrorTest, PropertyBasedErrorTestBody
+from .errors import PropertyBasedErrorTest, PropertyBasedErrorTestBody, errors
 
 __all__ = ["PropertyBasedErrorTest", "PropertyBasedErrorTestBody", "errors"]

--- a/seed/fastapi/errors/resources/__init__.py
+++ b/seed/fastapi/errors/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import commons, simple
-from .commons import BadRequestError, ErrorBody, InternalServerError, NotFoundError
-from .simple import FooRequest, FooResponse, FooTooLittle, FooTooMuch
+from .commons import BadRequestError, ErrorBody, InternalServerError, NotFoundError, commons
+from .simple import FooRequest, FooResponse, FooTooLittle, FooTooMuch, simple
 
 __all__ = [
     "BadRequestError",

--- a/seed/fastapi/examples/resources/__init__.py
+++ b/seed/fastapi/examples/resources/__init__.py
@@ -2,7 +2,8 @@
 
 # isort: skip_file
 
-from . import commons, file, types
+from .commons import commons
+from .file import file
 from .types import (
     Actor,
     Actress,
@@ -30,6 +31,7 @@ from .types import (
     StuntDouble,
     Test,
     Tree,
+    types,
 )
 
 __all__ = [

--- a/seed/fastapi/examples/resources/commons/resources/__init__.py
+++ b/seed/fastapi/examples/resources/commons/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import types
-from .types import Data, EventInfo, Metadata, Tag
+from .types import Data, EventInfo, Metadata, Tag, types
 
 __all__ = ["Data", "EventInfo", "Metadata", "Tag", "types"]

--- a/seed/fastapi/examples/resources/file/resources/__init__.py
+++ b/seed/fastapi/examples/resources/file/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Filename
+from .service import Filename, service
 
 __all__ = ["Filename", "service"]

--- a/seed/fastapi/exhaustive/frozen_utils/resources/__init__.py
+++ b/seed/fastapi/exhaustive/frozen_utils/resources/__init__.py
@@ -2,9 +2,10 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, types
-from .general_errors import BadObjectRequestInfo, BadRequestBody
-from .inlined_requests import PostWithObjectBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import PostWithObjectBody, inlined_requests
+from .types import types
 
 __all__ = [
     "BadObjectRequestInfo",

--- a/seed/fastapi/exhaustive/frozen_utils/resources/endpoints/resources/__init__.py
+++ b/seed/fastapi/exhaustive/frozen_utils/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/fastapi/exhaustive/frozen_utils/resources/types/resources/__init__.py
+++ b/seed/fastapi/exhaustive/frozen_utils/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -17,8 +16,9 @@ from .object import (
     ObjectWithRequiredField,
     ObjectWithRequiredFieldError,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Cat, Dog, ErrorWithUnionBody
+from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 
 __all__ = [
     "Animal",

--- a/seed/fastapi/exhaustive/ignore-extra-fields/resources/__init__.py
+++ b/seed/fastapi/exhaustive/ignore-extra-fields/resources/__init__.py
@@ -2,9 +2,10 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, types
-from .general_errors import BadObjectRequestInfo, BadRequestBody
-from .inlined_requests import PostWithObjectBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import PostWithObjectBody, inlined_requests
+from .types import types
 
 __all__ = [
     "BadObjectRequestInfo",

--- a/seed/fastapi/exhaustive/ignore-extra-fields/resources/endpoints/resources/__init__.py
+++ b/seed/fastapi/exhaustive/ignore-extra-fields/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/fastapi/exhaustive/ignore-extra-fields/resources/types/resources/__init__.py
+++ b/seed/fastapi/exhaustive/ignore-extra-fields/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -17,8 +16,9 @@ from .object import (
     ObjectWithRequiredField,
     ObjectWithRequiredFieldError,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Cat, Dog, ErrorWithUnionBody
+from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 
 __all__ = [
     "Animal",

--- a/seed/fastapi/exhaustive/include-validators/resources/__init__.py
+++ b/seed/fastapi/exhaustive/include-validators/resources/__init__.py
@@ -2,9 +2,10 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, types
-from .general_errors import BadObjectRequestInfo, BadRequestBody
-from .inlined_requests import PostWithObjectBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import PostWithObjectBody, inlined_requests
+from .types import types
 
 __all__ = [
     "BadObjectRequestInfo",

--- a/seed/fastapi/exhaustive/include-validators/resources/endpoints/resources/__init__.py
+++ b/seed/fastapi/exhaustive/include-validators/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/fastapi/exhaustive/include-validators/resources/types/resources/__init__.py
+++ b/seed/fastapi/exhaustive/include-validators/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -17,8 +16,9 @@ from .object import (
     ObjectWithRequiredField,
     ObjectWithRequiredFieldError,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Cat, Dog, ErrorWithUnionBody
+from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 
 __all__ = [
     "Animal",

--- a/seed/fastapi/exhaustive/no-custom-config/resources/__init__.py
+++ b/seed/fastapi/exhaustive/no-custom-config/resources/__init__.py
@@ -2,9 +2,10 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, types
-from .general_errors import BadObjectRequestInfo, BadRequestBody
-from .inlined_requests import PostWithObjectBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import PostWithObjectBody, inlined_requests
+from .types import types
 
 __all__ = [
     "BadObjectRequestInfo",

--- a/seed/fastapi/exhaustive/no-custom-config/resources/endpoints/resources/__init__.py
+++ b/seed/fastapi/exhaustive/no-custom-config/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/fastapi/exhaustive/no-custom-config/resources/types/resources/__init__.py
+++ b/seed/fastapi/exhaustive/no-custom-config/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -17,8 +16,9 @@ from .object import (
     ObjectWithRequiredField,
     ObjectWithRequiredFieldError,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Cat, Dog, ErrorWithUnionBody
+from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 
 __all__ = [
     "Animal",

--- a/seed/fastapi/exhaustive/pydantic-v1/resources/__init__.py
+++ b/seed/fastapi/exhaustive/pydantic-v1/resources/__init__.py
@@ -2,9 +2,10 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, types
-from .general_errors import BadObjectRequestInfo, BadRequestBody
-from .inlined_requests import PostWithObjectBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import PostWithObjectBody, inlined_requests
+from .types import types
 
 __all__ = [
     "BadObjectRequestInfo",

--- a/seed/fastapi/exhaustive/pydantic-v1/resources/endpoints/resources/__init__.py
+++ b/seed/fastapi/exhaustive/pydantic-v1/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/fastapi/exhaustive/pydantic-v1/resources/types/resources/__init__.py
+++ b/seed/fastapi/exhaustive/pydantic-v1/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -17,8 +16,9 @@ from .object import (
     ObjectWithRequiredField,
     ObjectWithRequiredFieldError,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Cat, Dog, ErrorWithUnionBody
+from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 
 __all__ = [
     "Animal",

--- a/seed/fastapi/exhaustive/pydantic-v2/resources/__init__.py
+++ b/seed/fastapi/exhaustive/pydantic-v2/resources/__init__.py
@@ -2,9 +2,10 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, types
-from .general_errors import BadObjectRequestInfo, BadRequestBody
-from .inlined_requests import PostWithObjectBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import PostWithObjectBody, inlined_requests
+from .types import types
 
 __all__ = [
     "BadObjectRequestInfo",

--- a/seed/fastapi/exhaustive/pydantic-v2/resources/endpoints/resources/__init__.py
+++ b/seed/fastapi/exhaustive/pydantic-v2/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/fastapi/exhaustive/pydantic-v2/resources/types/resources/__init__.py
+++ b/seed/fastapi/exhaustive/pydantic-v2/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -17,8 +16,9 @@ from .object import (
     ObjectWithRequiredField,
     ObjectWithRequiredFieldError,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Cat, Dog, ErrorWithUnionBody
+from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 
 __all__ = [
     "Animal",

--- a/seed/fastapi/exhaustive/skip-formatting/resources/__init__.py
+++ b/seed/fastapi/exhaustive/skip-formatting/resources/__init__.py
@@ -2,7 +2,8 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, types
-from .general_errors import BadObjectRequestInfo, BadRequestBody
-from .inlined_requests import PostWithObjectBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import PostWithObjectBody, inlined_requests
+from .types import types
 __all__ = ["BadObjectRequestInfo", "BadRequestBody", "PostWithObjectBody", "endpoints", "general_errors", "inlined_requests", "types"]

--- a/seed/fastapi/exhaustive/skip-formatting/resources/endpoints/resources/__init__.py
+++ b/seed/fastapi/exhaustive/skip-formatting/resources/endpoints/resources/__init__.py
@@ -2,6 +2,5 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/fastapi/exhaustive/skip-formatting/resources/types/resources/__init__.py
+++ b/seed/fastapi/exhaustive/skip-formatting/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
-from .object import DoubleOptional, NestedObjectWithOptionalField, NestedObjectWithOptionalFieldError, NestedObjectWithRequiredField, NestedObjectWithRequiredFieldError, ObjectWithMapOfMap, ObjectWithOptionalField, ObjectWithOptionalFieldError, ObjectWithRequiredField, ObjectWithRequiredFieldError, OptionalAlias
-from .union import Animal, Cat, Dog, ErrorWithUnionBody
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
+from .object import DoubleOptional, NestedObjectWithOptionalField, NestedObjectWithOptionalFieldError, NestedObjectWithRequiredField, NestedObjectWithRequiredFieldError, ObjectWithMapOfMap, ObjectWithOptionalField, ObjectWithOptionalFieldError, ObjectWithRequiredField, ObjectWithRequiredFieldError, OptionalAlias, object
+from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 __all__ = ["Animal", "Cat", "Dog", "DoubleOptional", "ErrorWithEnumBody", "ErrorWithUnionBody", "NestedObjectWithOptionalField", "NestedObjectWithOptionalFieldError", "NestedObjectWithRequiredField", "NestedObjectWithRequiredFieldError", "ObjectWithDocs", "ObjectWithMapOfMap", "ObjectWithOptionalField", "ObjectWithOptionalFieldError", "ObjectWithRequiredField", "ObjectWithRequiredFieldError", "OptionalAlias", "WeatherReport", "docs", "enum", "object", "union"]

--- a/seed/fastapi/extra-properties/resources/__init__.py
+++ b/seed/fastapi/extra-properties/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import CreateUserRequest, User
+from .user import CreateUserRequest, User, user
 
 __all__ = ["CreateUserRequest", "User", "user"]

--- a/seed/fastapi/file-upload/resources/__init__.py
+++ b/seed/fastapi/file-upload/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
 from .service import (
     Id,
     MyAliasObject,
@@ -11,6 +10,7 @@ from .service import (
     MyObject,
     MyObjectWithOptional,
     ObjectType,
+    service,
 )
 
 __all__ = [

--- a/seed/fastapi/folders/resources/__init__.py
+++ b/seed/fastapi/folders/resources/__init__.py
@@ -2,6 +2,7 @@
 
 # isort: skip_file
 
-from . import a, folder
+from .a import a
+from .folder import folder
 
 __all__ = ["a", "folder"]

--- a/seed/fastapi/folders/resources/a/resources/__init__.py
+++ b/seed/fastapi/folders/resources/a/resources/__init__.py
@@ -2,6 +2,6 @@
 
 # isort: skip_file
 
-from . import d
+from .d import d
 
 __all__ = ["d"]

--- a/seed/fastapi/folders/resources/a/resources/d/resources/__init__.py
+++ b/seed/fastapi/folders/resources/a/resources/d/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import types
-from .types import Foo
+from .types import Foo, types
 
 __all__ = ["Foo", "types"]

--- a/seed/fastapi/folders/resources/folder/resources/__init__.py
+++ b/seed/fastapi/folders/resources/folder/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import NotFoundError
+from .service import NotFoundError, service
 
 __all__ = ["NotFoundError", "service"]

--- a/seed/fastapi/http-head/resources/__init__.py
+++ b/seed/fastapi/http-head/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User
+from .user import User, user
 
 __all__ = ["User", "user"]

--- a/seed/fastapi/idempotency-headers/resources/__init__.py
+++ b/seed/fastapi/idempotency-headers/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import payment
-from .payment import CreatePaymentRequest, Currency
+from .payment import CreatePaymentRequest, Currency, payment
 
 __all__ = ["CreatePaymentRequest", "Currency", "payment"]

--- a/seed/fastapi/imdb/async-handlers/resources/__init__.py
+++ b/seed/fastapi/imdb/async-handlers/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import imdb
-from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId
+from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId, imdb
 
 __all__ = ["CreateMovieRequest", "Movie", "MovieDoesNotExistError", "MovieId", "imdb"]

--- a/seed/fastapi/imdb/includes-extra-fields/resources/__init__.py
+++ b/seed/fastapi/imdb/includes-extra-fields/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import imdb
-from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId
+from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId, imdb
 
 __all__ = ["CreateMovieRequest", "Movie", "MovieDoesNotExistError", "MovieId", "imdb"]

--- a/seed/fastapi/imdb/no-custom-config/resources/__init__.py
+++ b/seed/fastapi/imdb/no-custom-config/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import imdb
-from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId
+from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId, imdb
 
 __all__ = ["CreateMovieRequest", "Movie", "MovieDoesNotExistError", "MovieId", "imdb"]

--- a/seed/fastapi/imdb/v1_on_v2/resources/__init__.py
+++ b/seed/fastapi/imdb/v1_on_v2/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import imdb
-from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId
+from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId, imdb
 
 __all__ = ["CreateMovieRequest", "Movie", "MovieDoesNotExistError", "MovieId", "imdb"]

--- a/seed/fastapi/inferred-auth-explicit/resources/__init__.py
+++ b/seed/fastapi/inferred-auth-explicit/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "RefreshTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/inferred-auth-implicit-no-expiry/resources/__init__.py
+++ b/seed/fastapi/inferred-auth-implicit-no-expiry/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "RefreshTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/inferred-auth-implicit/resources/__init__.py
+++ b/seed/fastapi/inferred-auth-implicit/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "RefreshTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/literals-unions/resources/__init__.py
+++ b/seed/fastapi/literals-unions/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import literals
-from .literals import LiteralString, UnionOverLiteral
+from .literals import LiteralString, UnionOverLiteral, literals
 
 __all__ = ["LiteralString", "UnionOverLiteral", "literals"]

--- a/seed/fastapi/mixed-case/resources/__init__.py
+++ b/seed/fastapi/mixed-case/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import NestedUser, Organization, Resource, ResourceStatus, User
+from .service import NestedUser, Organization, Resource, ResourceStatus, User, service
 
 __all__ = ["NestedUser", "Organization", "Resource", "ResourceStatus", "User", "service"]

--- a/seed/fastapi/mixed-file-directory/resources/__init__.py
+++ b/seed/fastapi/mixed-file-directory/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import organization, user
-from .organization import CreateOrganizationRequest, Organization
-from .user import User
+from .organization import CreateOrganizationRequest, Organization, organization
+from .user import User, user
 
 __all__ = ["CreateOrganizationRequest", "Organization", "User", "organization", "user"]

--- a/seed/fastapi/mixed-file-directory/resources/user/resources/__init__.py
+++ b/seed/fastapi/mixed-file-directory/resources/user/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import events
-from .events import Event
+from .events import Event, events
 
 __all__ = ["Event", "events"]

--- a/seed/fastapi/mixed-file-directory/resources/user/resources/events/resources/__init__.py
+++ b/seed/fastapi/mixed-file-directory/resources/user/resources/events/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import metadata
-from .metadata import Metadata
+from .metadata import Metadata, metadata
 
 __all__ = ["Metadata", "metadata"]

--- a/seed/fastapi/multi-line-docs/resources/__init__.py
+++ b/seed/fastapi/multi-line-docs/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import CreateUserRequest, User
+from .user import CreateUserRequest, User, user
 
 __all__ = ["CreateUserRequest", "User", "user"]

--- a/seed/fastapi/multi-url-environment-no-default/resources/__init__.py
+++ b/seed/fastapi/multi-url-environment-no-default/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import ec_2, s_3
-from .ec_2 import BootInstanceRequest
-from .s_3 import GetPresignedUrlRequest
+from .ec_2 import BootInstanceRequest, ec_2
+from .s_3 import GetPresignedUrlRequest, s_3
 
 __all__ = ["BootInstanceRequest", "GetPresignedUrlRequest", "ec_2", "s_3"]

--- a/seed/fastapi/multi-url-environment/resources/__init__.py
+++ b/seed/fastapi/multi-url-environment/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import ec_2, s_3
-from .ec_2 import BootInstanceRequest
-from .s_3 import GetPresignedUrlRequest
+from .ec_2 import BootInstanceRequest, ec_2
+from .s_3 import GetPresignedUrlRequest, s_3
 
 __all__ = ["BootInstanceRequest", "GetPresignedUrlRequest", "ec_2", "s_3"]

--- a/seed/fastapi/nullable-optional/resources/__init__.py
+++ b/seed/fastapi/nullable-optional/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import nullable_optional
 from .nullable_optional import (
     Address,
     ComplexProfile,
@@ -26,6 +25,7 @@ from .nullable_optional import (
     UserResponse,
     UserRole,
     UserStatus,
+    nullable_optional,
 )
 
 __all__ = [

--- a/seed/fastapi/nullable/resources/__init__.py
+++ b/seed/fastapi/nullable/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import nullable
-from .nullable import CreateUserRequest, DeleteUserRequest, Email, Metadata, Status, User, UserId, WeirdNumber
+from .nullable import CreateUserRequest, DeleteUserRequest, Email, Metadata, Status, User, UserId, WeirdNumber, nullable
 
 __all__ = [
     "CreateUserRequest",

--- a/seed/fastapi/oauth-client-credentials-custom/resources/__init__.py
+++ b/seed/fastapi/oauth-client-credentials-custom/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "RefreshTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/oauth-client-credentials-default/resources/__init__.py
+++ b/seed/fastapi/oauth-client-credentials-default/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, TokenResponse
+from .auth import GetTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/oauth-client-credentials-environment-variables/resources/__init__.py
+++ b/seed/fastapi/oauth-client-credentials-environment-variables/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "RefreshTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/oauth-client-credentials-nested-root/resources/__init__.py
+++ b/seed/fastapi/oauth-client-credentials-nested-root/resources/__init__.py
@@ -2,6 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
+from .auth import auth
 
 __all__ = ["auth"]

--- a/seed/fastapi/oauth-client-credentials-with-variables/resources/__init__.py
+++ b/seed/fastapi/oauth-client-credentials-with-variables/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "RefreshTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/oauth-client-credentials/resources/__init__.py
+++ b/seed/fastapi/oauth-client-credentials/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
 
 __all__ = ["GetTokenRequest", "RefreshTokenRequest", "TokenResponse", "auth"]

--- a/seed/fastapi/objects-with-imports/resources/__init__.py
+++ b/seed/fastapi/objects-with-imports/resources/__init__.py
@@ -2,7 +2,7 @@
 
 # isort: skip_file
 
-from . import commons, file
-from .file import File, FileInfo
+from .commons import commons
+from .file import File, FileInfo, file
 
 __all__ = ["File", "FileInfo", "commons", "file"]

--- a/seed/fastapi/objects-with-imports/resources/commons/resources/__init__.py
+++ b/seed/fastapi/objects-with-imports/resources/commons/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import metadata
-from .metadata import Metadata
+from .metadata import Metadata, metadata
 
 __all__ = ["Metadata", "metadata"]

--- a/seed/fastapi/objects-with-imports/resources/file/resources/__init__.py
+++ b/seed/fastapi/objects-with-imports/resources/file/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import directory
-from .directory import Directory
+from .directory import Directory, directory
 
 __all__ = ["Directory", "directory"]

--- a/seed/fastapi/pagination/no-custom-config/resources/__init__.py
+++ b/seed/fastapi/pagination/no-custom-config/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import complex, inline_users, users
 from .complex import (
     Conversation,
     CursorPages,
@@ -15,7 +14,9 @@ from .complex import (
     SingleFilterSearchRequest,
     SingleFilterSearchRequestOperator,
     StartingAfterPaging,
+    complex,
 )
+from .inline_users import inline_users
 from .users import (
     ListUsersBodyCursorPaginationRequest,
     ListUsersBodyOffsetPaginationRequest,
@@ -34,6 +35,7 @@ from .users import (
     UsernameContainer,
     WithCursor,
     WithPage,
+    users,
 )
 
 __all__ = [

--- a/seed/fastapi/pagination/no-custom-config/resources/inline_users/resources/__init__.py
+++ b/seed/fastapi/pagination/no-custom-config/resources/inline_users/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import inline_users
 from .inline_users import (
     ListUsersBodyCursorPaginationRequest,
     ListUsersBodyOffsetPaginationRequest,
@@ -22,6 +21,7 @@ from .inline_users import (
     Users,
     WithCursor,
     WithPage,
+    inline_users,
 )
 
 __all__ = [

--- a/seed/fastapi/pagination/no-inheritance-for-extended-models/resources/__init__.py
+++ b/seed/fastapi/pagination/no-inheritance-for-extended-models/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import complex, inline_users, users
 from .complex import (
     Conversation,
     CursorPages,
@@ -15,7 +14,9 @@ from .complex import (
     SingleFilterSearchRequest,
     SingleFilterSearchRequestOperator,
     StartingAfterPaging,
+    complex,
 )
+from .inline_users import inline_users
 from .users import (
     ListUsersBodyCursorPaginationRequest,
     ListUsersBodyOffsetPaginationRequest,
@@ -34,6 +35,7 @@ from .users import (
     UsernameContainer,
     WithCursor,
     WithPage,
+    users,
 )
 
 __all__ = [

--- a/seed/fastapi/pagination/no-inheritance-for-extended-models/resources/inline_users/resources/__init__.py
+++ b/seed/fastapi/pagination/no-inheritance-for-extended-models/resources/inline_users/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import inline_users
 from .inline_users import (
     ListUsersBodyCursorPaginationRequest,
     ListUsersBodyOffsetPaginationRequest,
@@ -22,6 +21,7 @@ from .inline_users import (
     Users,
     WithCursor,
     WithPage,
+    inline_users,
 )
 
 __all__ = [

--- a/seed/fastapi/path-parameters/resources/__init__.py
+++ b/seed/fastapi/path-parameters/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import organizations, user
-from .organizations import Organization
-from .user import User
+from .organizations import Organization, organizations
+from .user import User, user
 
 __all__ = ["Organization", "User", "organizations", "user"]

--- a/seed/fastapi/reserved-keywords/resources/__init__.py
+++ b/seed/fastapi/reserved-keywords/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import package
-from .package import Package, Record
+from .package import Package, Record, package
 
 __all__ = ["Package", "Record", "package"]

--- a/seed/fastapi/simple-api/resources/__init__.py
+++ b/seed/fastapi/simple-api/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User
+from .user import User, user
 
 __all__ = ["User", "user"]

--- a/seed/fastapi/trace/resources/__init__.py
+++ b/seed/fastapi/trace/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import admin, commons, lang_server, migration, playlist, problem, submission, v_2
-from .admin import StoreTracedTestCaseRequest, StoreTracedWorkspaceRequest, Test
+from .admin import StoreTracedTestCaseRequest, StoreTracedWorkspaceRequest, Test, admin
 from .commons import (
     BinaryTreeNodeAndTreeValue,
     BinaryTreeNodeValue,
@@ -31,9 +30,10 @@ from .commons import (
     UserId,
     VariableType,
     VariableValue,
+    commons,
 )
-from .lang_server import LangServerRequest, LangServerResponse
-from .migration import Migration, MigrationStatus
+from .lang_server import LangServerRequest, LangServerResponse, lang_server
+from .migration import Migration, MigrationStatus, migration
 from .playlist import (
     Playlist,
     PlaylistCreateRequest,
@@ -43,6 +43,7 @@ from .playlist import (
     ReservedKeywordEnum,
     UnauthorizedError,
     UpdatePlaylistRequest,
+    playlist,
 )
 from .problem import (
     CreateProblemError,
@@ -57,6 +58,7 @@ from .problem import (
     ProblemInfo,
     UpdateProblemResponse,
     VariableTypeAndName,
+    problem,
 )
 from .submission import (
     ActualResult,
@@ -139,7 +141,9 @@ from .submission import (
     WorkspaceSubmissionUpdateInfo,
     WorkspaceSubmitRequest,
     WorkspaceTracedUpdate,
+    submission,
 )
+from .v_2 import v_2
 
 __all__ = [
     "ActualResult",

--- a/seed/fastapi/trace/resources/v_2/resources/__init__.py
+++ b/seed/fastapi/trace/resources/v_2/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import problem, v_3
 from .problem import (
     AssertCorrectnessCheck,
     BasicCustomFiles,
@@ -45,7 +44,9 @@ from .problem import (
     VoidFunctionDefinitionThatTakesActualResult,
     VoidFunctionSignature,
     VoidFunctionSignatureThatTakesActualResult,
+    problem,
 )
+from .v_3 import v_3
 
 __all__ = [
     "AssertCorrectnessCheck",

--- a/seed/fastapi/trace/resources/v_2/resources/v_3/resources/__init__.py
+++ b/seed/fastapi/trace/resources/v_2/resources/v_3/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import problem
 from .problem import (
     AssertCorrectnessCheck,
     BasicCustomFiles,
@@ -45,6 +44,7 @@ from .problem import (
     VoidFunctionDefinitionThatTakesActualResult,
     VoidFunctionSignature,
     VoidFunctionSignatureThatTakesActualResult,
+    problem,
 )
 
 __all__ = [

--- a/seed/fastapi/undiscriminated-unions/resources/__init__.py
+++ b/seed/fastapi/undiscriminated-unions/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import union
 from .union import (
     Key,
     KeyType,
@@ -19,6 +18,7 @@ from .union import (
     UnionWithDuplicateTypes,
     UnionWithIdenticalPrimitives,
     UnionWithIdenticalStrings,
+    union,
 )
 
 __all__ = [

--- a/seed/fastapi/unions/no-custom-config/resources/__init__.py
+++ b/seed/fastapi/unions/no-custom-config/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import bigunion, types, union
 from .bigunion import (
     ActiveDiamond,
     AttractiveScript,
@@ -34,6 +33,7 @@ from .bigunion import (
     UniqueStress,
     UnwillingSmoke,
     VibrantExcitement,
+    bigunion,
 )
 from .types import (
     Bar,
@@ -55,8 +55,9 @@ from .types import (
     UnionWithSubTypes,
     UnionWithTime,
     UnionWithoutKey,
+    types,
 )
-from .union import Circle, GetShapeRequest, Shape, Square, WithName
+from .union import Circle, GetShapeRequest, Shape, Square, WithName, union
 
 __all__ = [
     "ActiveDiamond",

--- a/seed/fastapi/unions/no-inheritance-for-extended-models/resources/__init__.py
+++ b/seed/fastapi/unions/no-inheritance-for-extended-models/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import bigunion, types, union
 from .bigunion import (
     ActiveDiamond,
     AttractiveScript,
@@ -34,6 +33,7 @@ from .bigunion import (
     UniqueStress,
     UnwillingSmoke,
     VibrantExcitement,
+    bigunion,
 )
 from .types import (
     Bar,
@@ -55,8 +55,9 @@ from .types import (
     UnionWithSubTypes,
     UnionWithTime,
     UnionWithoutKey,
+    types,
 )
-from .union import Circle, GetShapeRequest, Shape, Square, WithName
+from .union import Circle, GetShapeRequest, Shape, Square, WithName, union
 
 __all__ = [
     "ActiveDiamond",

--- a/seed/fastapi/unknown/resources/__init__.py
+++ b/seed/fastapi/unknown/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import unknown
-from .unknown import MyAlias, MyObject
+from .unknown import MyAlias, MyObject, unknown
 
 __all__ = ["MyAlias", "MyObject", "unknown"]

--- a/seed/fastapi/version-no-default/resources/__init__.py
+++ b/seed/fastapi/version-no-default/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User, UserId
+from .user import User, UserId, user
 
 __all__ = ["User", "UserId", "user"]

--- a/seed/fastapi/version/resources/__init__.py
+++ b/seed/fastapi/version/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User, UserId
+from .user import User, UserId, user
 
 __all__ = ["User", "UserId", "user"]

--- a/seed/fastapi/websocket-bearer-auth/resources/__init__.py
+++ b/seed/fastapi/websocket-bearer-auth/resources/__init__.py
@@ -2,8 +2,16 @@
 
 # isort: skip_file
 
-from . import realtime
-from .realtime import ReceiveEvent, ReceiveEvent2, ReceiveEvent3, ReceiveSnakeCase, SendEvent, SendEvent2, SendSnakeCase
+from .realtime import (
+    ReceiveEvent,
+    ReceiveEvent2,
+    ReceiveEvent3,
+    ReceiveSnakeCase,
+    SendEvent,
+    SendEvent2,
+    SendSnakeCase,
+    realtime,
+)
 
 __all__ = [
     "ReceiveEvent",

--- a/seed/fastapi/websocket-inferred-auth/resources/__init__.py
+++ b/seed/fastapi/websocket-inferred-auth/resources/__init__.py
@@ -2,9 +2,17 @@
 
 # isort: skip_file
 
-from . import auth, realtime
-from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse
-from .realtime import ReceiveEvent, ReceiveEvent2, ReceiveEvent3, ReceiveSnakeCase, SendEvent, SendEvent2, SendSnakeCase
+from .auth import GetTokenRequest, RefreshTokenRequest, TokenResponse, auth
+from .realtime import (
+    ReceiveEvent,
+    ReceiveEvent2,
+    ReceiveEvent3,
+    ReceiveSnakeCase,
+    SendEvent,
+    SendEvent2,
+    SendSnakeCase,
+    realtime,
+)
 
 __all__ = [
     "GetTokenRequest",

--- a/seed/fastapi/websocket/resources/__init__.py
+++ b/seed/fastapi/websocket/resources/__init__.py
@@ -2,8 +2,16 @@
 
 # isort: skip_file
 
-from . import realtime
-from .realtime import ReceiveEvent, ReceiveEvent2, ReceiveEvent3, ReceiveSnakeCase, SendEvent, SendEvent2, SendSnakeCase
+from .realtime import (
+    ReceiveEvent,
+    ReceiveEvent2,
+    ReceiveEvent3,
+    ReceiveSnakeCase,
+    SendEvent,
+    SendEvent2,
+    SendSnakeCase,
+    realtime,
+)
 
 __all__ = [
     "ReceiveEvent",

--- a/seed/pydantic/any-auth/src/seed/any_auth/resources/__init__.py
+++ b/seed/pydantic/any-auth/src/seed/any_auth/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import auth, user
-from .auth import TokenResponse
-from .user import User
+from .auth import TokenResponse, auth
+from .user import User, user
 
 __all__ = ["TokenResponse", "User", "auth", "user"]

--- a/seed/pydantic/audiences/src/seed/audiences/resources/__init__.py
+++ b/seed/pydantic/audiences/src/seed/audiences/resources/__init__.py
@@ -2,9 +2,12 @@
 
 # isort: skip_file
 
-from . import commons, folder_a, folder_b, folder_c, folder_d, foo
-from .commons import Imported
-from .foo import FilteredType, ImportingType, OptionalString
+from .commons import Imported, commons
+from .folder_a import folder_a
+from .folder_b import folder_b
+from .folder_c import folder_c
+from .folder_d import folder_d
+from .foo import FilteredType, ImportingType, OptionalString, foo
 
 __all__ = [
     "FilteredType",

--- a/seed/pydantic/audiences/src/seed/audiences/resources/folder_a/resources/__init__.py
+++ b/seed/pydantic/audiences/src/seed/audiences/resources/folder_a/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/pydantic/audiences/src/seed/audiences/resources/folder_b/resources/__init__.py
+++ b/seed/pydantic/audiences/src/seed/audiences/resources/folder_b/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import Foo
+from .common import Foo, common
 
 __all__ = ["Foo", "common"]

--- a/seed/pydantic/audiences/src/seed/audiences/resources/folder_c/resources/__init__.py
+++ b/seed/pydantic/audiences/src/seed/audiences/resources/folder_c/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import FolderCFoo
+from .common import FolderCFoo, common
 
 __all__ = ["FolderCFoo", "common"]

--- a/seed/pydantic/audiences/src/seed/audiences/resources/folder_d/resources/__init__.py
+++ b/seed/pydantic/audiences/src/seed/audiences/resources/folder_d/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/pydantic/basic-auth-environment-variables/src/seed/basic_auth_environment_variables/resources/__init__.py
+++ b/seed/pydantic/basic-auth-environment-variables/src/seed/basic_auth_environment_variables/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import UnauthorizedRequestErrorBody
+from .errors import UnauthorizedRequestErrorBody, errors
 
 __all__ = ["UnauthorizedRequestErrorBody", "errors"]

--- a/seed/pydantic/basic-auth/src/seed/basic_auth/resources/__init__.py
+++ b/seed/pydantic/basic-auth/src/seed/basic_auth/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import UnauthorizedRequestErrorBody
+from .errors import UnauthorizedRequestErrorBody, errors
 
 __all__ = ["UnauthorizedRequestErrorBody", "errors"]

--- a/seed/pydantic/circular-references-advanced/no-custom-config/src/seed/api/resources/__init__.py
+++ b/seed/pydantic/circular-references-advanced/no-custom-config/src/seed/api/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
+from .a import A, a
 from .ast import (
     Acai,
     Animal,
@@ -27,6 +26,7 @@ from .ast import (
     ObjectFieldValue,
     ObjectValue,
     PrimitiveValue,
+    ast,
 )
 
 __all__ = [

--- a/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/src/seed/api/resources/__init__.py
+++ b/seed/pydantic/circular-references-advanced/no-inheritance-for-extended-models/src/seed/api/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
+from .a import A, a
 from .ast import (
     Acai,
     Animal,
@@ -27,6 +26,7 @@ from .ast import (
     ObjectFieldValue,
     ObjectValue,
     PrimitiveValue,
+    ast,
 )
 
 __all__ = [

--- a/seed/pydantic/circular-references/no-custom-config/src/seed/api/resources/__init__.py
+++ b/seed/pydantic/circular-references/no-custom-config/src/seed/api/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
+from .a import A, a
 from .ast import (
     ContainerValue,
     ContainerValue_List,
@@ -18,6 +17,7 @@ from .ast import (
     T,
     TorU,
     U,
+    ast,
 )
 
 __all__ = [

--- a/seed/pydantic/circular-references/no-inheritance-for-extended-models/src/seed/api/resources/__init__.py
+++ b/seed/pydantic/circular-references/no-inheritance-for-extended-models/src/seed/api/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import a, ast
-from .a import A
+from .a import A, a
 from .ast import (
     ContainerValue,
     ContainerValue_List,
@@ -18,6 +17,7 @@ from .ast import (
     T,
     TorU,
     U,
+    ast,
 )
 
 __all__ = [

--- a/seed/pydantic/client-side-params/src/seed/client_side_params/resources/__init__.py
+++ b/seed/pydantic/client-side-params/src/seed/client_side_params/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import types
 from .types import (
     Client,
     Connection,
@@ -14,6 +13,7 @@ from .types import (
     SearchResponse,
     UpdateUserRequest,
     User,
+    types,
 )
 
 __all__ = [

--- a/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/__init__.py
+++ b/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/__init__.py
@@ -2,9 +2,12 @@
 
 # isort: skip_file
 
-from . import commons, folder_a, folder_b, folder_c, folder_d, foo
-from .commons import Imported
-from .foo import ImportingType, OptionalString
+from .commons import Imported, commons
+from .folder_a import folder_a
+from .folder_b import folder_b
+from .folder_c import folder_c
+from .folder_d import folder_d
+from .foo import ImportingType, OptionalString, foo
 
 __all__ = [
     "Imported",

--- a/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_a/resources/__init__.py
+++ b/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_a/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_b/resources/__init__.py
+++ b/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_b/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import Foo
+from .common import Foo, common
 
 __all__ = ["Foo", "common"]

--- a/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_c/resources/__init__.py
+++ b/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_c/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import common
-from .common import Foo
+from .common import Foo, common
 
 __all__ = ["Foo", "common"]

--- a/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_d/resources/__init__.py
+++ b/seed/pydantic/cross-package-type-names/src/seed/cross_package_type_names/resources/folder_d/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Response
+from .service import Response, service
 
 __all__ = ["Response", "service"]

--- a/seed/pydantic/custom-auth/src/seed/custom_auth/resources/__init__.py
+++ b/seed/pydantic/custom-auth/src/seed/custom_auth/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import UnauthorizedRequestErrorBody
+from .errors import UnauthorizedRequestErrorBody, errors
 
 __all__ = ["UnauthorizedRequestErrorBody", "errors"]

--- a/seed/pydantic/empty-clients/src/seed/empty_clients/resources/__init__.py
+++ b/seed/pydantic/empty-clients/src/seed/empty_clients/resources/__init__.py
@@ -2,6 +2,6 @@
 
 # isort: skip_file
 
-from . import level_1
+from .level_1 import level_1
 
 __all__ = ["level_1"]

--- a/seed/pydantic/empty-clients/src/seed/empty_clients/resources/level_1/resources/__init__.py
+++ b/seed/pydantic/empty-clients/src/seed/empty_clients/resources/level_1/resources/__init__.py
@@ -2,7 +2,7 @@
 
 # isort: skip_file
 
-from . import level_2, types
-from .types import Address, Person
+from .level_2 import level_2
+from .types import Address, Person, types
 
 __all__ = ["Address", "Person", "level_2", "types"]

--- a/seed/pydantic/empty-clients/src/seed/empty_clients/resources/level_1/resources/level_2/resources/__init__.py
+++ b/seed/pydantic/empty-clients/src/seed/empty_clients/resources/level_1/resources/level_2/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import types
-from .types import Address, Person
+from .types import Address, Person, types
 
 __all__ = ["Address", "Person", "types"]

--- a/seed/pydantic/enum/src/seed/enum/resources/__init__.py
+++ b/seed/pydantic/enum/src/seed/enum/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import unknown
-from .unknown import Status
+from .unknown import Status, unknown
 
 __all__ = ["Status", "unknown"]

--- a/seed/pydantic/error-property/src/seed/error_property/resources/__init__.py
+++ b/seed/pydantic/error-property/src/seed/error_property/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import errors
-from .errors import PropertyBasedErrorTestBody
+from .errors import PropertyBasedErrorTestBody, errors
 
 __all__ = ["PropertyBasedErrorTestBody", "errors"]

--- a/seed/pydantic/errors/src/seed/errors/resources/__init__.py
+++ b/seed/pydantic/errors/src/seed/errors/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import commons, simple
-from .commons import ErrorBody
-from .simple import FooRequest, FooResponse
+from .commons import ErrorBody, commons
+from .simple import FooRequest, FooResponse, simple
 
 __all__ = ["ErrorBody", "FooRequest", "FooResponse", "commons", "simple"]

--- a/seed/pydantic/examples/src/seed/examples/resources/__init__.py
+++ b/seed/pydantic/examples/src/seed/examples/resources/__init__.py
@@ -2,7 +2,8 @@
 
 # isort: skip_file
 
-from . import commons, file, types
+from .commons import commons
+from .file import file
 from .types import (
     Actor,
     Actress,
@@ -35,6 +36,7 @@ from .types import (
     Test_And,
     Test_Or,
     Tree,
+    types,
 )
 
 __all__ = [

--- a/seed/pydantic/examples/src/seed/examples/resources/commons/resources/__init__.py
+++ b/seed/pydantic/examples/src/seed/examples/resources/commons/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import types
-from .types import Data, Data_Base64, Data_String, EventInfo, EventInfo_Metadata, EventInfo_Tag, Metadata, Tag
+from .types import Data, Data_Base64, Data_String, EventInfo, EventInfo_Metadata, EventInfo_Tag, Metadata, Tag, types
 
 __all__ = [
     "Data",

--- a/seed/pydantic/examples/src/seed/examples/resources/file/resources/__init__.py
+++ b/seed/pydantic/examples/src/seed/examples/resources/file/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Filename
+from .service import Filename, service
 
 __all__ = ["Filename", "service"]

--- a/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/resources/__init__.py
+++ b/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/resources/__init__.py
@@ -2,7 +2,8 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, types
-from .general_errors import BadObjectRequestInfo
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, general_errors
+from .types import types
 
 __all__ = ["BadObjectRequestInfo", "endpoints", "general_errors", "types"]

--- a/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/resources/endpoints/resources/__init__.py
+++ b/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/resources/types/resources/__init__.py
+++ b/seed/pydantic/exhaustive/pydantic-v1/src/seed/exhaustive/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -13,8 +12,9 @@ from .object import (
     ObjectWithOptionalField,
     ObjectWithRequiredField,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog
+from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, union
 
 __all__ = [
     "Animal",

--- a/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/resources/__init__.py
+++ b/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/resources/__init__.py
@@ -2,7 +2,8 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, types
-from .general_errors import BadObjectRequestInfo
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, general_errors
+from .types import types
 
 __all__ = ["BadObjectRequestInfo", "endpoints", "general_errors", "types"]

--- a/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/resources/endpoints/resources/__init__.py
+++ b/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/resources/endpoints/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import put
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
 
 __all__ = ["Error", "ErrorCategory", "ErrorCode", "PutResponse", "put"]

--- a/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/resources/types/resources/__init__.py
+++ b/seed/pydantic/exhaustive/pydantic-v2/src/seed/exhaustive/resources/types/resources/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -13,8 +12,9 @@ from .object import (
     ObjectWithOptionalField,
     ObjectWithRequiredField,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog
+from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, union
 
 __all__ = [
     "Animal",

--- a/seed/pydantic/extra-properties/src/seed/extra_properties/resources/__init__.py
+++ b/seed/pydantic/extra-properties/src/seed/extra_properties/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User
+from .user import User, user
 
 __all__ = ["User", "user"]

--- a/seed/pydantic/file-upload/src/seed/file_upload/resources/__init__.py
+++ b/seed/pydantic/file-upload/src/seed/file_upload/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
 from .service import (
     Id,
     MyAliasObject,
@@ -11,6 +10,7 @@ from .service import (
     MyObject,
     MyObjectWithOptional,
     ObjectType,
+    service,
 )
 
 __all__ = [

--- a/seed/pydantic/folders/src/seed/api/resources/__init__.py
+++ b/seed/pydantic/folders/src/seed/api/resources/__init__.py
@@ -2,6 +2,6 @@
 
 # isort: skip_file
 
-from . import a
+from .a import a
 
 __all__ = ["a"]

--- a/seed/pydantic/folders/src/seed/api/resources/a/resources/__init__.py
+++ b/seed/pydantic/folders/src/seed/api/resources/a/resources/__init__.py
@@ -2,6 +2,6 @@
 
 # isort: skip_file
 
-from . import d
+from .d import d
 
 __all__ = ["d"]

--- a/seed/pydantic/folders/src/seed/api/resources/a/resources/d/resources/__init__.py
+++ b/seed/pydantic/folders/src/seed/api/resources/a/resources/d/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import types
-from .types import Foo
+from .types import Foo, types
 
 __all__ = ["Foo", "types"]

--- a/seed/pydantic/http-head/src/seed/http_head/resources/__init__.py
+++ b/seed/pydantic/http-head/src/seed/http_head/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User
+from .user import User, user
 
 __all__ = ["User", "user"]

--- a/seed/pydantic/idempotency-headers/src/seed/idempotency_headers/resources/__init__.py
+++ b/seed/pydantic/idempotency-headers/src/seed/idempotency_headers/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import payment
-from .payment import Currency
+from .payment import Currency, payment
 
 __all__ = ["Currency", "payment"]

--- a/seed/pydantic/imdb/src/seed/api/resources/__init__.py
+++ b/seed/pydantic/imdb/src/seed/api/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import imdb
-from .imdb import CreateMovieRequest, Movie, MovieId
+from .imdb import CreateMovieRequest, Movie, MovieId, imdb
 
 __all__ = ["CreateMovieRequest", "Movie", "MovieId", "imdb"]

--- a/seed/pydantic/inferred-auth-explicit/src/seed/inferred_auth_explicit/resources/__init__.py
+++ b/seed/pydantic/inferred-auth-explicit/src/seed/inferred_auth_explicit/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/inferred-auth-implicit-no-expiry/src/seed/inferred_auth_implicit_no_expiry/resources/__init__.py
+++ b/seed/pydantic/inferred-auth-implicit-no-expiry/src/seed/inferred_auth_implicit_no_expiry/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/inferred-auth-implicit/src/seed/inferred_auth_implicit/resources/__init__.py
+++ b/seed/pydantic/inferred-auth-implicit/src/seed/inferred_auth_implicit/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/literal/src/seed/literal/resources/__init__.py
+++ b/seed/pydantic/literal/src/seed/literal/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import inlined, query, reference
 from .inlined import (
     ANestedLiteral,
     ATopLevelLiteral,
@@ -13,9 +12,10 @@ from .inlined import (
     DiscriminatedLiteral_LiteralGeorge,
     SomeAliasedLiteral,
     UndiscriminatedLiteral,
+    inlined,
 )
-from .query import AliasToPrompt, AliasToStream
-from .reference import ContainerObject, NestedObjectWithLiterals, SendRequest, SomeLiteral
+from .query import AliasToPrompt, AliasToStream, query
+from .reference import ContainerObject, NestedObjectWithLiterals, SendRequest, SomeLiteral, reference
 
 __all__ = [
     "ANestedLiteral",

--- a/seed/pydantic/literals-unions/src/seed/literals_unions/resources/__init__.py
+++ b/seed/pydantic/literals-unions/src/seed/literals_unions/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import literals
-from .literals import LiteralString, UnionOverLiteral
+from .literals import LiteralString, UnionOverLiteral, literals
 
 __all__ = ["LiteralString", "UnionOverLiteral", "literals"]

--- a/seed/pydantic/mixed-case/src/seed/mixed_case/resources/__init__.py
+++ b/seed/pydantic/mixed-case/src/seed/mixed_case/resources/__init__.py
@@ -2,8 +2,16 @@
 
 # isort: skip_file
 
-from . import service
-from .service import NestedUser, Organization, Resource, ResourceStatus, Resource_Organization, Resource_User, User
+from .service import (
+    NestedUser,
+    Organization,
+    Resource,
+    ResourceStatus,
+    Resource_Organization,
+    Resource_User,
+    User,
+    service,
+)
 
 __all__ = [
     "NestedUser",

--- a/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/resources/__init__.py
+++ b/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import organization, user
-from .organization import CreateOrganizationRequest, Organization
-from .user import User
+from .organization import CreateOrganizationRequest, Organization, organization
+from .user import User, user
 
 __all__ = ["CreateOrganizationRequest", "Organization", "User", "organization", "user"]

--- a/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/resources/user/resources/__init__.py
+++ b/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/resources/user/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import events
-from .events import Event
+from .events import Event, events
 
 __all__ = ["Event", "events"]

--- a/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/resources/user/resources/events/resources/__init__.py
+++ b/seed/pydantic/mixed-file-directory/src/seed/mixed_file_directory/resources/user/resources/events/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import metadata
-from .metadata import Metadata
+from .metadata import Metadata, metadata
 
 __all__ = ["Metadata", "metadata"]

--- a/seed/pydantic/multi-line-docs/src/seed/multi_line_docs/resources/__init__.py
+++ b/seed/pydantic/multi-line-docs/src/seed/multi_line_docs/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User
+from .user import User, user
 
 __all__ = ["User", "user"]

--- a/seed/pydantic/nullable-optional/src/seed/nullable_optional/resources/__init__.py
+++ b/seed/pydantic/nullable-optional/src/seed/nullable_optional/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import nullable_optional
 from .nullable_optional import (
     Address,
     ComplexProfile,
@@ -29,6 +28,7 @@ from .nullable_optional import (
     UserResponse,
     UserRole,
     UserStatus,
+    nullable_optional,
 )
 
 __all__ = [

--- a/seed/pydantic/nullable/src/seed/nullable/resources/__init__.py
+++ b/seed/pydantic/nullable/src/seed/nullable/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import nullable
 from .nullable import (
     Email,
     Metadata,
@@ -13,6 +12,7 @@ from .nullable import (
     User,
     UserId,
     WeirdNumber,
+    nullable,
 )
 
 __all__ = [

--- a/seed/pydantic/oauth-client-credentials-custom/src/seed/oauth_client_credentials/resources/__init__.py
+++ b/seed/pydantic/oauth-client-credentials-custom/src/seed/oauth_client_credentials/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/oauth-client-credentials-default/src/seed/oauth_client_credentials_default/resources/__init__.py
+++ b/seed/pydantic/oauth-client-credentials-default/src/seed/oauth_client_credentials_default/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/oauth-client-credentials-environment-variables/src/seed/oauth_client_credentials_environment_variables/resources/__init__.py
+++ b/seed/pydantic/oauth-client-credentials-environment-variables/src/seed/oauth_client_credentials_environment_variables/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/oauth-client-credentials-nested-root/src/seed/oauth_client_credentials/resources/__init__.py
+++ b/seed/pydantic/oauth-client-credentials-nested-root/src/seed/oauth_client_credentials/resources/__init__.py
@@ -2,6 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
+from .auth import auth
 
 __all__ = ["auth"]

--- a/seed/pydantic/oauth-client-credentials-with-variables/src/seed/oauth_client_credentials_with_variables/resources/__init__.py
+++ b/seed/pydantic/oauth-client-credentials-with-variables/src/seed/oauth_client_credentials_with_variables/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/oauth-client-credentials/src/seed/oauth_client_credentials/resources/__init__.py
+++ b/seed/pydantic/oauth-client-credentials/src/seed/oauth_client_credentials/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import auth
-from .auth import TokenResponse
+from .auth import TokenResponse, auth
 
 __all__ = ["TokenResponse", "auth"]

--- a/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/resources/__init__.py
+++ b/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/resources/__init__.py
@@ -2,7 +2,7 @@
 
 # isort: skip_file
 
-from . import commons, file
-from .file import File, FileInfo
+from .commons import commons
+from .file import File, FileInfo, file
 
 __all__ = ["File", "FileInfo", "commons", "file"]

--- a/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/resources/commons/resources/__init__.py
+++ b/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/resources/commons/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import metadata
-from .metadata import Metadata
+from .metadata import Metadata, metadata
 
 __all__ = ["Metadata", "metadata"]

--- a/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/resources/file/resources/__init__.py
+++ b/seed/pydantic/objects-with-imports/src/seed/objects_with_imports/resources/file/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import directory
-from .directory import Directory
+from .directory import Directory, directory
 
 __all__ = ["Directory", "directory"]

--- a/seed/pydantic/pagination/no-custom-config/src/seed/pagination/resources/__init__.py
+++ b/seed/pydantic/pagination/no-custom-config/src/seed/pagination/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import complex_, inline_users, users
 from .complex_ import (
     Conversation,
     CursorPages,
@@ -15,7 +14,9 @@ from .complex_ import (
     SingleFilterSearchRequest,
     SingleFilterSearchRequestOperator,
     StartingAfterPaging,
+    complex_,
 )
+from .inline_users import inline_users
 from .users import (
     ListUsersExtendedOptionalListResponse,
     ListUsersExtendedResponse,
@@ -32,6 +33,7 @@ from .users import (
     UsernameContainer,
     WithCursor,
     WithPage,
+    users,
 )
 
 __all__ = [

--- a/seed/pydantic/pagination/no-custom-config/src/seed/pagination/resources/inline_users/resources/__init__.py
+++ b/seed/pydantic/pagination/no-custom-config/src/seed/pagination/resources/inline_users/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import inline_users
 from .inline_users import (
     ListUsersExtendedOptionalListResponse,
     ListUsersExtendedResponse,
@@ -20,6 +19,7 @@ from .inline_users import (
     Users,
     WithCursor,
     WithPage,
+    inline_users,
 )
 
 __all__ = [

--- a/seed/pydantic/pagination/no-inheritance-for-extended-models/src/seed/pagination/resources/__init__.py
+++ b/seed/pydantic/pagination/no-inheritance-for-extended-models/src/seed/pagination/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import complex_, inline_users, users
 from .complex_ import (
     Conversation,
     CursorPages,
@@ -15,7 +14,9 @@ from .complex_ import (
     SingleFilterSearchRequest,
     SingleFilterSearchRequestOperator,
     StartingAfterPaging,
+    complex_,
 )
+from .inline_users import inline_users
 from .users import (
     ListUsersExtendedOptionalListResponse,
     ListUsersExtendedResponse,
@@ -32,6 +33,7 @@ from .users import (
     UsernameContainer,
     WithCursor,
     WithPage,
+    users,
 )
 
 __all__ = [

--- a/seed/pydantic/pagination/no-inheritance-for-extended-models/src/seed/pagination/resources/inline_users/resources/__init__.py
+++ b/seed/pydantic/pagination/no-inheritance-for-extended-models/src/seed/pagination/resources/inline_users/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import inline_users
 from .inline_users import (
     ListUsersExtendedOptionalListResponse,
     ListUsersExtendedResponse,
@@ -20,6 +19,7 @@ from .inline_users import (
     Users,
     WithCursor,
     WithPage,
+    inline_users,
 )
 
 __all__ = [

--- a/seed/pydantic/path-parameters/src/seed/path_parameters/resources/__init__.py
+++ b/seed/pydantic/path-parameters/src/seed/path_parameters/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import organizations, user
-from .organizations import Organization
-from .user import User
+from .organizations import Organization, organizations
+from .user import User, user
 
 __all__ = ["Organization", "User", "organizations", "user"]

--- a/seed/pydantic/query-parameters/src/seed/query_parameters/resources/__init__.py
+++ b/seed/pydantic/query-parameters/src/seed/query_parameters/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import NestedUser, User
+from .user import NestedUser, User, user
 
 __all__ = ["NestedUser", "User", "user"]

--- a/seed/pydantic/request-parameters/src/seed/request_parameters/resources/__init__.py
+++ b/seed/pydantic/request-parameters/src/seed/request_parameters/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import CreateUsernameBody, NestedUser, User
+from .user import CreateUsernameBody, NestedUser, User, user
 
 __all__ = ["CreateUsernameBody", "NestedUser", "User", "user"]

--- a/seed/pydantic/reserved-keywords/src/seed/nursery_api/resources/__init__.py
+++ b/seed/pydantic/reserved-keywords/src/seed/nursery_api/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import package
-from .package import Package, Record
+from .package import Package, Record, package
 
 __all__ = ["Package", "Record", "package"]

--- a/seed/pydantic/response-property/src/seed/response_property/resources/__init__.py
+++ b/seed/pydantic/response-property/src/seed/response_property/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import service
-from .service import Movie, OptionalWithDocs, Response, WithDocs
+from .service import Movie, OptionalWithDocs, Response, WithDocs, service
 
 __all__ = ["Movie", "OptionalWithDocs", "Response", "WithDocs", "service"]

--- a/seed/pydantic/server-sent-event-examples/src/seed/server_sent_events/resources/__init__.py
+++ b/seed/pydantic/server-sent-event-examples/src/seed/server_sent_events/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import completions
-from .completions import StreamedCompletion
+from .completions import StreamedCompletion, completions
 
 __all__ = ["StreamedCompletion", "completions"]

--- a/seed/pydantic/server-sent-events/src/seed/server_sent_events/resources/__init__.py
+++ b/seed/pydantic/server-sent-events/src/seed/server_sent_events/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import completions
-from .completions import StreamedCompletion
+from .completions import StreamedCompletion, completions
 
 __all__ = ["StreamedCompletion", "completions"]

--- a/seed/pydantic/simple-api/src/seed/simple_api/resources/__init__.py
+++ b/seed/pydantic/simple-api/src/seed/simple_api/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User
+from .user import User, user
 
 __all__ = ["User", "user"]

--- a/seed/pydantic/streaming-parameter/src/seed/streaming/resources/__init__.py
+++ b/seed/pydantic/streaming-parameter/src/seed/streaming/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import dummy
-from .dummy import RegularResponse, StreamResponse
+from .dummy import RegularResponse, StreamResponse, dummy
 
 __all__ = ["RegularResponse", "StreamResponse", "dummy"]

--- a/seed/pydantic/streaming/src/seed/streaming/resources/__init__.py
+++ b/seed/pydantic/streaming/src/seed/streaming/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import dummy
-from .dummy import StreamResponse
+from .dummy import StreamResponse, dummy
 
 __all__ = ["StreamResponse", "dummy"]

--- a/seed/pydantic/trace/src/seed/trace/resources/__init__.py
+++ b/seed/pydantic/trace/src/seed/trace/resources/__init__.py
@@ -2,8 +2,7 @@
 
 # isort: skip_file
 
-from . import admin, commons, lang_server, migration, playlist, problem, submission, v_2
-from .admin import Test, Test_And, Test_Or
+from .admin import Test, Test_And, Test_Or, admin
 from .commons import (
     BinaryTreeNodeAndTreeValue,
     BinaryTreeNodeValue,
@@ -65,9 +64,10 @@ from .commons import (
     VariableValue_NullValue,
     VariableValue_SinglyLinkedListValue,
     VariableValue_StringValue,
+    commons,
 )
-from .lang_server import LangServerRequest, LangServerResponse
-from .migration import Migration, MigrationStatus
+from .lang_server import LangServerRequest, LangServerResponse, lang_server
+from .migration import Migration, MigrationStatus, migration
 from .playlist import (
     Playlist,
     PlaylistCreateRequest,
@@ -76,6 +76,7 @@ from .playlist import (
     PlaylistIdNotFoundErrorBody_PlaylistId,
     ReservedKeywordEnum,
     UpdatePlaylistRequest,
+    playlist,
 )
 from .problem import (
     CreateProblemError,
@@ -95,6 +96,7 @@ from .problem import (
     ProblemInfo,
     UpdateProblemResponse,
     VariableTypeAndName,
+    problem,
 )
 from .submission import (
     ActualResult,
@@ -241,7 +243,9 @@ from .submission import (
     WorkspaceSubmissionUpdateInfo_TracedV2,
     WorkspaceSubmitRequest,
     WorkspaceTracedUpdate,
+    submission,
 )
+from .v_2 import v_2
 
 __all__ = [
     "ActualResult",

--- a/seed/pydantic/trace/src/seed/trace/resources/v_2/resources/__init__.py
+++ b/seed/pydantic/trace/src/seed/trace/resources/v_2/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import problem, v_3
 from .problem import (
     AssertCorrectnessCheck,
     AssertCorrectnessCheck_Custom,
@@ -58,7 +57,9 @@ from .problem import (
     VoidFunctionDefinitionThatTakesActualResult,
     VoidFunctionSignature,
     VoidFunctionSignatureThatTakesActualResult,
+    problem,
 )
+from .v_3 import v_3
 
 __all__ = [
     "AssertCorrectnessCheck",

--- a/seed/pydantic/trace/src/seed/trace/resources/v_2/resources/v_3/resources/__init__.py
+++ b/seed/pydantic/trace/src/seed/trace/resources/v_2/resources/v_3/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import problem
 from .problem import (
     AssertCorrectnessCheck,
     AssertCorrectnessCheck_Custom,
@@ -58,6 +57,7 @@ from .problem import (
     VoidFunctionDefinitionThatTakesActualResult,
     VoidFunctionSignature,
     VoidFunctionSignatureThatTakesActualResult,
+    problem,
 )
 
 __all__ = [

--- a/seed/pydantic/undiscriminated-unions/src/seed/undiscriminated_unions/resources/__init__.py
+++ b/seed/pydantic/undiscriminated-unions/src/seed/undiscriminated_unions/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import union
 from .union import (
     Key,
     KeyType,
@@ -19,6 +18,7 @@ from .union import (
     UnionWithDuplicateTypes,
     UnionWithIdenticalPrimitives,
     UnionWithIdenticalStrings,
+    union,
 )
 
 __all__ = [

--- a/seed/pydantic/unions/no-custom-config/src/seed/unions/resources/__init__.py
+++ b/seed/pydantic/unions/no-custom-config/src/seed/unions/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import bigunion, types, union
 from .bigunion import (
     ActiveDiamond,
     AttractiveScript,
@@ -63,6 +62,7 @@ from .bigunion import (
     UniqueStress,
     UnwillingSmoke,
     VibrantExcitement,
+    bigunion,
 )
 from .types import (
     Bar,
@@ -121,8 +121,9 @@ from .types import (
     UnionWithoutKey_Foo,
     Union_Bar,
     Union_Foo,
+    types,
 )
-from .union import Circle, GetShapeRequest, Shape, Shape_Circle, Shape_Square, Square, WithName
+from .union import Circle, GetShapeRequest, Shape, Shape_Circle, Shape_Square, Square, WithName, union
 
 __all__ = [
     "ActiveDiamond",

--- a/seed/pydantic/unions/no-inheritance-for-extended-models/src/seed/unions/resources/__init__.py
+++ b/seed/pydantic/unions/no-inheritance-for-extended-models/src/seed/unions/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import bigunion, types, union
 from .bigunion import (
     ActiveDiamond,
     AttractiveScript,
@@ -63,6 +62,7 @@ from .bigunion import (
     UniqueStress,
     UnwillingSmoke,
     VibrantExcitement,
+    bigunion,
 )
 from .types import (
     Bar,
@@ -121,8 +121,9 @@ from .types import (
     UnionWithoutKey_Foo,
     Union_Bar,
     Union_Foo,
+    types,
 )
-from .union import Circle, GetShapeRequest, Shape, Shape_Circle, Shape_Square, Square, WithName
+from .union import Circle, GetShapeRequest, Shape, Shape_Circle, Shape_Square, Square, WithName, union
 
 __all__ = [
     "ActiveDiamond",

--- a/seed/pydantic/unknown/src/seed/unknown_as_any/resources/__init__.py
+++ b/seed/pydantic/unknown/src/seed/unknown_as_any/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import unknown
-from .unknown import MyAlias, MyObject
+from .unknown import MyAlias, MyObject, unknown
 
 __all__ = ["MyAlias", "MyObject", "unknown"]

--- a/seed/pydantic/version-no-default/src/seed/version/resources/__init__.py
+++ b/seed/pydantic/version-no-default/src/seed/version/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User, UserId
+from .user import User, UserId, user
 
 __all__ = ["User", "UserId", "user"]

--- a/seed/pydantic/version/src/seed/version/resources/__init__.py
+++ b/seed/pydantic/version/src/seed/version/resources/__init__.py
@@ -2,7 +2,6 @@
 
 # isort: skip_file
 
-from . import user
-from .user import User, UserId
+from .user import User, UserId, user
 
 __all__ = ["User", "UserId", "user"]

--- a/seed/pydantic/websocket-bearer-auth/src/seed/websocket_bearer_auth/resources/__init__.py
+++ b/seed/pydantic/websocket-bearer-auth/src/seed/websocket_bearer_auth/resources/__init__.py
@@ -2,8 +2,16 @@
 
 # isort: skip_file
 
-from . import realtime
-from .realtime import ReceiveEvent, ReceiveEvent2, ReceiveEvent3, ReceiveSnakeCase, SendEvent, SendEvent2, SendSnakeCase
+from .realtime import (
+    ReceiveEvent,
+    ReceiveEvent2,
+    ReceiveEvent3,
+    ReceiveSnakeCase,
+    SendEvent,
+    SendEvent2,
+    SendSnakeCase,
+    realtime,
+)
 
 __all__ = [
     "ReceiveEvent",

--- a/seed/pydantic/websocket-inferred-auth/src/seed/websocket_auth/resources/__init__.py
+++ b/seed/pydantic/websocket-inferred-auth/src/seed/websocket_auth/resources/__init__.py
@@ -2,9 +2,17 @@
 
 # isort: skip_file
 
-from . import auth, realtime
-from .auth import TokenResponse
-from .realtime import ReceiveEvent, ReceiveEvent2, ReceiveEvent3, ReceiveSnakeCase, SendEvent, SendEvent2, SendSnakeCase
+from .auth import TokenResponse, auth
+from .realtime import (
+    ReceiveEvent,
+    ReceiveEvent2,
+    ReceiveEvent3,
+    ReceiveSnakeCase,
+    SendEvent,
+    SendEvent2,
+    SendSnakeCase,
+    realtime,
+)
 
 __all__ = [
     "ReceiveEvent",

--- a/seed/pydantic/websocket/src/seed/websocket/resources/__init__.py
+++ b/seed/pydantic/websocket/src/seed/websocket/resources/__init__.py
@@ -2,8 +2,16 @@
 
 # isort: skip_file
 
-from . import realtime
-from .realtime import ReceiveEvent, ReceiveEvent2, ReceiveEvent3, ReceiveSnakeCase, SendEvent, SendEvent2, SendSnakeCase
+from .realtime import (
+    ReceiveEvent,
+    ReceiveEvent2,
+    ReceiveEvent3,
+    ReceiveSnakeCase,
+    SendEvent,
+    SendEvent2,
+    SendSnakeCase,
+    realtime,
+)
 
 __all__ = [
     "ReceiveEvent",

--- a/seed/python-sdk/accept-header/src/seed/__init__.py
+++ b/seed/python-sdk/accept-header/src/seed/__init__.py
@@ -6,16 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedAccept, SeedAccept
-    from .service import NotFoundError
+    from .service import NotFoundError, service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedAccept": ".client",
     "NotFoundError": ".service",
     "SeedAccept": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/any-auth/src/seed/__init__.py
+++ b/seed/python-sdk/any-auth/src/seed/__init__.py
@@ -6,10 +6,9 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, user
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedAnyAuth, SeedAnyAuth
-    from .user import User
+    from .user import User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedAnyAuth": ".client",
@@ -17,8 +16,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "TokenResponse": ".auth",
     "User": ".user",
     "__version__": ".version",
-    "auth": ".",
-    "user": ".",
+    "auth": ".auth",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/api-wide-base-path/src/seed/__init__.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedApiWideBasePath, SeedApiWideBasePath
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedApiWideBasePath": ".client",
     "SeedApiWideBasePath": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/audiences/src/seed/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/__init__.py
@@ -6,11 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import commons, folder_a, folder_b, folder_c, folder_d, foo
     from .client import AsyncSeedAudiences, SeedAudiences
-    from .commons import Imported
+    from .commons import Imported, commons
     from .environment import SeedAudiencesEnvironment
-    from .foo import FilteredType, ImportingType, OptionalString
+    from .folder_a import folder_a
+    from .folder_b import folder_b
+    from .folder_c import folder_c
+    from .folder_d import folder_d
+    from .foo import FilteredType, ImportingType, OptionalString, foo
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedAudiences": ".client",
@@ -21,12 +24,12 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedAudiences": ".client",
     "SeedAudiencesEnvironment": ".environment",
     "__version__": ".version",
-    "commons": ".",
-    "folder_a": ".",
-    "folder_b": ".",
-    "folder_c": ".",
-    "folder_d": ".",
-    "foo": ".",
+    "commons": ".commons",
+    "folder_a": ".folder_a",
+    "folder_b": ".folder_b",
+    "folder_c": ".folder_c",
+    "folder_d": ".folder_d",
+    "foo": ".foo",
 }
 
 

--- a/seed/python-sdk/audiences/src/seed/folder_a/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_a/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-    from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+    from .service import Response, service
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/audiences/src/seed/folder_b/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_b/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import common
-    from .common import Foo
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": "."}
+    from .common import Foo, common
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/audiences/src/seed/folder_c/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_c/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import common
-    from .common import FolderCFoo
-_dynamic_imports: typing.Dict[str, str] = {"FolderCFoo": ".common", "common": "."}
+    from .common import FolderCFoo, common
+_dynamic_imports: typing.Dict[str, str] = {"FolderCFoo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/audiences/src/seed/folder_d/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_d/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-    from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+    from .service import Response, service
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/auth-environment-variables/src/seed/__init__.py
+++ b/seed/python-sdk/auth-environment-variables/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedAuthEnvironmentVariables, SeedAuthEnvironmentVariables
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedAuthEnvironmentVariables": ".client",
     "SeedAuthEnvironmentVariables": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/__init__.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody
-    from . import basic_auth, errors
+    from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody, errors
+    from .basic_auth import basic_auth
     from .client import AsyncSeedBasicAuthEnvironmentVariables, SeedBasicAuthEnvironmentVariables
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnauthorizedRequest": ".errors",
     "UnauthorizedRequestErrorBody": ".errors",
     "__version__": ".version",
-    "basic_auth": ".",
-    "errors": ".",
+    "basic_auth": ".basic_auth",
+    "errors": ".errors",
 }
 
 

--- a/seed/python-sdk/basic-auth/src/seed/__init__.py
+++ b/seed/python-sdk/basic-auth/src/seed/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody
-    from . import basic_auth, errors
+    from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody, errors
+    from .basic_auth import basic_auth
     from .client import AsyncSeedBasicAuth, SeedBasicAuth
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnauthorizedRequest": ".errors",
     "UnauthorizedRequestErrorBody": ".errors",
     "__version__": ".version",
-    "basic_auth": ".",
-    "errors": ".",
+    "basic_auth": ".basic_auth",
+    "errors": ".errors",
 }
 
 

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/__init__.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedBearerTokenEnvironmentVariable, SeedBearerTokenEnvironmentVariable
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedBearerTokenEnvironmentVariable": ".client",
     "SeedBearerTokenEnvironmentVariable": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/bytes-download/src/seed/__init__.py
+++ b/seed/python-sdk/bytes-download/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedBytesDownload, SeedBytesDownload
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedBytesDownload": ".client",
     "SeedBytesDownload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/bytes-upload/src/seed/__init__.py
+++ b/seed/python-sdk/bytes-upload/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedBytesUpload, SeedBytesUpload
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedBytesUpload": ".client",
     "SeedBytesUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -7,8 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import ImportingA, RootType
-    from . import a, ast
-    from .a import A
+    from .a import A, a
     from .ast import (
         Acai,
         Animal,
@@ -32,6 +31,7 @@ if typing.TYPE_CHECKING:
         ObjectFieldValue,
         ObjectValue,
         PrimitiveValue,
+        ast,
     )
     from .client import AsyncSeedApi, SeedApi
     from .version import __version__
@@ -64,8 +64,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "RootType": ".types",
     "SeedApi": ".client",
     "__version__": ".version",
-    "a": ".",
-    "ast": ".",
+    "a": ".a",
+    "ast": ".ast",
 }
 
 

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/__init__.py
@@ -7,8 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import ImportingA, RootType
-    from . import a, ast
-    from .a import A
+    from .a import A, a
     from .ast import (
         ContainerValue,
         ContainerValue_List,
@@ -23,6 +22,7 @@ if typing.TYPE_CHECKING:
         T,
         TorU,
         U,
+        ast,
     )
     from .client import AsyncSeedApi, SeedApi
     from .version import __version__
@@ -46,8 +46,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "TorU": ".ast",
     "U": ".ast",
     "__version__": ".version",
-    "a": ".",
-    "ast": ".",
+    "a": ".a",
+    "ast": ".ast",
 }
 
 

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -7,8 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import ImportingA, RootType
-    from . import a, ast
-    from .a import A
+    from .a import A, a
     from .ast import (
         ContainerValue,
         ContainerValue_List,
@@ -23,6 +22,7 @@ if typing.TYPE_CHECKING:
         T,
         TorU,
         U,
+        ast,
     )
     from .client import AsyncSeedApi, SeedApi
     from .version import __version__
@@ -46,8 +46,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "TorU": ".ast",
     "U": ".ast",
     "__version__": ".version",
-    "a": ".",
-    "ast": ".",
+    "a": ".a",
+    "ast": ".ast",
 }
 
 

--- a/seed/python-sdk/client-side-params/src/seed/__init__.py
+++ b/seed/python-sdk/client-side-params/src/seed/__init__.py
@@ -17,9 +17,10 @@ if typing.TYPE_CHECKING:
         SearchResponse,
         UpdateUserRequest,
         User,
+        types,
     )
-    from . import service, types
     from .client import AsyncSeedClientSideParams, SeedClientSideParams
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedClientSideParams": ".client",
@@ -35,8 +36,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UpdateUserRequest": ".types",
     "User": ".types",
     "__version__": ".version",
-    "service": ".",
-    "types": ".",
+    "service": ".service",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/content-type/src/seed/__init__.py
+++ b/seed/python-sdk/content-type/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedContentTypes, SeedContentTypes
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedContentTypes": ".client",
     "SeedContentTypes": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/cross-package-type-names/src/seed/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/__init__.py
@@ -6,10 +6,13 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import commons, folder_a, folder_b, folder_c, folder_d, foo
     from .client import AsyncSeedCrossPackageTypeNames, SeedCrossPackageTypeNames
-    from .commons import Imported
-    from .foo import ImportingType, OptionalString
+    from .commons import Imported, commons
+    from .folder_a import folder_a
+    from .folder_b import folder_b
+    from .folder_c import folder_c
+    from .folder_d import folder_d
+    from .foo import ImportingType, OptionalString, foo
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedCrossPackageTypeNames": ".client",
@@ -18,12 +21,12 @@ _dynamic_imports: typing.Dict[str, str] = {
     "OptionalString": ".foo",
     "SeedCrossPackageTypeNames": ".client",
     "__version__": ".version",
-    "commons": ".",
-    "folder_a": ".",
-    "folder_b": ".",
-    "folder_c": ".",
-    "folder_d": ".",
-    "foo": ".",
+    "commons": ".commons",
+    "folder_a": ".folder_a",
+    "folder_b": ".folder_b",
+    "folder_c": ".folder_c",
+    "folder_d": ".folder_d",
+    "foo": ".foo",
 }
 
 

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_a/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_a/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-    from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+    from .service import Response, service
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_b/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_b/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import common
-    from .common import Foo
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": "."}
+    from .common import Foo, common
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_c/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_c/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import common
-    from .common import Foo
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": "."}
+    from .common import Foo, common
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_d/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_d/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-    from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+    from .service import Response, service
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/custom-auth/src/seed/__init__.py
+++ b/seed/python-sdk/custom-auth/src/seed/__init__.py
@@ -6,9 +6,9 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody
-    from . import custom_auth, errors
+    from .errors import BadRequest, UnauthorizedRequest, UnauthorizedRequestErrorBody, errors
     from .client import AsyncSeedCustomAuth, SeedCustomAuth
+    from .custom_auth import custom_auth
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedCustomAuth": ".client",
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnauthorizedRequest": ".errors",
     "UnauthorizedRequestErrorBody": ".errors",
     "__version__": ".version",
-    "custom_auth": ".",
-    "errors": ".",
+    "custom_auth": ".custom_auth",
+    "errors": ".errors",
 }
 
 

--- a/seed/python-sdk/empty-clients/src/seed/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import level_1
     from .client import AsyncSeedEmptyClients, SeedEmptyClients
+    from .level_1 import level_1
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedEmptyClients": ".client",
     "SeedEmptyClients": ".client",
     "__version__": ".version",
-    "level_1": ".",
+    "level_1": ".level_1",
 }
 
 

--- a/seed/python-sdk/empty-clients/src/seed/level_1/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .types import Address, Person
-    from . import level_2, types
-_dynamic_imports: typing.Dict[str, str] = {"Address": ".types", "Person": ".types", "level_2": ".", "types": "."}
+    from .types import Address, Person, types
+    from .level_2 import level_2
+_dynamic_imports: typing.Dict[str, str] = {
+    "Address": ".types",
+    "Person": ".types",
+    "level_2": ".level_2",
+    "types": ".types",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/empty-clients/src/seed/level_1/level_2/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/level_2/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .types import Address, Person
-    from . import types
-_dynamic_imports: typing.Dict[str, str] = {"Address": ".types", "Person": ".types", "types": "."}
+    from .types import Address, Person, types
+_dynamic_imports: typing.Dict[str, str] = {"Address": ".types", "Person": ".types", "types": ".types"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/enum/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/__init__.py
@@ -7,9 +7,12 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import Color, ColorOrOperand, EnumWithCustom, EnumWithSpecialCharacters, Operand, SpecialEnum
-    from . import headers, inlined_request, path_param, query_param, unknown
     from .client import AsyncSeedEnum, SeedEnum
-    from .unknown import Status
+    from .headers import headers
+    from .inlined_request import inlined_request
+    from .path_param import path_param
+    from .query_param import query_param
+    from .unknown import Status, unknown
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedEnum": ".client",
@@ -22,11 +25,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SpecialEnum": ".types",
     "Status": ".unknown",
     "__version__": ".version",
-    "headers": ".",
-    "inlined_request": ".",
-    "path_param": ".",
-    "query_param": ".",
-    "unknown": ".",
+    "headers": ".headers",
+    "inlined_request": ".inlined_request",
+    "path_param": ".path_param",
+    "query_param": ".query_param",
+    "unknown": ".unknown",
 }
 
 

--- a/seed/python-sdk/enum/strenum/src/seed/__init__.py
+++ b/seed/python-sdk/enum/strenum/src/seed/__init__.py
@@ -7,9 +7,12 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import Color, ColorOrOperand, EnumWithCustom, EnumWithSpecialCharacters, Operand, SpecialEnum
-    from . import headers, inlined_request, path_param, query_param, unknown
     from .client import AsyncSeedEnum, SeedEnum
-    from .unknown import Status
+    from .headers import headers
+    from .inlined_request import inlined_request
+    from .path_param import path_param
+    from .query_param import query_param
+    from .unknown import Status, unknown
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedEnum": ".client",
@@ -22,11 +25,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SpecialEnum": ".types",
     "Status": ".unknown",
     "__version__": ".version",
-    "headers": ".",
-    "inlined_request": ".",
-    "path_param": ".",
-    "query_param": ".",
-    "unknown": ".",
+    "headers": ".headers",
+    "inlined_request": ".inlined_request",
+    "path_param": ".path_param",
+    "query_param": ".query_param",
+    "unknown": ".unknown",
 }
 
 

--- a/seed/python-sdk/error-property/src/seed/__init__.py
+++ b/seed/python-sdk/error-property/src/seed/__init__.py
@@ -6,9 +6,9 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .errors import PropertyBasedErrorTest, PropertyBasedErrorTestBody
-    from . import errors, property_based_error
+    from .errors import PropertyBasedErrorTest, PropertyBasedErrorTestBody, errors
     from .client import AsyncSeedErrorProperty, SeedErrorProperty
+    from .property_based_error import property_based_error
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedErrorProperty": ".client",
@@ -16,8 +16,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "PropertyBasedErrorTestBody": ".errors",
     "SeedErrorProperty": ".client",
     "__version__": ".version",
-    "errors": ".",
-    "property_based_error": ".",
+    "errors": ".errors",
+    "property_based_error": ".property_based_error",
 }
 
 

--- a/seed/python-sdk/errors/src/seed/__init__.py
+++ b/seed/python-sdk/errors/src/seed/__init__.py
@@ -6,10 +6,9 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import commons, simple
     from .client import AsyncSeedErrors, SeedErrors
-    from .commons import BadRequestError, ErrorBody, InternalServerError, NotFoundError
-    from .simple import FooRequest, FooResponse, FooTooLittle, FooTooMuch
+    from .commons import BadRequestError, ErrorBody, InternalServerError, NotFoundError, commons
+    from .simple import FooRequest, FooResponse, FooTooLittle, FooTooMuch, simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedErrors": ".client",
@@ -23,8 +22,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "NotFoundError": ".commons",
     "SeedErrors": ".client",
     "__version__": ".version",
-    "commons": ".",
-    "simple": ".",
+    "commons": ".commons",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/examples/client-filename/src/seed/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/__init__.py
@@ -43,10 +43,14 @@ if typing.TYPE_CHECKING:
         Test_Or,
         Tree,
         Type,
+        types,
     )
-    from . import commons, file, health, service, types
     from .client import AsyncSeedExhaustive, SeedExhaustive
+    from .commons import commons
     from .environment import SeedExhaustiveEnvironment
+    from .file import file
+    from .health import health
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "Actor": ".types",
@@ -89,11 +93,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/client-filename/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/commons/__init__.py
@@ -6,8 +6,17 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .types import Data, Data_Base64, Data_String, EventInfo, EventInfo_Metadata, EventInfo_Tag, Metadata, Tag
-    from . import types
+    from .types import (
+        Data,
+        Data_Base64,
+        Data_String,
+        EventInfo,
+        EventInfo_Metadata,
+        EventInfo_Tag,
+        Metadata,
+        Tag,
+        types,
+    )
 _dynamic_imports: typing.Dict[str, str] = {
     "Data": ".types",
     "Data_Base64": ".types",
@@ -17,7 +26,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/client-filename/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/file/__init__.py
@@ -6,9 +6,13 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import notification, service
-    from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+    from .notification import notification
+    from .service import Filename, service
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/client-filename/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/file/notification/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/client-filename/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/health/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/__init__.py
@@ -43,10 +43,14 @@ if typing.TYPE_CHECKING:
         Test_Or,
         Tree,
         Type,
+        types,
     )
-    from . import commons, file, health, service, types
     from .client import AsyncSeedExamples, SeedExamples
+    from .commons import commons
     from .environment import SeedExamplesEnvironment
+    from .file import file
+    from .health import health
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "Actor": ".types",
@@ -89,11 +93,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/__init__.py
@@ -6,8 +6,17 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .types import Data, Data_Base64, Data_String, EventInfo, EventInfo_Metadata, EventInfo_Tag, Metadata, Tag
-    from . import types
+    from .types import (
+        Data,
+        Data_Base64,
+        Data_String,
+        EventInfo,
+        EventInfo_Metadata,
+        EventInfo_Tag,
+        Metadata,
+        Tag,
+        types,
+    )
 _dynamic_imports: typing.Dict[str, str] = {
     "Data": ".types",
     "Data_Base64": ".types",
@@ -17,7 +26,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/__init__.py
@@ -6,9 +6,13 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import notification, service
-    from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+    from .notification import notification
+    from .service import Filename, service
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/notification/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/health/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/__init__.py
@@ -43,10 +43,14 @@ if typing.TYPE_CHECKING:
         Test_Or,
         Tree,
         Type,
+        types,
     )
-    from . import commons, file, health, service, types
     from .client import AsyncSeedExamples, SeedExamples
+    from .commons import commons
     from .environment import SeedExamplesEnvironment
+    from .file import file
+    from .health import health
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "Actor": ".types",
@@ -89,11 +93,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/no-custom-config/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/commons/__init__.py
@@ -6,8 +6,17 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .types import Data, Data_Base64, Data_String, EventInfo, EventInfo_Metadata, EventInfo_Tag, Metadata, Tag
-    from . import types
+    from .types import (
+        Data,
+        Data_Base64,
+        Data_String,
+        EventInfo,
+        EventInfo_Metadata,
+        EventInfo_Tag,
+        Metadata,
+        Tag,
+        types,
+    )
 _dynamic_imports: typing.Dict[str, str] = {
     "Data": ".types",
     "Data_Base64": ".types",
@@ -17,7 +26,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/no-custom-config/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/file/__init__.py
@@ -6,9 +6,13 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import notification, service
-    from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+    from .notification import notification
+    from .service import Filename, service
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/file/notification/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/health/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/readme/src/seed/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/__init__.py
@@ -43,10 +43,14 @@ if typing.TYPE_CHECKING:
         Test_Or,
         Tree,
         Type,
+        types,
     )
-    from . import commons, file, health, service, types
     from .client import AsyncSeedExamples, SeedExamples
+    from .commons import commons
     from .environment import SeedExamplesEnvironment
+    from .file import file
+    from .health import health
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "Actor": ".types",
@@ -89,11 +93,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/readme/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/commons/__init__.py
@@ -6,8 +6,17 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .types import Data, Data_Base64, Data_String, EventInfo, EventInfo_Metadata, EventInfo_Tag, Metadata, Tag
-    from . import types
+    from .types import (
+        Data,
+        Data_Base64,
+        Data_String,
+        EventInfo,
+        EventInfo_Metadata,
+        EventInfo_Tag,
+        Metadata,
+        Tag,
+        types,
+    )
 _dynamic_imports: typing.Dict[str, str] = {
     "Data": ".types",
     "Data_Base64": ".types",
@@ -17,7 +26,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/examples/readme/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/file/__init__.py
@@ -6,9 +6,13 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import notification, service
-    from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+    from .notification import notification
+    from .service import Filename, service
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/readme/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/file/notification/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/examples/readme/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/health/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+    from .service import service
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/__init__.py
@@ -6,10 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
     from .client_additions import AnotherCustomClient, myCustomFunction
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AnotherCustomClient": ".client_additions",
@@ -18,14 +23,14 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
     "myCustomFunction": ".client_additions",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/__init__.py
@@ -2,9 +2,14 @@
 
 # isort: skip_file
 
-from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+from .types import types
 from .client import AsyncSeedExhaustive, SeedExhaustive
-from .general_errors import BadObjectRequestInfo, BadRequestBody
+from .endpoints import endpoints
+from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+from .inlined_requests import inlined_requests
+from .no_auth import no_auth
+from .no_req_body import no_req_body
+from .req_with_headers import req_with_headers
 from .version import __version__
 
 __all__ = [

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/endpoints/__init__.py
@@ -2,8 +2,16 @@
 
 # isort: skip_file
 
-from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-from .put import Error, ErrorCategory, ErrorCode, PutResponse
+from .container import container
+from .content_type import content_type
+from .enum import enum
+from .http_methods import http_methods
+from .object import object
+from .params import params
+from .primitive import primitive
+from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+from .union import union
+from .urls import urls
 
 __all__ = [
     "Error",

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/types/__init__.py
@@ -2,9 +2,8 @@
 
 # isort: skip_file
 
-from . import docs, enum, object, union
-from .docs import ObjectWithDocs
-from .enum import ErrorWithEnumBody, WeatherReport
+from .docs import ObjectWithDocs, docs
+from .enum import ErrorWithEnumBody, WeatherReport, enum
 from .object import (
     DoubleOptional,
     NestedObjectWithOptionalField,
@@ -17,8 +16,9 @@ from .object import (
     ObjectWithRequiredField,
     ObjectWithRequiredFieldError,
     OptionalAlias,
+    object,
 )
-from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 
 __all__ = [
     "Animal",

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Cat": ".union",
@@ -42,10 +42,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Animal_Cat, Animal_Dog, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Animal_Cat": ".union",
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/__init__.py
@@ -6,9 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import endpoints, general_errors, inlined_requests, no_auth, no_req_body, req_with_headers, types
+    from .types import types
     from .client import AsyncSeedExhaustive, SeedExhaustive
-    from .general_errors import BadObjectRequestInfo, BadRequestBody
+    from .endpoints import endpoints
+    from .general_errors import BadObjectRequestInfo, BadRequestBody, general_errors
+    from .inlined_requests import inlined_requests
+    from .no_auth import no_auth
+    from .no_req_body import no_req_body
+    from .req_with_headers import req_with_headers
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExhaustive": ".client",
@@ -16,13 +21,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/__init__.py
@@ -6,23 +6,31 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import container, content_type, enum, http_methods, object, params, primitive, put, union, urls
-    from .put import Error, ErrorCategory, ErrorCode, PutResponse
+    from .container import container
+    from .content_type import content_type
+    from .enum import enum
+    from .http_methods import http_methods
+    from .object import object
+    from .params import params
+    from .primitive import primitive
+    from .put import Error, ErrorCategory, ErrorCode, PutResponse, put
+    from .union import union
+    from .urls import urls
 _dynamic_imports: typing.Dict[str, str] = {
     "Error": ".put",
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import docs, enum, object, union
-    from .docs import ObjectWithDocs
-    from .enum import ErrorWithEnumBody, WeatherReport
+    from .docs import ObjectWithDocs, docs
+    from .enum import ErrorWithEnumBody, WeatherReport, enum
     from .object import (
         DoubleOptional,
         NestedObjectWithOptionalField,
@@ -21,8 +20,9 @@ if typing.TYPE_CHECKING:
         ObjectWithRequiredField,
         ObjectWithRequiredFieldError,
         OptionalAlias,
+        object,
     )
-    from .union import Animal, Cat, Dog, ErrorWithUnionBody
+    from .union import Animal, Cat, Dog, ErrorWithUnionBody, union
 _dynamic_imports: typing.Dict[str, str] = {
     "Animal": ".union",
     "Cat": ".union",
@@ -42,10 +42,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/extra-properties/src/seed/__init__.py
+++ b/seed/python-sdk/extra-properties/src/seed/__init__.py
@@ -7,9 +7,8 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import Failure
-    from . import user
     from .client import AsyncSeedExtraProperties, SeedExtraProperties
-    from .user import User
+    from .user import User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedExtraProperties": ".client",
@@ -17,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedExtraProperties": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/__init__.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedFileDownload, SeedFileDownload
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedFileDownload": ".client",
     "SeedFileDownload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedFileDownload, SeedFileDownload
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedFileDownload": ".client",
     "SeedFileDownload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/__init__.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedFileUpload, SeedFileUpload
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedFileUpload": ".client",
     "SeedFileUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedFileUpload, SeedFileUpload
     from .service import (
         Id,
@@ -16,6 +15,7 @@ if typing.TYPE_CHECKING:
         MyObject,
         MyObjectWithOptional,
         ObjectType,
+        service,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectType": ".service",
     "SeedFileUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/__init__.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedFileUpload, SeedFileUpload
     from .service import (
         Id,
@@ -21,6 +20,7 @@ if typing.TYPE_CHECKING:
         MyObjectWithOptional,
         MyObjectWithOptionalParams,
         ObjectType,
+        service,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -39,7 +39,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectType": ".service",
     "SeedFileUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/folders/src/seed/__init__.py
+++ b/seed/python-sdk/folders/src/seed/__init__.py
@@ -6,15 +6,16 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import a, folder
+    from .a import a
     from .client import AsyncSeedApi, SeedApi
+    from .folder import folder
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedApi": ".client",
     "SeedApi": ".client",
     "__version__": ".version",
-    "a": ".",
-    "folder": ".",
+    "a": ".a",
+    "folder": ".folder",
 }
 
 

--- a/seed/python-sdk/folders/src/seed/a/__init__.py
+++ b/seed/python-sdk/folders/src/seed/a/__init__.py
@@ -6,8 +6,10 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import b, c, d
-_dynamic_imports: typing.Dict[str, str] = {"b": ".", "c": ".", "d": "."}
+    from .b import b
+    from .c import c
+    from .d import d
+_dynamic_imports: typing.Dict[str, str] = {"b": ".b", "c": ".c", "d": ".d"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/folders/src/seed/a/d/__init__.py
+++ b/seed/python-sdk/folders/src/seed/a/d/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .types import Foo
-    from . import types
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".types", "types": "."}
+    from .types import Foo, types
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".types", "types": ".types"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/folders/src/seed/folder/__init__.py
+++ b/seed/python-sdk/folders/src/seed/folder/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
-    from .service import NotFoundError
-_dynamic_imports: typing.Dict[str, str] = {"NotFoundError": ".service", "service": "."}
+    from .service import NotFoundError, service
+_dynamic_imports: typing.Dict[str, str] = {"NotFoundError": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/http-head/src/seed/__init__.py
+++ b/seed/python-sdk/http-head/src/seed/__init__.py
@@ -6,16 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import user
     from .client import AsyncSeedHttpHead, SeedHttpHead
-    from .user import User
+    from .user import User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedHttpHead": ".client",
     "SeedHttpHead": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/idempotency-headers/src/seed/__init__.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/__init__.py
@@ -6,16 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import payment
     from .client import AsyncSeedIdempotencyHeaders, SeedIdempotencyHeaders
-    from .payment import Currency
+    from .payment import Currency, payment
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedIdempotencyHeaders": ".client",
     "Currency": ".payment",
     "SeedIdempotencyHeaders": ".client",
     "__version__": ".version",
-    "payment": ".",
+    "payment": ".payment",
 }
 
 

--- a/seed/python-sdk/imdb/src/seed/__init__.py
+++ b/seed/python-sdk/imdb/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import imdb
     from .client import AsyncSeedApi, SeedApi
-    from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId
+    from .imdb import CreateMovieRequest, Movie, MovieDoesNotExistError, MovieId, imdb
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedApi": ".client",
@@ -18,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "MovieId": ".imdb",
     "SeedApi": ".client",
     "__version__": ".version",
-    "imdb": ".",
+    "imdb": ".imdb",
 }
 
 

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/__init__.py
@@ -6,19 +6,21 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedInferredAuthExplicit, SeedInferredAuthExplicit
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedInferredAuthExplicit": ".client",
     "SeedInferredAuthExplicit": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/nested/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/__init__.py
@@ -6,19 +6,21 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedInferredAuthImplicitNoExpiry, SeedInferredAuthImplicitNoExpiry
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedInferredAuthImplicitNoExpiry": ".client",
     "SeedInferredAuthImplicitNoExpiry": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/__init__.py
@@ -6,19 +6,21 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedInferredAuthImplicit, SeedInferredAuthImplicit
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedInferredAuthImplicit": ".client",
     "SeedInferredAuthImplicit": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/nested/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/__init__.py
@@ -7,8 +7,8 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import SendResponse
-    from . import headers, inlined, path, query, reference
     from .client import AsyncSeedLiteral, SeedLiteral
+    from .headers import headers
     from .inlined import (
         ANestedLiteral,
         ATopLevelLiteral,
@@ -19,9 +19,11 @@ if typing.TYPE_CHECKING:
         DiscriminatedLiteral_LiteralGeorge,
         SomeAliasedLiteral,
         UndiscriminatedLiteral,
+        inlined,
     )
-    from .query import AliasToPrompt, AliasToStream
-    from .reference import ContainerObject, NestedObjectWithLiterals, SendRequest, SomeLiteral
+    from .path import path
+    from .query import AliasToPrompt, AliasToStream, query
+    from .reference import ContainerObject, NestedObjectWithLiterals, SendRequest, SomeLiteral, reference
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "ANestedLiteral": ".inlined",
@@ -43,11 +45,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SomeLiteral": ".reference",
     "UndiscriminatedLiteral": ".inlined",
     "__version__": ".version",
-    "headers": ".",
-    "inlined": ".",
-    "path": ".",
-    "query": ".",
-    "reference": ".",
+    "headers": ".headers",
+    "inlined": ".inlined",
+    "path": ".path",
+    "query": ".query",
+    "reference": ".reference",
 }
 
 

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/__init__.py
@@ -7,8 +7,8 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import SendResponse
-    from . import headers, inlined, path, query, reference
     from .client import AsyncSeedLiteral, SeedLiteral
+    from .headers import headers
     from .inlined import (
         ANestedLiteral,
         ANestedLiteralParams,
@@ -27,8 +27,10 @@ if typing.TYPE_CHECKING:
         SomeAliasedLiteral,
         UndiscriminatedLiteral,
         UndiscriminatedLiteralParams,
+        inlined,
     )
-    from .query import AliasToPrompt, AliasToStream
+    from .path import path
+    from .query import AliasToPrompt, AliasToStream, query
     from .reference import (
         ContainerObject,
         ContainerObjectParams,
@@ -37,6 +39,7 @@ if typing.TYPE_CHECKING:
         SendRequest,
         SendRequestParams,
         SomeLiteral,
+        reference,
     )
     from .requests import SendResponseParams
     from .version import __version__
@@ -72,11 +75,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UndiscriminatedLiteral": ".inlined",
     "UndiscriminatedLiteralParams": ".inlined",
     "__version__": ".version",
-    "headers": ".",
-    "inlined": ".",
-    "path": ".",
-    "query": ".",
-    "reference": ".",
+    "headers": ".headers",
+    "inlined": ".inlined",
+    "path": ".path",
+    "query": ".query",
+    "reference": ".reference",
 }
 
 

--- a/seed/python-sdk/literals-unions/src/seed/__init__.py
+++ b/seed/python-sdk/literals-unions/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import literals
     from .client import AsyncSeedLiteralsUnions, SeedLiteralsUnions
-    from .literals import LiteralString, UnionOverLiteral
+    from .literals import LiteralString, UnionOverLiteral, literals
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedLiteralsUnions": ".client",
@@ -16,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedLiteralsUnions": ".client",
     "UnionOverLiteral": ".literals",
     "__version__": ".version",
-    "literals": ".",
+    "literals": ".literals",
 }
 
 

--- a/seed/python-sdk/mixed-case/src/seed/__init__.py
+++ b/seed/python-sdk/mixed-case/src/seed/__init__.py
@@ -6,9 +6,17 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedMixedCase, SeedMixedCase
-    from .service import NestedUser, Organization, Resource, ResourceStatus, Resource_Organization, Resource_User, User
+    from .service import (
+        NestedUser,
+        Organization,
+        Resource,
+        ResourceStatus,
+        Resource_Organization,
+        Resource_User,
+        User,
+        service,
+    )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedMixedCase": ".client",
@@ -21,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMixedCase": ".client",
     "User": ".service",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/__init__.py
@@ -6,15 +6,16 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import organization, user
     from .client import AsyncSeedMixedFileDirectory, SeedMixedFileDirectory
+    from .organization import organization
+    from .user import user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedMixedFileDirectory": ".client",
     "SeedMixedFileDirectory": ".client",
     "__version__": ".version",
-    "organization": ".",
-    "user": ".",
+    "organization": ".organization",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import events
-_dynamic_imports: typing.Dict[str, str] = {"events": "."}
+    from .events import events
+_dynamic_imports: typing.Dict[str, str] = {"events": ".events"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/events/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/events/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import metadata
-_dynamic_imports: typing.Dict[str, str] = {"metadata": "."}
+    from .metadata import metadata
+_dynamic_imports: typing.Dict[str, str] = {"metadata": ".metadata"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/__init__.py
@@ -7,10 +7,9 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import Id
-    from . import organization, user
     from .client import AsyncSeedMixedFileDirectory, SeedMixedFileDirectory
-    from .organization import CreateOrganizationRequest, Organization
-    from .user import User
+    from .organization import CreateOrganizationRequest, Organization, organization
+    from .user import User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedMixedFileDirectory": ".client",
@@ -20,8 +19,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMixedFileDirectory": ".client",
     "User": ".user",
     "__version__": ".version",
-    "organization": ".",
-    "user": ".",
+    "organization": ".organization",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/__init__.py
@@ -7,9 +7,8 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import User
-    from . import events
-    from .events import Event
-_dynamic_imports: typing.Dict[str, str] = {"Event": ".events", "User": ".types", "events": "."}
+    from .events import Event, events
+_dynamic_imports: typing.Dict[str, str] = {"Event": ".events", "User": ".types", "events": ".events"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/__init__.py
@@ -7,9 +7,8 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import Event
-    from . import metadata
-    from .metadata import Metadata
-_dynamic_imports: typing.Dict[str, str] = {"Event": ".types", "Metadata": ".metadata", "metadata": "."}
+    from .metadata import Metadata, metadata
+_dynamic_imports: typing.Dict[str, str] = {"Event": ".types", "Metadata": ".metadata", "metadata": ".metadata"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/multi-line-docs/src/seed/__init__.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/__init__.py
@@ -7,9 +7,8 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import Operand
-    from . import user
     from .client import AsyncSeedMultiLineDocs, SeedMultiLineDocs
-    from .user import User
+    from .user import User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedMultiLineDocs": ".client",
@@ -17,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMultiLineDocs": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/__init__.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/__init__.py
@@ -6,17 +6,18 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import ec_2, s_3
     from .client import AsyncSeedMultiUrlEnvironmentNoDefault, SeedMultiUrlEnvironmentNoDefault
+    from .ec_2 import ec_2
     from .environment import SeedMultiUrlEnvironmentNoDefaultEnvironment
+    from .s_3 import s_3
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedMultiUrlEnvironmentNoDefault": ".client",
     "SeedMultiUrlEnvironmentNoDefault": ".client",
     "SeedMultiUrlEnvironmentNoDefaultEnvironment": ".environment",
     "__version__": ".version",
-    "ec_2": ".",
-    "s_3": ".",
+    "ec_2": ".ec_2",
+    "s_3": ".s_3",
 }
 
 

--- a/seed/python-sdk/multi-url-environment/src/seed/__init__.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/__init__.py
@@ -6,17 +6,18 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import ec_2, s_3
     from .client import AsyncSeedMultiUrlEnvironment, SeedMultiUrlEnvironment
+    from .ec_2 import ec_2
     from .environment import SeedMultiUrlEnvironmentEnvironment
+    from .s_3 import s_3
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedMultiUrlEnvironment": ".client",
     "SeedMultiUrlEnvironment": ".client",
     "SeedMultiUrlEnvironmentEnvironment": ".environment",
     "__version__": ".version",
-    "ec_2": ".",
-    "s_3": ".",
+    "ec_2": ".ec_2",
+    "s_3": ".s_3",
 }
 
 

--- a/seed/python-sdk/no-environment/src/seed/__init__.py
+++ b/seed/python-sdk/no-environment/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import dummy
     from .client import AsyncSeedNoEnvironment, SeedNoEnvironment
+    from .dummy import dummy
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedNoEnvironment": ".client",
     "SeedNoEnvironment": ".client",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 

--- a/seed/python-sdk/nullable-optional/src/seed/__init__.py
+++ b/seed/python-sdk/nullable-optional/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import nullable_optional
     from .client import AsyncSeedNullableOptional, SeedNullableOptional
     from .nullable_optional import (
         Address,
@@ -34,6 +33,7 @@ if typing.TYPE_CHECKING:
         UserResponse,
         UserRole,
         UserStatus,
+        nullable_optional,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -65,7 +65,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UserRole": ".nullable_optional",
     "UserStatus": ".nullable_optional",
     "__version__": ".version",
-    "nullable_optional": ".",
+    "nullable_optional": ".nullable_optional",
 }
 
 

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import nullable
     from .client import AsyncSeedNullable, SeedNullable
     from .nullable import (
         Email,
@@ -18,6 +17,7 @@ if typing.TYPE_CHECKING:
         User,
         UserId,
         WeirdNumber,
+        nullable,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -33,7 +33,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UserId": ".nullable",
     "WeirdNumber": ".nullable",
     "__version__": ".version",
-    "nullable": ".",
+    "nullable": ".nullable",
 }
 
 

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/__init__.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import nullable
     from .client import AsyncSeedNullable, SeedNullable
     from .nullable import (
         Email,
@@ -25,6 +24,7 @@ if typing.TYPE_CHECKING:
         UserParams,
         WeirdNumber,
         WeirdNumberParams,
+        nullable,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -47,7 +47,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WeirdNumber": ".nullable",
     "WeirdNumberParams": ".nullable",
     "__version__": ".version",
-    "nullable": ".",
+    "nullable": ".nullable",
 }
 
 

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/__init__.py
@@ -6,19 +6,21 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedOauthClientCredentials, SeedOauthClientCredentials
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedOauthClientCredentials": ".client",
     "SeedOauthClientCredentials": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/__init__.py
@@ -6,19 +6,21 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedOauthClientCredentialsDefault, SeedOauthClientCredentialsDefault
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedOauthClientCredentialsDefault": ".client",
     "SeedOauthClientCredentialsDefault": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/__init__.py
@@ -6,22 +6,24 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import (
         AsyncSeedOauthClientCredentialsEnvironmentVariables,
         SeedOauthClientCredentialsEnvironmentVariables,
     )
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedOauthClientCredentialsEnvironmentVariables": ".client",
     "SeedOauthClientCredentialsEnvironmentVariables": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/__init__.py
@@ -6,17 +6,20 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
+    from .auth import auth
     from .client import AsyncSeedOauthClientCredentials, SeedOauthClientCredentials
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedOauthClientCredentials": ".client",
     "SeedOauthClientCredentials": ".client",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/__init__.py
@@ -6,20 +6,23 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, service, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedOauthClientCredentialsWithVariables, SeedOauthClientCredentialsWithVariables
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .service import service
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedOauthClientCredentialsWithVariables": ".client",
     "SeedOauthClientCredentialsWithVariables": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "service": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "service": ".service",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/__init__.py
@@ -6,19 +6,21 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, nested, nested_no_auth, simple
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedOauthClientCredentials, SeedOauthClientCredentials
+    from .nested import nested
+    from .nested_no_auth import nested_no_auth
+    from .simple import simple
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedOauthClientCredentials": ".client",
     "SeedOauthClientCredentials": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 

--- a/seed/python-sdk/oauth-client-credentials/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/nested/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/nested_no_auth/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+    from .api import api
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/objects-with-imports/src/seed/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/__init__.py
@@ -7,9 +7,9 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import Node, Tree
-    from . import commons, file
     from .client import AsyncSeedObjectsWithImports, SeedObjectsWithImports
-    from .file import File, FileInfo
+    from .commons import commons
+    from .file import File, FileInfo, file
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedObjectsWithImports": ".client",
@@ -19,8 +19,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedObjectsWithImports": ".client",
     "Tree": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
+    "commons": ".commons",
+    "file": ".file",
 }
 
 

--- a/seed/python-sdk/objects-with-imports/src/seed/commons/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/commons/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import metadata
-    from .metadata import Metadata
-_dynamic_imports: typing.Dict[str, str] = {"Metadata": ".metadata", "metadata": "."}
+    from .metadata import Metadata, metadata
+_dynamic_imports: typing.Dict[str, str] = {"Metadata": ".metadata", "metadata": ".metadata"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:

--- a/seed/python-sdk/objects-with-imports/src/seed/file/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/file/__init__.py
@@ -7,13 +7,12 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import File, FileInfo
-    from . import directory
-    from .directory import Directory
+    from .directory import Directory, directory
 _dynamic_imports: typing.Dict[str, str] = {
     "Directory": ".directory",
     "File": ".types",
     "FileInfo": ".types",
-    "directory": ".",
+    "directory": ".directory",
 }
 
 

--- a/seed/python-sdk/optional/src/seed/__init__.py
+++ b/seed/python-sdk/optional/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import optional
     from .client import AsyncSeedObjectsWithImports, SeedObjectsWithImports
+    from .optional import optional
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedObjectsWithImports": ".client",
     "SeedObjectsWithImports": ".client",
     "__version__": ".version",
-    "optional": ".",
+    "optional": ".optional",
 }
 
 

--- a/seed/python-sdk/package-yml/src/seed/__init__.py
+++ b/seed/python-sdk/package-yml/src/seed/__init__.py
@@ -7,15 +7,15 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import EchoRequest
-    from . import service
     from .client import AsyncSeedPackageYml, SeedPackageYml
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedPackageYml": ".client",
     "EchoRequest": ".types",
     "SeedPackageYml": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/__init__.py
@@ -7,7 +7,6 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import UsernameCursor, UsernamePage
-    from . import complex_, inline_users, users
     from .client import AsyncSeedPagination, SeedPagination
     from .complex_ import (
         Conversation,
@@ -21,7 +20,9 @@ if typing.TYPE_CHECKING:
         SingleFilterSearchRequest,
         SingleFilterSearchRequestOperator,
         StartingAfterPaging,
+        complex_,
     )
+    from .inline_users import inline_users
     from .users import (
         ListUsersExtendedOptionalListResponse,
         ListUsersExtendedResponse,
@@ -38,6 +39,7 @@ if typing.TYPE_CHECKING:
         UsernameContainer,
         WithCursor,
         WithPage,
+        users,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -72,9 +74,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WithCursor": ".users",
     "WithPage": ".users",
     "__version__": ".version",
-    "complex_": ".",
-    "inline_users": ".",
-    "users": ".",
+    "complex_": ".complex_",
+    "inline_users": ".inline_users",
+    "users": ".users",
 }
 
 

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import inline_users
     from .inline_users import (
         ListUsersExtendedOptionalListResponse,
         ListUsersExtendedResponse,
@@ -24,6 +23,7 @@ if typing.TYPE_CHECKING:
         Users,
         WithCursor,
         WithPage,
+        inline_users,
     )
 _dynamic_imports: typing.Dict[str, str] = {
     "ListUsersExtendedOptionalListResponse": ".inline_users",
@@ -42,7 +42,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Users": ".inline_users",
     "WithCursor": ".inline_users",
     "WithPage": ".inline_users",
-    "inline_users": ".",
+    "inline_users": ".inline_users",
 }
 
 

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -7,7 +7,6 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import UsernameCursor, UsernamePage
-    from . import complex_, inline_users, users
     from .client import AsyncSeedPagination, SeedPagination
     from .complex_ import (
         Conversation,
@@ -21,7 +20,9 @@ if typing.TYPE_CHECKING:
         SingleFilterSearchRequest,
         SingleFilterSearchRequestOperator,
         StartingAfterPaging,
+        complex_,
     )
+    from .inline_users import inline_users
     from .users import (
         ListUsersExtendedOptionalListResponse,
         ListUsersExtendedResponse,
@@ -38,6 +39,7 @@ if typing.TYPE_CHECKING:
         UsernameContainer,
         WithCursor,
         WithPage,
+        users,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -72,9 +74,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WithCursor": ".users",
     "WithPage": ".users",
     "__version__": ".version",
-    "complex_": ".",
-    "inline_users": ".",
-    "users": ".",
+    "complex_": ".complex_",
+    "inline_users": ".inline_users",
+    "users": ".users",
 }
 
 

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import inline_users
     from .inline_users import (
         ListUsersExtendedOptionalListResponse,
         ListUsersExtendedResponse,
@@ -24,6 +23,7 @@ if typing.TYPE_CHECKING:
         Users,
         WithCursor,
         WithPage,
+        inline_users,
     )
 _dynamic_imports: typing.Dict[str, str] = {
     "ListUsersExtendedOptionalListResponse": ".inline_users",
@@ -42,7 +42,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Users": ".inline_users",
     "WithCursor": ".inline_users",
     "WithPage": ".inline_users",
-    "inline_users": ".",
+    "inline_users": ".inline_users",
 }
 
 

--- a/seed/python-sdk/path-parameters/src/seed/__init__.py
+++ b/seed/python-sdk/path-parameters/src/seed/__init__.py
@@ -6,10 +6,9 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import organizations, user
     from .client import AsyncSeedPathParameters, SeedPathParameters
-    from .organizations import Organization
-    from .user import User
+    from .organizations import Organization, organizations
+    from .user import User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedPathParameters": ".client",
@@ -17,8 +16,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedPathParameters": ".client",
     "User": ".user",
     "__version__": ".version",
-    "organizations": ".",
-    "user": ".",
+    "organizations": ".organizations",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/plain-text/src/seed/__init__.py
+++ b/seed/python-sdk/plain-text/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedPlainText, SeedPlainText
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedPlainText": ".client",
     "SeedPlainText": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/public-object/src/seed/__init__.py
+++ b/seed/python-sdk/public-object/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedPublicObject, SeedPublicObject
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedPublicObject": ".client",
     "SeedPublicObject": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import user
     from .client import AsyncSeedQueryParameters, SeedQueryParameters
-    from .user import NestedUser, User
+    from .user import NestedUser, User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedQueryParameters": ".client",
@@ -16,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedQueryParameters": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/request-parameters/src/seed/__init__.py
+++ b/seed/python-sdk/request-parameters/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import user
     from .client import AsyncSeedRequestParameters, SeedRequestParameters
-    from .user import CreateUsernameBody, NestedUser, User
+    from .user import CreateUsernameBody, NestedUser, User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedRequestParameters": ".client",
@@ -17,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedRequestParameters": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/reserved-keywords/src/seed/__init__.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import package
     from .client import AsyncSeedNurseryApi, SeedNurseryApi
-    from .package import Package, Record
+    from .package import Package, Record, package
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedNurseryApi": ".client",
@@ -16,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Record": ".package",
     "SeedNurseryApi": ".client",
     "__version__": ".version",
-    "package": ".",
+    "package": ".package",
 }
 
 

--- a/seed/python-sdk/response-property/src/seed/__init__.py
+++ b/seed/python-sdk/response-property/src/seed/__init__.py
@@ -7,9 +7,8 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import OptionalStringResponse, StringResponse, WithMetadata
-    from . import service
     from .client import AsyncSeedResponseProperty, SeedResponseProperty
-    from .service import Movie, OptionalWithDocs, Response, WithDocs
+    from .service import Movie, OptionalWithDocs, Response, WithDocs, service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedResponseProperty": ".client",
@@ -22,7 +21,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WithDocs": ".service",
     "WithMetadata": ".types",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/server-sent-event-examples/src/seed/__init__.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/__init__.py
@@ -6,16 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import completions
     from .client import AsyncSeedServerSentEvents, SeedServerSentEvents
-    from .completions import StreamedCompletion
+    from .completions import StreamedCompletion, completions
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedServerSentEvents": ".client",
     "SeedServerSentEvents": ".client",
     "StreamedCompletion": ".completions",
     "__version__": ".version",
-    "completions": ".",
+    "completions": ".completions",
 }
 
 

--- a/seed/python-sdk/server-sent-events/src/seed/__init__.py
+++ b/seed/python-sdk/server-sent-events/src/seed/__init__.py
@@ -6,16 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import completions
     from .client import AsyncSeedServerSentEvents, SeedServerSentEvents
-    from .completions import StreamedCompletion
+    from .completions import StreamedCompletion, completions
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedServerSentEvents": ".client",
     "SeedServerSentEvents": ".client",
     "StreamedCompletion": ".completions",
     "__version__": ".version",
-    "completions": ".",
+    "completions": ".completions",
 }
 
 

--- a/seed/python-sdk/simple-api/src/seed/__init__.py
+++ b/seed/python-sdk/simple-api/src/seed/__init__.py
@@ -6,10 +6,9 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import user
     from .client import AsyncSeedSimpleApi, SeedSimpleApi
     from .environment import SeedSimpleApiEnvironment
-    from .user import User
+    from .user import User, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedSimpleApi": ".client",
@@ -17,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedSimpleApiEnvironment": ".environment",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/single-url-environment-default/src/seed/__init__.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import dummy
     from .client import AsyncSeedSingleUrlEnvironmentDefault, SeedSingleUrlEnvironmentDefault
+    from .dummy import dummy
     from .environment import SeedSingleUrlEnvironmentDefaultEnvironment
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedSingleUrlEnvironmentDefault": ".client",
     "SeedSingleUrlEnvironmentDefaultEnvironment": ".environment",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/__init__.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/__init__.py
@@ -6,8 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import dummy
     from .client import AsyncSeedSingleUrlEnvironmentNoDefault, SeedSingleUrlEnvironmentNoDefault
+    from .dummy import dummy
     from .environment import SeedSingleUrlEnvironmentNoDefaultEnvironment
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedSingleUrlEnvironmentNoDefault": ".client",
     "SeedSingleUrlEnvironmentNoDefaultEnvironment": ".environment",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 

--- a/seed/python-sdk/streaming-parameter/src/seed/__init__.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import dummy
     from .client import AsyncSeedStreaming, SeedStreaming
-    from .dummy import RegularResponse, StreamResponse
+    from .dummy import RegularResponse, StreamResponse, dummy
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedStreaming": ".client",
@@ -16,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedStreaming": ".client",
     "StreamResponse": ".dummy",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/__init__.py
@@ -6,16 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import dummy
     from .client import AsyncSeedStreaming, SeedStreaming
-    from .dummy import StreamResponse
+    from .dummy import StreamResponse, dummy
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedStreaming": ".client",
     "SeedStreaming": ".client",
     "StreamResponse": ".dummy",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/__init__.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/__init__.py
@@ -6,16 +6,15 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import dummy
     from .client import AsyncSeedStreaming, SeedStreaming
-    from .dummy import StreamResponse
+    from .dummy import StreamResponse, dummy
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedStreaming": ".client",
     "SeedStreaming": ".client",
     "StreamResponse": ".dummy",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 

--- a/seed/python-sdk/trace/src/seed/__init__.py
+++ b/seed/python-sdk/trace/src/seed/__init__.py
@@ -6,8 +6,7 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import admin, commons, homepage, lang_server, migration, playlist, problem, submission, sysprop, v_2
-    from .admin import Test, Test_And, Test_Or
+    from .admin import Test, Test_And, Test_Or, admin
     from .client import AsyncSeedTrace, SeedTrace
     from .commons import (
         BinaryTreeNodeAndTreeValue,
@@ -70,10 +69,12 @@ if typing.TYPE_CHECKING:
         VariableValue_NullValue,
         VariableValue_SinglyLinkedListValue,
         VariableValue_StringValue,
+        commons,
     )
     from .environment import SeedTraceEnvironment
-    from .lang_server import LangServerRequest, LangServerResponse
-    from .migration import Migration, MigrationStatus
+    from .homepage import homepage
+    from .lang_server import LangServerRequest, LangServerResponse, lang_server
+    from .migration import Migration, MigrationStatus, migration
     from .playlist import (
         Playlist,
         PlaylistCreateRequest,
@@ -84,6 +85,7 @@ if typing.TYPE_CHECKING:
         ReservedKeywordEnum,
         UnauthorizedError,
         UpdatePlaylistRequest,
+        playlist,
     )
     from .problem import (
         CreateProblemError,
@@ -103,6 +105,7 @@ if typing.TYPE_CHECKING:
         ProblemInfo,
         UpdateProblemResponse,
         VariableTypeAndName,
+        problem,
     )
     from .submission import (
         ActualResult,
@@ -249,7 +252,10 @@ if typing.TYPE_CHECKING:
         WorkspaceSubmissionUpdateInfo_TracedV2,
         WorkspaceSubmitRequest,
         WorkspaceTracedUpdate,
+        submission,
     )
+    from .sysprop import sysprop
+    from .v_2 import v_2
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "ActualResult": ".submission",
@@ -493,16 +499,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WorkspaceSubmitRequest": ".submission",
     "WorkspaceTracedUpdate": ".submission",
     "__version__": ".version",
-    "admin": ".",
-    "commons": ".",
-    "homepage": ".",
-    "lang_server": ".",
-    "migration": ".",
-    "playlist": ".",
-    "problem": ".",
-    "submission": ".",
-    "sysprop": ".",
-    "v_2": ".",
+    "admin": ".admin",
+    "commons": ".commons",
+    "homepage": ".homepage",
+    "lang_server": ".lang_server",
+    "migration": ".migration",
+    "playlist": ".playlist",
+    "problem": ".problem",
+    "submission": ".submission",
+    "sysprop": ".sysprop",
+    "v_2": ".v_2",
 }
 
 

--- a/seed/python-sdk/trace/src/seed/v_2/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import problem, v_3
     from .problem import (
         AssertCorrectnessCheck,
         AssertCorrectnessCheck_Custom,
@@ -62,7 +61,9 @@ if typing.TYPE_CHECKING:
         VoidFunctionDefinitionThatTakesActualResult,
         VoidFunctionSignature,
         VoidFunctionSignatureThatTakesActualResult,
+        problem,
     )
+    from .v_3 import v_3
 _dynamic_imports: typing.Dict[str, str] = {
     "AssertCorrectnessCheck": ".problem",
     "AssertCorrectnessCheck_Custom": ".problem",
@@ -118,8 +119,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VoidFunctionDefinitionThatTakesActualResult": ".problem",
     "VoidFunctionSignature": ".problem",
     "VoidFunctionSignatureThatTakesActualResult": ".problem",
-    "problem": ".",
-    "v_3": ".",
+    "problem": ".problem",
+    "v_3": ".v_3",
 }
 
 

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import problem
     from .problem import (
         AssertCorrectnessCheck,
         AssertCorrectnessCheck_Custom,
@@ -62,6 +61,7 @@ if typing.TYPE_CHECKING:
         VoidFunctionDefinitionThatTakesActualResult,
         VoidFunctionSignature,
         VoidFunctionSignatureThatTakesActualResult,
+        problem,
     )
 _dynamic_imports: typing.Dict[str, str] = {
     "AssertCorrectnessCheck": ".problem",
@@ -118,7 +118,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VoidFunctionDefinitionThatTakesActualResult": ".problem",
     "VoidFunctionSignature": ".problem",
     "VoidFunctionSignatureThatTakesActualResult": ".problem",
-    "problem": ".",
+    "problem": ".problem",
 }
 
 

--- a/seed/python-sdk/undiscriminated-unions/src/seed/__init__.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import union
     from .client import AsyncSeedUndiscriminatedUnions, SeedUndiscriminatedUnions
     from .union import (
         Key,
@@ -24,6 +23,7 @@ if typing.TYPE_CHECKING:
         UnionWithDuplicateTypes,
         UnionWithIdenticalPrimitives,
         UnionWithIdenticalStrings,
+        union,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -45,7 +45,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnionWithIdenticalPrimitives": ".union",
     "UnionWithIdenticalStrings": ".union",
     "__version__": ".version",
-    "union": ".",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/unions/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/__init__.py
@@ -63,8 +63,8 @@ if typing.TYPE_CHECKING:
         UnionWithoutKey_Foo,
         Union_Bar,
         Union_Foo,
+        types,
     )
-    from . import bigunion, types, union
     from .bigunion import (
         ActiveDiamond,
         AttractiveScript,
@@ -125,9 +125,10 @@ if typing.TYPE_CHECKING:
         UniqueStress,
         UnwillingSmoke,
         VibrantExcitement,
+        bigunion,
     )
     from .client import AsyncSeedUnions, SeedUnions
-    from .union import Circle, GetShapeRequest, Shape, Shape_Circle, Shape_Square, Square, WithName
+    from .union import Circle, GetShapeRequest, Shape, Shape_Circle, Shape_Square, Square, WithName, union
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "ActiveDiamond": ".bigunion",
@@ -255,9 +256,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VibrantExcitement": ".bigunion",
     "WithName": ".union",
     "__version__": ".version",
-    "bigunion": ".",
-    "types": ".",
-    "union": ".",
+    "bigunion": ".bigunion",
+    "types": ".types",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/__init__.py
@@ -63,8 +63,8 @@ if typing.TYPE_CHECKING:
         UnionWithTime,
         UnionWithoutKey,
         ValueUnionWithTime,
+        types,
     )
-    from . import bigunion, types, union
     from .bigunion import (
         ActiveDiamond,
         ActiveDiamondBigUnion,
@@ -125,9 +125,10 @@ if typing.TYPE_CHECKING:
         UnwillingSmokeBigUnion,
         VibrantExcitement,
         VibrantExcitementBigUnion,
+        bigunion,
     )
     from .client import AsyncSeedUnions, SeedUnions
-    from .union import Circle, CircleShape, GetShapeRequest, Shape, Square, SquareShape, WithName
+    from .union import Circle, CircleShape, GetShapeRequest, Shape, Square, SquareShape, WithName, union
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "ActiveDiamond": ".bigunion",
@@ -255,9 +256,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VibrantExcitementBigUnion": ".bigunion",
     "WithName": ".union",
     "__version__": ".version",
-    "bigunion": ".",
-    "types": ".",
-    "union": ".",
+    "bigunion": ".bigunion",
+    "types": ".types",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/unions/union-utils/src/seed/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/__init__.py
@@ -26,8 +26,8 @@ if typing.TYPE_CHECKING:
         UnionWithSubTypes,
         UnionWithTime,
         UnionWithoutKey,
+        types,
     )
-    from . import bigunion, types, union
     from .bigunion import (
         ActiveDiamond,
         AttractiveScript,
@@ -59,9 +59,10 @@ if typing.TYPE_CHECKING:
         UniqueStress,
         UnwillingSmoke,
         VibrantExcitement,
+        bigunion,
     )
     from .client import AsyncSeedUnions, SeedUnions
-    from .union import Circle, GetShapeRequest, Shape, Square, WithName
+    from .union import Circle, GetShapeRequest, Shape, Square, WithName, union
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "ActiveDiamond": ".bigunion",
@@ -121,9 +122,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VibrantExcitement": ".bigunion",
     "WithName": ".union",
     "__version__": ".version",
-    "bigunion": ".",
-    "types": ".",
-    "union": ".",
+    "bigunion": ".bigunion",
+    "types": ".types",
+    "union": ".union",
 }
 
 

--- a/seed/python-sdk/unknown/src/seed/__init__.py
+++ b/seed/python-sdk/unknown/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import unknown
     from .client import AsyncSeedUnknownAsAny, SeedUnknownAsAny
-    from .unknown import MyAlias, MyObject
+    from .unknown import MyAlias, MyObject, unknown
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedUnknownAsAny": ".client",
@@ -16,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "MyObject": ".unknown",
     "SeedUnknownAsAny": ".client",
     "__version__": ".version",
-    "unknown": ".",
+    "unknown": ".unknown",
 }
 
 

--- a/seed/python-sdk/variables/src/seed/__init__.py
+++ b/seed/python-sdk/variables/src/seed/__init__.py
@@ -6,14 +6,14 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import service
     from .client import AsyncSeedVariables, SeedVariables
+    from .service import service
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedVariables": ".client",
     "SeedVariables": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 

--- a/seed/python-sdk/version-no-default/src/seed/__init__.py
+++ b/seed/python-sdk/version-no-default/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import user
     from .client import AsyncSeedVersion, SeedVersion
-    from .user import User, UserId
+    from .user import User, UserId, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedVersion": ".client",
@@ -16,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "User": ".user",
     "UserId": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/version/src/seed/__init__.py
+++ b/seed/python-sdk/version/src/seed/__init__.py
@@ -6,9 +6,8 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import user
     from .client import AsyncSeedVersion, SeedVersion
-    from .user import User, UserId
+    from .user import User, UserId, user
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedVersion": ".client",
@@ -16,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "User": ".user",
     "UserId": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/__init__.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import realtime
     from .client import AsyncSeedWebsocketBearerAuth, SeedWebsocketBearerAuth
     from .realtime import (
         ReceiveEvent,
@@ -16,6 +15,7 @@ if typing.TYPE_CHECKING:
         SendEvent,
         SendEvent2,
         SendSnakeCase,
+        realtime,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendEvent2": ".realtime",
     "SendSnakeCase": ".realtime",
     "__version__": ".version",
-    "realtime": ".",
+    "realtime": ".realtime",
 }
 
 

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/__init__.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/__init__.py
@@ -6,8 +6,7 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import auth, realtime
-    from .auth import TokenResponse
+    from .auth import TokenResponse, auth
     from .client import AsyncSeedWebsocketAuth, SeedWebsocketAuth
     from .realtime import (
         ReceiveEvent,
@@ -17,6 +16,7 @@ if typing.TYPE_CHECKING:
         SendEvent,
         SendEvent2,
         SendSnakeCase,
+        realtime,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -31,8 +31,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendSnakeCase": ".realtime",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "realtime": ".",
+    "auth": ".auth",
+    "realtime": ".realtime",
 }
 
 

--- a/seed/python-sdk/websocket/websocket-base/src/seed/__init__.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import realtime
     from .client import AsyncSeedWebsocket, SeedWebsocket
     from .realtime import (
         ReceiveEvent,
@@ -16,6 +15,7 @@ if typing.TYPE_CHECKING:
         SendEvent,
         SendEvent2,
         SendSnakeCase,
+        realtime,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendEvent2": ".realtime",
     "SendSnakeCase": ".realtime",
     "__version__": ".version",
-    "realtime": ".",
+    "realtime": ".realtime",
 }
 
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/__init__.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/__init__.py
@@ -6,7 +6,6 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from . import realtime
     from .client import AsyncSeedWebsocket, SeedWebsocket
     from .realtime import (
         ReceiveEvent,
@@ -16,6 +15,7 @@ if typing.TYPE_CHECKING:
         SendEvent,
         SendEvent2,
         SendSnakeCase,
+        realtime,
     )
     from .version import __version__
 _dynamic_imports: typing.Dict[str, str] = {
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendEvent2": ".realtime",
     "SendSnakeCase": ".realtime",
     "__version__": ".version",
-    "realtime": ".",
+    "realtime": ".realtime",
 }
 
 


### PR DESCRIPTION
## Description
See title, should fix issues like https://github.com/merge-api/merge-python-client/issues/141 where a library is looking at getattr.

## Changes Made
- Namespace exports reference the submodule instead of `.`

## Testing
- Existing seed tests