### PR TITLE
fix(python): Dynamic imports specially handle submodules

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.29.2
+  changelogEntry:
+    - summary: |
+        Exports in init files always reference the submodule instead of the current module.
+        This should fix infinite recursion in libraries that inspect getattr, like freezegun.
+      type: fix
+  createdAt: "2025-09-22"
+  irVersion: 59
+
 - version: 4.29.1
   changelogEntry:
     - summary: Fixes issue where colliding classes were not lazily imported correctly.

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
-- version: 4.29.2
+- version: 4.29.2-rc0
   changelogEntry:
     - summary: |
         Exports in init files always reference the submodule instead of the current module.

--- a/generators/python/src/fern_python/codegen/module_manager.py
+++ b/generators/python/src/fern_python/codegen/module_manager.py
@@ -69,7 +69,7 @@ def _write_attr_function(writer: AST.Writer) -> None:
             writer.write_line("module = import_module(module_name, __package__)")
 
             # Check if we're importing a submodule (pattern: attr "foo" maps to ".foo")
-            writer.write_line('if module_name == f"{attr_name}":')
+            writer.write_line('if module_name == f".{attr_name}":')
             with writer.indent():
                 writer.write_line("return module")
             # Otherwise, return specific attribute from the module (like "from .module import Class")

--- a/seed/python-sdk/accept-header/src/seed/__init__.py
+++ b/seed/python-sdk/accept-header/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "NotFoundError": ".service",
     "SeedAccept": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/accept-header/src/seed/core/__init__.py
+++ b/seed/python-sdk/accept-header/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/accept-header/src/seed/service/__init__.py
+++ b/seed/python-sdk/accept-header/src/seed/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/accept-header/src/seed/service/errors/__init__.py
+++ b/seed/python-sdk/accept-header/src/seed/service/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/types/__init__.py
@@ -18,8 +18,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/__init__.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/types/__init__.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/types/__init__.py
@@ -18,8 +18,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias/src/seed/__init__.py
+++ b/seed/python-sdk/alias/src/seed/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias/src/seed/core/__init__.py
+++ b/seed/python-sdk/alias/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/alias/src/seed/types/__init__.py
+++ b/seed/python-sdk/alias/src/seed/types/__init__.py
@@ -18,8 +18,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/any-auth/src/seed/__init__.py
+++ b/seed/python-sdk/any-auth/src/seed/__init__.py
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "TokenResponse": ".auth",
     "User": ".user",
     "__version__": ".version",
-    "auth": ".",
-    "user": ".",
+    "auth": ".auth",
+    "user": ".user",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/any-auth/src/seed/auth/__init__.py
+++ b/seed/python-sdk/any-auth/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/any-auth/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/any-auth/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/any-auth/src/seed/core/__init__.py
+++ b/seed/python-sdk/any-auth/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/any-auth/src/seed/user/__init__.py
+++ b/seed/python-sdk/any-auth/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/any-auth/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/any-auth/src/seed/user/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/api-wide-base-path/src/seed/__init__.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedApiWideBasePath": ".client",
     "SeedApiWideBasePath": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/__init__.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/__init__.py
@@ -21,12 +21,12 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedAudiences": ".client",
     "SeedAudiencesEnvironment": ".environment",
     "__version__": ".version",
-    "commons": ".",
-    "folder_a": ".",
-    "folder_b": ".",
-    "folder_c": ".",
-    "folder_d": ".",
-    "foo": ".",
+    "commons": ".commons",
+    "folder_a": ".folder_a",
+    "folder_b": ".folder_b",
+    "folder_c": ".folder_c",
+    "folder_d": ".folder_d",
+    "foo": ".foo",
 }
 
 
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/commons/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/commons/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/commons/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/core/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_a/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_a/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import service
     from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_a/service/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_a/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_a/service/types/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_a/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_b/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_b/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import common
     from .common import Foo
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_b/common/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_b/common/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_b/common/types/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_b/common/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_c/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_c/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import common
     from .common import FolderCFoo
-_dynamic_imports: typing.Dict[str, str] = {"FolderCFoo": ".common", "common": "."}
+_dynamic_imports: typing.Dict[str, str] = {"FolderCFoo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_c/common/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_c/common/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_c/common/types/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_c/common/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_d/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_d/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import service
     from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_d/service/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_d/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/folder_d/service/types/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/folder_d/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/foo/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/foo/__init__.py
@@ -20,8 +20,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/audiences/src/seed/foo/types/__init__.py
+++ b/seed/python-sdk/audiences/src/seed/foo/types/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/auth-environment-variables/src/seed/__init__.py
+++ b/seed/python-sdk/auth-environment-variables/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedAuthEnvironmentVariables": ".client",
     "SeedAuthEnvironmentVariables": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/auth-environment-variables/src/seed/core/__init__.py
+++ b/seed/python-sdk/auth-environment-variables/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/__init__.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/__init__.py
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnauthorizedRequest": ".errors",
     "UnauthorizedRequestErrorBody": ".errors",
     "__version__": ".version",
-    "basic_auth": ".",
-    "errors": ".",
+    "basic_auth": ".basic_auth",
+    "errors": ".errors",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/__init__.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/errors/__init__.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/errors/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/errors/errors/__init__.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/errors/errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/errors/types/__init__.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth/src/seed/__init__.py
+++ b/seed/python-sdk/basic-auth/src/seed/__init__.py
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnauthorizedRequest": ".errors",
     "UnauthorizedRequestErrorBody": ".errors",
     "__version__": ".version",
-    "basic_auth": ".",
-    "errors": ".",
+    "basic_auth": ".basic_auth",
+    "errors": ".errors",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth/src/seed/core/__init__.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth/src/seed/errors/__init__.py
+++ b/seed/python-sdk/basic-auth/src/seed/errors/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth/src/seed/errors/errors/__init__.py
+++ b/seed/python-sdk/basic-auth/src/seed/errors/errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/basic-auth/src/seed/errors/types/__init__.py
+++ b/seed/python-sdk/basic-auth/src/seed/errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/__init__.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedBearerTokenEnvironmentVariable": ".client",
     "SeedBearerTokenEnvironmentVariable": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/__init__.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/bytes-download/src/seed/__init__.py
+++ b/seed/python-sdk/bytes-download/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedBytesDownload": ".client",
     "SeedBytesDownload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/bytes-download/src/seed/core/__init__.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/bytes-upload/src/seed/__init__.py
+++ b/seed/python-sdk/bytes-upload/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedBytesUpload": ".client",
     "SeedBytesUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/bytes-upload/src/seed/core/__init__.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -64,8 +64,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "RootType": ".types",
     "SeedApi": ".client",
     "__version__": ".version",
-    "a": ".",
-    "ast": ".",
+    "a": ".a",
+    "ast": ".ast",
 }
 
 
@@ -75,8 +75,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/a/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/a/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/a/types/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/a/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/__init__.py
@@ -62,8 +62,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/ast/types/__init__.py
@@ -55,8 +55,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/types/__init__.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/__init__.py
@@ -46,8 +46,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "TorU": ".ast",
     "U": ".ast",
     "__version__": ".version",
-    "a": ".",
-    "ast": ".",
+    "a": ".a",
+    "ast": ".ast",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/a/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/a/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/a/types/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/a/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/ast/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/ast/__init__.py
@@ -44,8 +44,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/ast/types/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/ast/types/__init__.py
@@ -37,8 +37,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -46,8 +46,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "TorU": ".ast",
     "U": ".ast",
     "__version__": ".version",
-    "a": ".",
-    "ast": ".",
+    "a": ".a",
+    "ast": ".ast",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/a/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/a/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/a/types/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/a/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/ast/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/ast/__init__.py
@@ -44,8 +44,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/ast/types/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/ast/types/__init__.py
@@ -37,8 +37,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/types/__init__.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/client-side-params/src/seed/__init__.py
+++ b/seed/python-sdk/client-side-params/src/seed/__init__.py
@@ -35,8 +35,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UpdateUserRequest": ".types",
     "User": ".types",
     "__version__": ".version",
-    "service": ".",
-    "types": ".",
+    "service": ".service",
+    "types": ".types",
 }
 
 
@@ -46,8 +46,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/client-side-params/src/seed/core/__init__.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/client-side-params/src/seed/types/__init__.py
+++ b/seed/python-sdk/client-side-params/src/seed/types/__init__.py
@@ -38,8 +38,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/client-side-params/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/client-side-params/src/seed/types/types/__init__.py
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/content-type/src/seed/__init__.py
+++ b/seed/python-sdk/content-type/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedContentTypes": ".client",
     "SeedContentTypes": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/content-type/src/seed/core/__init__.py
+++ b/seed/python-sdk/content-type/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/__init__.py
@@ -18,12 +18,12 @@ _dynamic_imports: typing.Dict[str, str] = {
     "OptionalString": ".foo",
     "SeedCrossPackageTypeNames": ".client",
     "__version__": ".version",
-    "commons": ".",
-    "folder_a": ".",
-    "folder_b": ".",
-    "folder_c": ".",
-    "folder_d": ".",
-    "foo": ".",
+    "commons": ".commons",
+    "folder_a": ".folder_a",
+    "folder_b": ".folder_b",
+    "folder_c": ".folder_c",
+    "folder_d": ".folder_d",
+    "foo": ".foo",
 }
 
 
@@ -33,8 +33,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/commons/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/commons/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/commons/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_a/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_a/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import service
     from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_a/service/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_a/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_a/service/types/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_a/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_b/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_b/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import common
     from .common import Foo
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_b/common/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_b/common/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_b/common/types/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_b/common/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_c/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_c/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import common
     from .common import Foo
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".common", "common": ".common"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_c/common/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_c/common/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_c/common/types/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_c/common/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_d/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_d/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import service
     from .service import Response
-_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Response": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_d/service/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_d/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/folder_d/service/types/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/folder_d/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/foo/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/foo/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/cross-package-type-names/src/seed/foo/types/__init__.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/foo/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/custom-auth/src/seed/__init__.py
+++ b/seed/python-sdk/custom-auth/src/seed/__init__.py
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnauthorizedRequest": ".errors",
     "UnauthorizedRequestErrorBody": ".errors",
     "__version__": ".version",
-    "custom_auth": ".",
-    "errors": ".",
+    "custom_auth": ".custom_auth",
+    "errors": ".errors",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/custom-auth/src/seed/core/__init__.py
+++ b/seed/python-sdk/custom-auth/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/custom-auth/src/seed/errors/__init__.py
+++ b/seed/python-sdk/custom-auth/src/seed/errors/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/custom-auth/src/seed/errors/errors/__init__.py
+++ b/seed/python-sdk/custom-auth/src/seed/errors/errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/custom-auth/src/seed/errors/types/__init__.py
+++ b/seed/python-sdk/custom-auth/src/seed/errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedEmptyClients": ".client",
     "SeedEmptyClients": ".client",
     "__version__": ".version",
-    "level_1": ".",
+    "level_1": ".level_1",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/core/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/level_1/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/__init__.py
@@ -8,7 +8,12 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from .types import Address, Person
     from . import level_2, types
-_dynamic_imports: typing.Dict[str, str] = {"Address": ".types", "Person": ".types", "level_2": ".", "types": "."}
+_dynamic_imports: typing.Dict[str, str] = {
+    "Address": ".types",
+    "Person": ".types",
+    "level_2": ".level_2",
+    "types": ".types",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/level_1/level_2/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/level_2/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from .types import Address, Person
     from . import types
-_dynamic_imports: typing.Dict[str, str] = {"Address": ".types", "Person": ".types", "types": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Address": ".types", "Person": ".types", "types": ".types"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/level_1/level_2/types/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/level_2/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/level_1/level_2/types/types/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/level_2/types/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/level_1/types/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/empty-clients/src/seed/level_1/types/types/__init__.py
+++ b/seed/python-sdk/empty-clients/src/seed/level_1/types/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/__init__.py
@@ -22,11 +22,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SpecialEnum": ".types",
     "Status": ".unknown",
     "__version__": ".version",
-    "headers": ".",
-    "inlined_request": ".",
-    "path_param": ".",
-    "query_param": ".",
-    "unknown": ".",
+    "headers": ".headers",
+    "inlined_request": ".inlined_request",
+    "path_param": ".path_param",
+    "query_param": ".query_param",
+    "unknown": ".unknown",
 }
 
 
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/no-custom-config/src/seed/unknown/__init__.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/unknown/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/no-custom-config/src/seed/unknown/types/__init__.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/unknown/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/strenum/src/seed/__init__.py
+++ b/seed/python-sdk/enum/strenum/src/seed/__init__.py
@@ -22,11 +22,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SpecialEnum": ".types",
     "Status": ".unknown",
     "__version__": ".version",
-    "headers": ".",
-    "inlined_request": ".",
-    "path_param": ".",
-    "query_param": ".",
-    "unknown": ".",
+    "headers": ".headers",
+    "inlined_request": ".inlined_request",
+    "path_param": ".path_param",
+    "query_param": ".query_param",
+    "unknown": ".unknown",
 }
 
 
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/strenum/src/seed/core/__init__.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/strenum/src/seed/types/__init__.py
+++ b/seed/python-sdk/enum/strenum/src/seed/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/strenum/src/seed/unknown/__init__.py
+++ b/seed/python-sdk/enum/strenum/src/seed/unknown/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/enum/strenum/src/seed/unknown/types/__init__.py
+++ b/seed/python-sdk/enum/strenum/src/seed/unknown/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/error-property/src/seed/__init__.py
+++ b/seed/python-sdk/error-property/src/seed/__init__.py
@@ -16,8 +16,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "PropertyBasedErrorTestBody": ".errors",
     "SeedErrorProperty": ".client",
     "__version__": ".version",
-    "errors": ".",
-    "property_based_error": ".",
+    "errors": ".errors",
+    "property_based_error": ".property_based_error",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/error-property/src/seed/core/__init__.py
+++ b/seed/python-sdk/error-property/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/error-property/src/seed/errors/__init__.py
+++ b/seed/python-sdk/error-property/src/seed/errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/error-property/src/seed/errors/errors/__init__.py
+++ b/seed/python-sdk/error-property/src/seed/errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/error-property/src/seed/errors/types/__init__.py
+++ b/seed/python-sdk/error-property/src/seed/errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/__init__.py
+++ b/seed/python-sdk/errors/src/seed/__init__.py
@@ -23,8 +23,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "NotFoundError": ".commons",
     "SeedErrors": ".client",
     "__version__": ".version",
-    "commons": ".",
-    "simple": ".",
+    "commons": ".commons",
+    "simple": ".simple",
 }
 
 
@@ -34,8 +34,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/commons/__init__.py
+++ b/seed/python-sdk/errors/src/seed/commons/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/commons/errors/__init__.py
+++ b/seed/python-sdk/errors/src/seed/commons/errors/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/errors/src/seed/commons/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/core/__init__.py
+++ b/seed/python-sdk/errors/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/simple/__init__.py
+++ b/seed/python-sdk/errors/src/seed/simple/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/simple/errors/__init__.py
+++ b/seed/python-sdk/errors/src/seed/simple/errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/errors/src/seed/simple/types/__init__.py
+++ b/seed/python-sdk/errors/src/seed/simple/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/__init__.py
@@ -89,11 +89,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 
@@ -103,8 +103,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/commons/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/commons/types/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/commons/types/types/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/commons/types/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/core/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/file/__init__.py
@@ -8,7 +8,11 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import notification, service
     from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/file/notification/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/file/service/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/file/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/file/service/types/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/file/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/health/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/types/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/__init__.py
@@ -90,8 +90,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/types/errors/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/client-filename/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/types/types/__init__.py
@@ -72,8 +72,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/__init__.py
@@ -89,11 +89,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 
@@ -103,8 +103,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/types/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/commons/types/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/__init__.py
@@ -8,7 +8,11 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import notification, service
     from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/notification/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/service/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/service/types/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/file/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/health/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/__init__.py
@@ -90,8 +90,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/errors/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/types/types/__init__.py
@@ -72,8 +72,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/__init__.py
@@ -89,11 +89,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 
@@ -103,8 +103,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/commons/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/types/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/commons/types/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/file/__init__.py
@@ -8,7 +8,11 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import notification, service
     from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/file/notification/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/file/service/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/file/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/file/service/types/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/file/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/health/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/__init__.py
@@ -90,8 +90,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/errors/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/no-custom-config/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/types/types/__init__.py
@@ -72,8 +72,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/__init__.py
@@ -89,11 +89,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Tree": ".types",
     "Type": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
-    "health": ".",
-    "service": ".",
-    "types": ".",
+    "commons": ".commons",
+    "file": ".file",
+    "health": ".health",
+    "service": ".service",
+    "types": ".types",
 }
 
 
@@ -103,8 +103,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/commons/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/commons/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EventInfo_Tag": ".types",
     "Metadata": ".types",
     "Tag": ".types",
-    "types": ".",
+    "types": ".types",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/commons/types/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/commons/types/types/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/commons/types/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/core/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/file/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/file/__init__.py
@@ -8,7 +8,11 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import notification, service
     from .service import Filename
-_dynamic_imports: typing.Dict[str, str] = {"Filename": ".service", "notification": ".", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {
+    "Filename": ".service",
+    "notification": ".notification",
+    "service": ".service",
+}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/file/notification/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/file/notification/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/file/service/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/file/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/file/service/types/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/file/service/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/health/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/health/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import service
-_dynamic_imports: typing.Dict[str, str] = {"service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/types/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/__init__.py
@@ -90,8 +90,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/types/errors/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/examples/readme/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/examples/readme/src/seed/types/types/__init__.py
@@ -72,8 +72,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/__init__.py
@@ -18,14 +18,14 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
     "myCustomFunction": ".client_additions",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -35,8 +35,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/__init__.py
@@ -65,8 +65,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/__init__.py
@@ -42,10 +42,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -55,8 +55,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/types/union/types/__init__.py
@@ -18,8 +18,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/__init__.py
@@ -65,8 +65,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/__init__.py
@@ -44,10 +44,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/types/union/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/__init__.py
@@ -16,13 +16,13 @@ _dynamic_imports: typing.Dict[str, str] = {
     "BadRequestBody": ".general_errors",
     "SeedExhaustive": ".client",
     "__version__": ".version",
-    "endpoints": ".",
-    "general_errors": ".",
-    "inlined_requests": ".",
-    "no_auth": ".",
-    "no_req_body": ".",
-    "req_with_headers": ".",
-    "types": ".",
+    "endpoints": ".endpoints",
+    "general_errors": ".general_errors",
+    "inlined_requests": ".inlined_requests",
+    "no_auth": ".no_auth",
+    "no_req_body": ".no_req_body",
+    "req_with_headers": ".req_with_headers",
+    "types": ".types",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/__init__.py
@@ -13,16 +13,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ErrorCategory": ".put",
     "ErrorCode": ".put",
     "PutResponse": ".put",
-    "container": ".",
-    "content_type": ".",
-    "enum": ".",
-    "http_methods": ".",
-    "object": ".",
-    "params": ".",
-    "primitive": ".",
-    "put": ".",
-    "union": ".",
-    "urls": ".",
+    "container": ".container",
+    "content_type": ".content_type",
+    "enum": ".enum",
+    "http_methods": ".http_methods",
+    "object": ".object",
+    "params": ".params",
+    "primitive": ".primitive",
+    "put": ".put",
+    "union": ".union",
+    "urls": ".urls",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/put/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/put/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/put/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/endpoints/put/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/general_errors/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/general_errors/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/general_errors/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/general_errors/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/general_errors/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/general_errors/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/__init__.py
@@ -42,10 +42,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectWithRequiredFieldError": ".object",
     "OptionalAlias": ".object",
     "WeatherReport": ".enum",
-    "docs": ".",
-    "enum": ".",
-    "object": ".",
-    "union": ".",
+    "docs": ".docs",
+    "enum": ".enum",
+    "object": ".object",
+    "union": ".union",
 }
 
 
@@ -55,8 +55,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/docs/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/docs/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/docs/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/docs/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/enum/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/enum/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/enum/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/enum/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/enum/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/enum/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/__init__.py
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/errors/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/object/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/errors/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/types/__init__.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/types/union/types/__init__.py
@@ -18,8 +18,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extends/src/seed/__init__.py
+++ b/seed/python-sdk/extends/src/seed/__init__.py
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extends/src/seed/core/__init__.py
+++ b/seed/python-sdk/extends/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extends/src/seed/types/__init__.py
+++ b/seed/python-sdk/extends/src/seed/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extra-properties/src/seed/__init__.py
+++ b/seed/python-sdk/extra-properties/src/seed/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedExtraProperties": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extra-properties/src/seed/core/__init__.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extra-properties/src/seed/types/__init__.py
+++ b/seed/python-sdk/extra-properties/src/seed/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extra-properties/src/seed/user/__init__.py
+++ b/seed/python-sdk/extra-properties/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/extra-properties/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/extra-properties/src/seed/user/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/__init__.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedFileDownload": ".client",
     "SeedFileDownload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/__init__.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedFileDownload": ".client",
     "SeedFileDownload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/__init__.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedFileUpload": ".client",
     "SeedFileUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/__init__.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/__init__.py
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectType": ".service",
     "SeedFileUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -39,8 +39,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/service/__init__.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/service/__init__.py
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/service/types/__init__.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/service/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/__init__.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/__init__.py
@@ -39,7 +39,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "ObjectType": ".service",
     "SeedFileUpload": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -49,8 +49,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/__init__.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/__init__.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/__init__.py
@@ -44,8 +44,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/requests/__init__.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/requests/__init__.py
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/types/__init__.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/service/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/__init__.py
+++ b/seed/python-sdk/folders/src/seed/__init__.py
@@ -13,8 +13,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedApi": ".client",
     "SeedApi": ".client",
     "__version__": ".version",
-    "a": ".",
-    "folder": ".",
+    "a": ".a",
+    "folder": ".folder",
 }
 
 
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/a/__init__.py
+++ b/seed/python-sdk/folders/src/seed/a/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import b, c, d
-_dynamic_imports: typing.Dict[str, str] = {"b": ".", "c": ".", "d": "."}
+_dynamic_imports: typing.Dict[str, str] = {"b": ".b", "c": ".c", "d": ".d"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/a/d/__init__.py
+++ b/seed/python-sdk/folders/src/seed/a/d/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from .types import Foo
     from . import types
-_dynamic_imports: typing.Dict[str, str] = {"Foo": ".types", "types": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Foo": ".types", "types": ".types"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/a/d/types/__init__.py
+++ b/seed/python-sdk/folders/src/seed/a/d/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/a/d/types/types/__init__.py
+++ b/seed/python-sdk/folders/src/seed/a/d/types/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/core/__init__.py
+++ b/seed/python-sdk/folders/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/folder/__init__.py
+++ b/seed/python-sdk/folders/src/seed/folder/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import service
     from .service import NotFoundError
-_dynamic_imports: typing.Dict[str, str] = {"NotFoundError": ".service", "service": "."}
+_dynamic_imports: typing.Dict[str, str] = {"NotFoundError": ".service", "service": ".service"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/folder/service/__init__.py
+++ b/seed/python-sdk/folders/src/seed/folder/service/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/folders/src/seed/folder/service/errors/__init__.py
+++ b/seed/python-sdk/folders/src/seed/folder/service/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/http-head/src/seed/__init__.py
+++ b/seed/python-sdk/http-head/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedHttpHead": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/http-head/src/seed/core/__init__.py
+++ b/seed/python-sdk/http-head/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/http-head/src/seed/user/__init__.py
+++ b/seed/python-sdk/http-head/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/http-head/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/http-head/src/seed/user/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/idempotency-headers/src/seed/__init__.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Currency": ".payment",
     "SeedIdempotencyHeaders": ".client",
     "__version__": ".version",
-    "payment": ".",
+    "payment": ".payment",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/idempotency-headers/src/seed/core/__init__.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/idempotency-headers/src/seed/payment/__init__.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/payment/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/idempotency-headers/src/seed/payment/types/__init__.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/payment/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/imdb/src/seed/__init__.py
+++ b/seed/python-sdk/imdb/src/seed/__init__.py
@@ -18,7 +18,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "MovieId": ".imdb",
     "SeedApi": ".client",
     "__version__": ".version",
-    "imdb": ".",
+    "imdb": ".imdb",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/imdb/src/seed/core/__init__.py
+++ b/seed/python-sdk/imdb/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/imdb/src/seed/imdb/__init__.py
+++ b/seed/python-sdk/imdb/src/seed/imdb/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/imdb/src/seed/imdb/errors/__init__.py
+++ b/seed/python-sdk/imdb/src/seed/imdb/errors/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/imdb/src/seed/imdb/types/__init__.py
+++ b/seed/python-sdk/imdb/src/seed/imdb/types/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/__init__.py
@@ -15,10 +15,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedInferredAuthExplicit": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/nested/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/__init__.py
@@ -15,10 +15,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedInferredAuthImplicitNoExpiry": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/__init__.py
@@ -15,10 +15,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedInferredAuthImplicit": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/nested/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/license/src/seed/__init__.py
+++ b/seed/python-sdk/license/src/seed/__init__.py
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/license/src/seed/core/__init__.py
+++ b/seed/python-sdk/license/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/license/src/seed/types/__init__.py
+++ b/seed/python-sdk/license/src/seed/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/__init__.py
@@ -43,11 +43,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SomeLiteral": ".reference",
     "UndiscriminatedLiteral": ".inlined",
     "__version__": ".version",
-    "headers": ".",
-    "inlined": ".",
-    "path": ".",
-    "query": ".",
-    "reference": ".",
+    "headers": ".headers",
+    "inlined": ".inlined",
+    "path": ".path",
+    "query": ".query",
+    "reference": ".reference",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/inlined/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/inlined/__init__.py
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/inlined/types/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/inlined/types/__init__.py
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/query/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/query/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/query/types/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/query/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/reference/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/reference/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/reference/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/__init__.py
@@ -72,11 +72,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UndiscriminatedLiteral": ".inlined",
     "UndiscriminatedLiteralParams": ".inlined",
     "__version__": ".version",
-    "headers": ".",
-    "inlined": ".",
-    "path": ".",
-    "query": ".",
-    "reference": ".",
+    "headers": ".headers",
+    "inlined": ".inlined",
+    "path": ".path",
+    "query": ".query",
+    "reference": ".reference",
 }
 
 
@@ -86,8 +86,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/__init__.py
@@ -54,8 +54,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/requests/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/requests/__init__.py
@@ -34,8 +34,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/types/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/inlined/types/__init__.py
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/query/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/query/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/query/types/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/query/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/__init__.py
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/requests/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/requests/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/reference/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/requests/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/requests/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/types/__init__.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literals-unions/src/seed/__init__.py
+++ b/seed/python-sdk/literals-unions/src/seed/__init__.py
@@ -16,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedLiteralsUnions": ".client",
     "UnionOverLiteral": ".literals",
     "__version__": ".version",
-    "literals": ".",
+    "literals": ".literals",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literals-unions/src/seed/core/__init__.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literals-unions/src/seed/literals/__init__.py
+++ b/seed/python-sdk/literals-unions/src/seed/literals/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/literals-unions/src/seed/literals/types/__init__.py
+++ b/seed/python-sdk/literals-unions/src/seed/literals/types/__init__.py
@@ -20,8 +20,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-case/src/seed/__init__.py
+++ b/seed/python-sdk/mixed-case/src/seed/__init__.py
@@ -21,7 +21,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMixedCase": ".client",
     "User": ".service",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -31,8 +31,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-case/src/seed/core/__init__.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-case/src/seed/service/__init__.py
+++ b/seed/python-sdk/mixed-case/src/seed/service/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-case/src/seed/service/types/__init__.py
+++ b/seed/python-sdk/mixed-case/src/seed/service/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/__init__.py
@@ -13,8 +13,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedMixedFileDirectory": ".client",
     "SeedMixedFileDirectory": ".client",
     "__version__": ".version",
-    "organization": ".",
-    "user": ".",
+    "organization": ".organization",
+    "user": ".user",
 }
 
 
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import events
-_dynamic_imports: typing.Dict[str, str] = {"events": "."}
+_dynamic_imports: typing.Dict[str, str] = {"events": ".events"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/events/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/user/events/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import metadata
-_dynamic_imports: typing.Dict[str, str] = {"metadata": "."}
+_dynamic_imports: typing.Dict[str, str] = {"metadata": ".metadata"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/__init__.py
@@ -20,8 +20,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMixedFileDirectory": ".client",
     "User": ".user",
     "__version__": ".version",
-    "organization": ".",
-    "user": ".",
+    "organization": ".organization",
+    "user": ".user",
 }
 
 
@@ -31,8 +31,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/organization/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/organization/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/organization/types/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/organization/types/__init__.py
@@ -20,8 +20,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/__init__.py
@@ -9,7 +9,7 @@ if typing.TYPE_CHECKING:
     from .types import User
     from . import events
     from .events import Event
-_dynamic_imports: typing.Dict[str, str] = {"Event": ".events", "User": ".types", "events": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Event": ".events", "User": ".types", "events": ".events"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -18,8 +18,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/__init__.py
@@ -9,7 +9,7 @@ if typing.TYPE_CHECKING:
     from .types import Event
     from . import metadata
     from .metadata import Metadata
-_dynamic_imports: typing.Dict[str, str] = {"Event": ".types", "Metadata": ".metadata", "metadata": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Event": ".types", "Metadata": ".metadata", "metadata": ".metadata"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -18,8 +18,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/metadata/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/metadata/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/metadata/types/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/metadata/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/types/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/events/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/user/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-line-docs/src/seed/__init__.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMultiLineDocs": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-line-docs/src/seed/core/__init__.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-line-docs/src/seed/types/__init__.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-line-docs/src/seed/user/__init__.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-line-docs/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/user/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/__init__.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/__init__.py
@@ -15,8 +15,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMultiUrlEnvironmentNoDefault": ".client",
     "SeedMultiUrlEnvironmentNoDefaultEnvironment": ".environment",
     "__version__": ".version",
-    "ec_2": ".",
-    "s_3": ".",
+    "ec_2": ".ec_2",
+    "s_3": ".s_3",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/__init__.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-url-environment/src/seed/__init__.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/__init__.py
@@ -15,8 +15,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedMultiUrlEnvironment": ".client",
     "SeedMultiUrlEnvironmentEnvironment": ".environment",
     "__version__": ".version",
-    "ec_2": ".",
-    "s_3": ".",
+    "ec_2": ".ec_2",
+    "s_3": ".s_3",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multi-url-environment/src/seed/core/__init__.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multiple-request-bodies/src/seed/__init__.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/__init__.py
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/__init__.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/multiple-request-bodies/src/seed/types/__init__.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/types/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/no-environment/src/seed/__init__.py
+++ b/seed/python-sdk/no-environment/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedNoEnvironment": ".client",
     "SeedNoEnvironment": ".client",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/no-environment/src/seed/core/__init__.py
+++ b/seed/python-sdk/no-environment/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable-optional/src/seed/__init__.py
+++ b/seed/python-sdk/nullable-optional/src/seed/__init__.py
@@ -65,7 +65,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UserRole": ".nullable_optional",
     "UserStatus": ".nullable_optional",
     "__version__": ".version",
-    "nullable_optional": ".",
+    "nullable_optional": ".nullable_optional",
 }
 
 
@@ -75,8 +75,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable-optional/src/seed/core/__init__.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/__init__.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/__init__.py
@@ -68,8 +68,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/__init__.py
+++ b/seed/python-sdk/nullable-optional/src/seed/nullable_optional/types/__init__.py
@@ -65,8 +65,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/__init__.py
@@ -33,7 +33,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UserId": ".nullable",
     "WeirdNumber": ".nullable",
     "__version__": ".version",
-    "nullable": ".",
+    "nullable": ".nullable",
 }
 
 
@@ -43,8 +43,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/__init__.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/__init__.py
@@ -36,8 +36,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/types/__init__.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/nullable/types/__init__.py
@@ -31,8 +31,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/__init__.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/__init__.py
@@ -47,7 +47,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WeirdNumber": ".nullable",
     "WeirdNumberParams": ".nullable",
     "__version__": ".version",
-    "nullable": ".",
+    "nullable": ".nullable",
 }
 
 
@@ -57,8 +57,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/__init__.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/__init__.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/__init__.py
@@ -52,8 +52,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/requests/__init__.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/requests/__init__.py
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/types/__init__.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/nullable/types/__init__.py
@@ -31,8 +31,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/__init__.py
@@ -15,10 +15,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedOauthClientCredentials": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/__init__.py
@@ -15,10 +15,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedOauthClientCredentialsDefault": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/__init__.py
@@ -18,10 +18,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedOauthClientCredentialsEnvironmentVariables": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -31,8 +31,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/__init__.py
@@ -13,10 +13,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedOauthClientCredentials": ".client",
     "SeedOauthClientCredentials": ".client",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/__init__.py
@@ -15,11 +15,11 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedOauthClientCredentialsWithVariables": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "service": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "service": ".service",
+    "simple": ".simple",
 }
 
 
@@ -29,8 +29,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/__init__.py
@@ -15,10 +15,10 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedOauthClientCredentials": ".client",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "nested": ".",
-    "nested_no_auth": ".",
-    "simple": ".",
+    "auth": ".auth",
+    "nested": ".nested",
+    "nested_no_auth": ".nested_no_auth",
+    "simple": ".simple",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/nested/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/nested/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/oauth-client-credentials/src/seed/nested_no_auth/__init__.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/nested_no_auth/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from . import api
-_dynamic_imports: typing.Dict[str, str] = {"api": "."}
+_dynamic_imports: typing.Dict[str, str] = {"api": ".api"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/object/src/seed/__init__.py
+++ b/seed/python-sdk/object/src/seed/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/object/src/seed/core/__init__.py
+++ b/seed/python-sdk/object/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/object/src/seed/types/__init__.py
+++ b/seed/python-sdk/object/src/seed/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/__init__.py
@@ -19,8 +19,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedObjectsWithImports": ".client",
     "Tree": ".types",
     "__version__": ".version",
-    "commons": ".",
-    "file": ".",
+    "commons": ".commons",
+    "file": ".file",
 }
 
 
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/commons/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/commons/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 if typing.TYPE_CHECKING:
     from . import metadata
     from .metadata import Metadata
-_dynamic_imports: typing.Dict[str, str] = {"Metadata": ".metadata", "metadata": "."}
+_dynamic_imports: typing.Dict[str, str] = {"Metadata": ".metadata", "metadata": ".metadata"}
 
 
 def __getattr__(attr_name: str) -> typing.Any:
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/commons/metadata/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/commons/metadata/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/commons/metadata/types/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/commons/metadata/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/core/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/file/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/file/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Directory": ".directory",
     "File": ".types",
     "FileInfo": ".types",
-    "directory": ".",
+    "directory": ".directory",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/file/directory/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/file/directory/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/file/directory/types/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/file/directory/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/file/types/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/file/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/objects-with-imports/src/seed/types/__init__.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/optional/src/seed/__init__.py
+++ b/seed/python-sdk/optional/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedObjectsWithImports": ".client",
     "SeedObjectsWithImports": ".client",
     "__version__": ".version",
-    "optional": ".",
+    "optional": ".optional",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/optional/src/seed/core/__init__.py
+++ b/seed/python-sdk/optional/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/package-yml/src/seed/__init__.py
+++ b/seed/python-sdk/package-yml/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "EchoRequest": ".types",
     "SeedPackageYml": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/package-yml/src/seed/core/__init__.py
+++ b/seed/python-sdk/package-yml/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/package-yml/src/seed/types/__init__.py
+++ b/seed/python-sdk/package-yml/src/seed/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/__init__.py
@@ -72,9 +72,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WithCursor": ".users",
     "WithPage": ".users",
     "__version__": ".version",
-    "complex_": ".",
-    "inline_users": ".",
-    "users": ".",
+    "complex_": ".complex_",
+    "inline_users": ".inline_users",
+    "users": ".users",
 }
 
 
@@ -84,8 +84,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/complex_/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/complex_/__init__.py
@@ -40,8 +40,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/complex_/types/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/complex_/types/__init__.py
@@ -38,8 +38,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/__init__.py
@@ -64,8 +64,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/__init__.py
@@ -42,7 +42,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Users": ".inline_users",
     "WithCursor": ".inline_users",
     "WithPage": ".inline_users",
-    "inline_users": ".",
+    "inline_users": ".inline_users",
 }
 
 
@@ -52,8 +52,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/__init__.py
@@ -50,8 +50,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/types/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/types/__init__.py
@@ -48,8 +48,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/users/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/users/__init__.py
@@ -48,8 +48,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/users/types/__init__.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/users/types/__init__.py
@@ -46,8 +46,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -72,9 +72,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WithCursor": ".users",
     "WithPage": ".users",
     "__version__": ".version",
-    "complex_": ".",
-    "inline_users": ".",
-    "users": ".",
+    "complex_": ".complex_",
+    "inline_users": ".inline_users",
+    "users": ".users",
 }
 
 
@@ -84,8 +84,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/complex_/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/complex_/__init__.py
@@ -40,8 +40,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/complex_/types/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/complex_/types/__init__.py
@@ -38,8 +38,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/__init__.py
@@ -64,8 +64,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/__init__.py
@@ -42,7 +42,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Users": ".inline_users",
     "WithCursor": ".inline_users",
     "WithPage": ".inline_users",
-    "inline_users": ".",
+    "inline_users": ".inline_users",
 }
 
 
@@ -52,8 +52,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/__init__.py
@@ -50,8 +50,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/types/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/types/__init__.py
@@ -48,8 +48,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/types/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/__init__.py
@@ -48,8 +48,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/types/__init__.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/types/__init__.py
@@ -46,8 +46,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/path-parameters/src/seed/__init__.py
+++ b/seed/python-sdk/path-parameters/src/seed/__init__.py
@@ -17,8 +17,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedPathParameters": ".client",
     "User": ".user",
     "__version__": ".version",
-    "organizations": ".",
-    "user": ".",
+    "organizations": ".organizations",
+    "user": ".user",
 }
 
 
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/path-parameters/src/seed/core/__init__.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/path-parameters/src/seed/organizations/__init__.py
+++ b/seed/python-sdk/path-parameters/src/seed/organizations/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/path-parameters/src/seed/organizations/types/__init__.py
+++ b/seed/python-sdk/path-parameters/src/seed/organizations/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/path-parameters/src/seed/user/__init__.py
+++ b/seed/python-sdk/path-parameters/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/path-parameters/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/path-parameters/src/seed/user/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/plain-text/src/seed/__init__.py
+++ b/seed/python-sdk/plain-text/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedPlainText": ".client",
     "SeedPlainText": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/plain-text/src/seed/core/__init__.py
+++ b/seed/python-sdk/plain-text/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/property-access/src/seed/__init__.py
+++ b/seed/python-sdk/property-access/src/seed/__init__.py
@@ -43,8 +43,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/property-access/src/seed/core/__init__.py
+++ b/seed/python-sdk/property-access/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/property-access/src/seed/types/__init__.py
+++ b/seed/python-sdk/property-access/src/seed/types/__init__.py
@@ -38,8 +38,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/public-object/src/seed/__init__.py
+++ b/seed/python-sdk/public-object/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedPublicObject": ".client",
     "SeedPublicObject": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/public-object/src/seed/core/__init__.py
+++ b/seed/python-sdk/public-object/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/__init__.py
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/types/__init__.py
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/__init__.py
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/__init__.py
@@ -16,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedQueryParameters": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/user/__init__.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/user/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/request-parameters/src/seed/__init__.py
+++ b/seed/python-sdk/request-parameters/src/seed/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedRequestParameters": ".client",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/request-parameters/src/seed/core/__init__.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/request-parameters/src/seed/user/__init__.py
+++ b/seed/python-sdk/request-parameters/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/request-parameters/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/request-parameters/src/seed/user/types/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/reserved-keywords/src/seed/__init__.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/__init__.py
@@ -16,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "Record": ".package",
     "SeedNurseryApi": ".client",
     "__version__": ".version",
-    "package": ".",
+    "package": ".package",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/reserved-keywords/src/seed/core/__init__.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/reserved-keywords/src/seed/package/__init__.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/package/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/reserved-keywords/src/seed/package/types/__init__.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/package/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/response-property/src/seed/__init__.py
+++ b/seed/python-sdk/response-property/src/seed/__init__.py
@@ -22,7 +22,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WithDocs": ".service",
     "WithMetadata": ".types",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/response-property/src/seed/core/__init__.py
+++ b/seed/python-sdk/response-property/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/response-property/src/seed/service/__init__.py
+++ b/seed/python-sdk/response-property/src/seed/service/__init__.py
@@ -21,8 +21,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/response-property/src/seed/service/types/__init__.py
+++ b/seed/python-sdk/response-property/src/seed/service/types/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/response-property/src/seed/types/__init__.py
+++ b/seed/python-sdk/response-property/src/seed/types/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-event-examples/src/seed/__init__.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedServerSentEvents": ".client",
     "StreamedCompletion": ".completions",
     "__version__": ".version",
-    "completions": ".",
+    "completions": ".completions",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-event-examples/src/seed/completions/__init__.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/completions/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-event-examples/src/seed/completions/types/__init__.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/completions/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/__init__.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-events/src/seed/__init__.py
+++ b/seed/python-sdk/server-sent-events/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedServerSentEvents": ".client",
     "StreamedCompletion": ".completions",
     "__version__": ".version",
-    "completions": ".",
+    "completions": ".completions",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-events/src/seed/completions/__init__.py
+++ b/seed/python-sdk/server-sent-events/src/seed/completions/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-events/src/seed/completions/types/__init__.py
+++ b/seed/python-sdk/server-sent-events/src/seed/completions/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/server-sent-events/src/seed/core/__init__.py
+++ b/seed/python-sdk/server-sent-events/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/simple-api/src/seed/__init__.py
+++ b/seed/python-sdk/simple-api/src/seed/__init__.py
@@ -17,7 +17,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedSimpleApiEnvironment": ".environment",
     "User": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -27,8 +27,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/simple-api/src/seed/core/__init__.py
+++ b/seed/python-sdk/simple-api/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/simple-api/src/seed/user/__init__.py
+++ b/seed/python-sdk/simple-api/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/simple-api/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/simple-api/src/seed/user/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/__init__.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/__init__.py
@@ -29,8 +29,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/__init__.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/types/__init__.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/single-url-environment-default/src/seed/__init__.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedSingleUrlEnvironmentDefault": ".client",
     "SeedSingleUrlEnvironmentDefaultEnvironment": ".environment",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/__init__.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/__init__.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedSingleUrlEnvironmentNoDefault": ".client",
     "SeedSingleUrlEnvironmentNoDefaultEnvironment": ".environment",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/__init__.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming-parameter/src/seed/__init__.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/__init__.py
@@ -16,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedStreaming": ".client",
     "StreamResponse": ".dummy",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming-parameter/src/seed/core/__init__.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming-parameter/src/seed/dummy/__init__.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/dummy/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming-parameter/src/seed/dummy/types/__init__.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/dummy/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedStreaming": ".client",
     "StreamResponse": ".dummy",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/dummy/__init__.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/dummy/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/dummy/types/__init__.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/dummy/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/__init__.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/__init__.py
@@ -15,7 +15,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SeedStreaming": ".client",
     "StreamResponse": ".dummy",
     "__version__": ".version",
-    "dummy": ".",
+    "dummy": ".dummy",
 }
 
 
@@ -25,8 +25,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/__init__.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/__init__.py
@@ -65,8 +65,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/dummy/__init__.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/dummy/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/dummy/types/__init__.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/dummy/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/__init__.py
+++ b/seed/python-sdk/trace/src/seed/__init__.py
@@ -493,16 +493,16 @@ _dynamic_imports: typing.Dict[str, str] = {
     "WorkspaceSubmitRequest": ".submission",
     "WorkspaceTracedUpdate": ".submission",
     "__version__": ".version",
-    "admin": ".",
-    "commons": ".",
-    "homepage": ".",
-    "lang_server": ".",
-    "migration": ".",
-    "playlist": ".",
-    "problem": ".",
-    "submission": ".",
-    "sysprop": ".",
-    "v_2": ".",
+    "admin": ".admin",
+    "commons": ".commons",
+    "homepage": ".homepage",
+    "lang_server": ".lang_server",
+    "migration": ".migration",
+    "playlist": ".playlist",
+    "problem": ".problem",
+    "submission": ".submission",
+    "sysprop": ".sysprop",
+    "v_2": ".v_2",
 }
 
 
@@ -512,8 +512,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/admin/__init__.py
+++ b/seed/python-sdk/trace/src/seed/admin/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/admin/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/admin/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/commons/__init__.py
+++ b/seed/python-sdk/trace/src/seed/commons/__init__.py
@@ -138,8 +138,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/commons/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/commons/types/__init__.py
@@ -142,8 +142,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/core/__init__.py
+++ b/seed/python-sdk/trace/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/lang_server/__init__.py
+++ b/seed/python-sdk/trace/src/seed/lang_server/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/lang_server/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/lang_server/types/__init__.py
@@ -20,8 +20,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/migration/__init__.py
+++ b/seed/python-sdk/trace/src/seed/migration/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/migration/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/migration/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/playlist/__init__.py
+++ b/seed/python-sdk/trace/src/seed/playlist/__init__.py
@@ -35,8 +35,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/playlist/errors/__init__.py
+++ b/seed/python-sdk/trace/src/seed/playlist/errors/__init__.py
@@ -20,8 +20,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/playlist/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/playlist/types/__init__.py
@@ -29,8 +29,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/problem/__init__.py
+++ b/seed/python-sdk/trace/src/seed/problem/__init__.py
@@ -52,8 +52,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/problem/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/problem/types/__init__.py
@@ -53,8 +53,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/submission/__init__.py
+++ b/seed/python-sdk/trace/src/seed/submission/__init__.py
@@ -306,8 +306,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/submission/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/submission/types/__init__.py
@@ -308,8 +308,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/v_2/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/__init__.py
@@ -118,8 +118,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VoidFunctionDefinitionThatTakesActualResult": ".problem",
     "VoidFunctionSignature": ".problem",
     "VoidFunctionSignatureThatTakesActualResult": ".problem",
-    "problem": ".",
-    "v_3": ".",
+    "problem": ".problem",
+    "v_3": ".v_3",
 }
 
 
@@ -129,8 +129,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/v_2/problem/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/__init__.py
@@ -126,8 +126,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/v_2/problem/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/problem/types/__init__.py
@@ -128,8 +128,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/__init__.py
@@ -118,7 +118,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VoidFunctionDefinitionThatTakesActualResult": ".problem",
     "VoidFunctionSignature": ".problem",
     "VoidFunctionSignatureThatTakesActualResult": ".problem",
-    "problem": ".",
+    "problem": ".problem",
 }
 
 
@@ -128,8 +128,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/__init__.py
@@ -126,8 +126,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/__init__.py
+++ b/seed/python-sdk/trace/src/seed/v_2/v_3/problem/types/__init__.py
@@ -128,8 +128,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/undiscriminated-unions/src/seed/__init__.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/__init__.py
@@ -45,7 +45,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "UnionWithIdenticalPrimitives": ".union",
     "UnionWithIdenticalStrings": ".union",
     "__version__": ".version",
-    "union": ".",
+    "union": ".union",
 }
 
 
@@ -55,8 +55,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/__init__.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/undiscriminated-unions/src/seed/union/__init__.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/union/__init__.py
@@ -48,8 +48,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/undiscriminated-unions/src/seed/union/types/__init__.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/union/types/__init__.py
@@ -46,8 +46,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/__init__.py
@@ -255,9 +255,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VibrantExcitement": ".bigunion",
     "WithName": ".union",
     "__version__": ".version",
-    "bigunion": ".",
-    "types": ".",
-    "union": ".",
+    "bigunion": ".bigunion",
+    "types": ".types",
+    "union": ".union",
 }
 
 
@@ -267,8 +267,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/bigunion/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/bigunion/__init__.py
@@ -136,8 +136,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/bigunion/types/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/bigunion/types/__init__.py
@@ -136,8 +136,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/types/__init__.py
@@ -130,8 +130,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/types/types/__init__.py
@@ -125,8 +125,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/union/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/no-custom-config/src/seed/union/types/__init__.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/union/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/__init__.py
@@ -255,9 +255,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VibrantExcitementBigUnion": ".bigunion",
     "WithName": ".union",
     "__version__": ".version",
-    "bigunion": ".",
-    "types": ".",
-    "union": ".",
+    "bigunion": ".bigunion",
+    "types": ".types",
+    "union": ".union",
 }
 
 
@@ -267,8 +267,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/bigunion/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/bigunion/__init__.py
@@ -136,8 +136,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/bigunion/types/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/bigunion/types/__init__.py
@@ -136,8 +136,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/types/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/types/__init__.py
@@ -130,8 +130,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/types/types/__init__.py
@@ -125,8 +125,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/union/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/union/__init__.py
@@ -24,8 +24,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/union/types/__init__.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/union/types/__init__.py
@@ -28,8 +28,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/__init__.py
@@ -121,9 +121,9 @@ _dynamic_imports: typing.Dict[str, str] = {
     "VibrantExcitement": ".bigunion",
     "WithName": ".union",
     "__version__": ".version",
-    "bigunion": ".",
-    "types": ".",
-    "union": ".",
+    "bigunion": ".bigunion",
+    "types": ".types",
+    "union": ".union",
 }
 
 
@@ -133,8 +133,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/bigunion/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/bigunion/__init__.py
@@ -78,8 +78,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/bigunion/types/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/bigunion/types/__init__.py
@@ -76,8 +76,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/core/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/types/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/__init__.py
@@ -56,8 +56,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/__init__.py
@@ -54,8 +54,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/union/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/union/__init__.py
@@ -22,8 +22,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unions/union-utils/src/seed/union/types/__init__.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/union/types/__init__.py
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unknown/src/seed/__init__.py
+++ b/seed/python-sdk/unknown/src/seed/__init__.py
@@ -16,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "MyObject": ".unknown",
     "SeedUnknownAsAny": ".client",
     "__version__": ".version",
-    "unknown": ".",
+    "unknown": ".unknown",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unknown/src/seed/core/__init__.py
+++ b/seed/python-sdk/unknown/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unknown/src/seed/unknown/__init__.py
+++ b/seed/python-sdk/unknown/src/seed/unknown/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/unknown/src/seed/unknown/types/__init__.py
+++ b/seed/python-sdk/unknown/src/seed/unknown/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/validation/no-custom-config/src/seed/__init__.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/__init__.py
@@ -29,8 +29,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/__init__.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/validation/no-custom-config/src/seed/types/__init__.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/validation/with-defaults/src/seed/__init__.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/__init__.py
@@ -29,8 +29,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/__init__.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/validation/with-defaults/src/seed/types/__init__.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/variables/src/seed/__init__.py
+++ b/seed/python-sdk/variables/src/seed/__init__.py
@@ -13,7 +13,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "AsyncSeedVariables": ".client",
     "SeedVariables": ".client",
     "__version__": ".version",
-    "service": ".",
+    "service": ".service",
 }
 
 
@@ -23,8 +23,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/variables/src/seed/core/__init__.py
+++ b/seed/python-sdk/variables/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version-no-default/src/seed/__init__.py
+++ b/seed/python-sdk/version-no-default/src/seed/__init__.py
@@ -16,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "User": ".user",
     "UserId": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version-no-default/src/seed/core/__init__.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version-no-default/src/seed/user/__init__.py
+++ b/seed/python-sdk/version-no-default/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version-no-default/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/version-no-default/src/seed/user/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version/src/seed/__init__.py
+++ b/seed/python-sdk/version/src/seed/__init__.py
@@ -16,7 +16,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "User": ".user",
     "UserId": ".user",
     "__version__": ".version",
-    "user": ".",
+    "user": ".user",
 }
 
 
@@ -26,8 +26,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version/src/seed/core/__init__.py
+++ b/seed/python-sdk/version/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version/src/seed/user/__init__.py
+++ b/seed/python-sdk/version/src/seed/user/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/version/src/seed/user/types/__init__.py
+++ b/seed/python-sdk/version/src/seed/user/types/__init__.py
@@ -17,8 +17,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/__init__.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/__init__.py
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendEvent2": ".realtime",
     "SendSnakeCase": ".realtime",
     "__version__": ".version",
-    "realtime": ".",
+    "realtime": ".realtime",
 }
 
 
@@ -39,8 +39,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/__init__.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/__init__.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/__init__.py
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/__init__.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/realtime/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/__init__.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/__init__.py
@@ -31,8 +31,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendSnakeCase": ".realtime",
     "TokenResponse": ".auth",
     "__version__": ".version",
-    "auth": ".",
-    "realtime": ".",
+    "auth": ".auth",
+    "realtime": ".realtime",
 }
 
 
@@ -42,8 +42,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/auth/__init__.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/auth/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/auth/types/__init__.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/auth/types/__init__.py
@@ -16,8 +16,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/__init__.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/__init__.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/__init__.py
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/__init__.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/realtime/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-base/src/seed/__init__.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/__init__.py
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendEvent2": ".realtime",
     "SendSnakeCase": ".realtime",
     "__version__": ".version",
-    "realtime": ".",
+    "realtime": ".realtime",
 }
 
 
@@ -39,8 +39,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/__init__.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/__init__.py
@@ -61,8 +61,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-base/src/seed/realtime/__init__.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/realtime/__init__.py
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/__init__.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/realtime/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/__init__.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/__init__.py
@@ -29,7 +29,7 @@ _dynamic_imports: typing.Dict[str, str] = {
     "SendEvent2": ".realtime",
     "SendSnakeCase": ".realtime",
     "__version__": ".version",
-    "realtime": ".",
+    "realtime": ".realtime",
 }
 
 
@@ -39,8 +39,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/__init__.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/__init__.py
@@ -64,8 +64,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/__init__.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/__init__.py
@@ -32,8 +32,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/__init__.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/realtime/types/__init__.py
@@ -30,8 +30,10 @@ def __getattr__(attr_name: str) -> typing.Any:
         raise AttributeError(f"No {attr_name} found in _dynamic_imports for module name -> {__name__}")
     try:
         module = import_module(module_name, __package__)
-        result = getattr(module, attr_name)
-        return result
+        if module_name == f".{attr_name}":
+            return module
+        else:
+            return getattr(module, attr_name)
     except ImportError as e:
         raise ImportError(f"Failed to import {attr_name} from {module_name}: {e}") from e
     except AttributeError as e:


### PR DESCRIPTION
## Description
Fixes infinite recursion bug when walking submodule attrs, e.g. https://github.com/merge-api/merge-python-client/issues/141. It also turns out that just running e.g. `merge.ats` would result in infinite recursion in the python runtime as well.

## Changes Made
- Specially handle submodule imports to import the submodule dynamically
  - Note that we don't change how type checking works
- When running getattr for a submodule, hand back the submodule

## Testing
- Existing seed tests