### PR TITLE
fix(postman): fix bundler transformation issue causing runtime error

### DIFF
--- a/generators/postman/Dockerfile
+++ b/generators/postman/Dockerfile
@@ -1,3 +1,5 @@
 FROM node:22.12-alpine3.20
-COPY dist /dist
+
+COPY generators/postman/dist /dist
+
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs"]

--- a/generators/postman/Dockerfile.dockerignore
+++ b/generators/postman/Dockerfile.dockerignore
@@ -1,2 +1,2 @@
 *
-!dist
+!generators/postman/dist

--- a/generators/postman/package.json
+++ b/generators/postman/package.json
@@ -27,7 +27,7 @@
     "compile": "tsc --build",
     "compile:debug": "tsc --build --sourceMap",
     "depcheck": "depcheck",
-    "dist:cli": "pnpm compile && tsup ./src/cli.ts --sourcemap",
+    "dist:cli": "pnpm compile && tsup",
     "dockerTagLatest": "pnpm dist:cli && docker build -f ./Dockerfile -t fernapi/fern-postman:latest .",
     "dockerTagVersion": "pnpm dist:cli && docker build -f ./Dockerfile -t fernapi/fern-postman:${0} .",
     "format": "prettier --write --ignore-unknown --ignore-path ../../shared/.prettierignore \"**\"",

--- a/generators/postman/src/writePostmanGithubWorkflows.ts
+++ b/generators/postman/src/writePostmanGithubWorkflows.ts
@@ -1,10 +1,12 @@
 import { GeneratorConfig, GithubOutputMode } from "@fern-api/base-generator";
-import endent from "endent";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
 import { PostmanGeneratorConfigSchema } from "./config/schemas/PostmanGeneratorConfigSchema";
 import { getCollectionOutputFilename } from "./writePostmanCollection";
+
+// Use dynamic require to bypass bundler's ES module transformation issues
+const { default: endent } = require("endent") as typeof import("endent");
 
 export async function writePostmanGithubWorkflows({
     config,

--- a/generators/postman/tsup.config.ts
+++ b/generators/postman/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/cli.ts"],
+    format: "cjs",
+    sourcemap: true
+});

--- a/generators/postman/versions.yml
+++ b/generators/postman/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
+
+- version: 0.4.1
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fixed "`import_endent.default` is not a function" error when generating GitHub workflows.
+  createdAt: "2025-09-23"
+  irVersion: 53
+
 - changelogEntry:
     - summary: |
         Introduces a `collection-name` configuration that allows you to control 


### PR DESCRIPTION
## Description
Linear ticket: [FER-6385](https://linear.app/buildwithfern/issue/FER-6385/flagright-postman-issue)
<!-- Provide a clear and concise description of the changes made in this PR -->
Fixes a bundler issue causing a Postman generation error when writing Github workflows. `endent` is a cjs package that signals `__esModule: true` which is causing tsup's `__toESM` wrapper to create a `default` property that already exists. Using a dynamic require allows us to avoid the `__toESM` wrapper.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Fixes `Dockerfile` and `Dockerfile.dockerignore` to run the generator
- Updates `writePostmanGithubWorkflows` to use a dynamic require with a type cast
- Inits tsup config file

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
