### PR TITLE
chore(python): add async client clarifier to README

### DIFF
--- a/generators/python/sdk/features.yml
+++ b/generators/python/sdk/features.yml
@@ -5,7 +5,7 @@ features:
 
   - id: ASYNC_CLIENT
     description: |
-      The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+      The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
   - id: EXCEPTION_HANDLING
     description: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 4.29.2
+  changelogEntry:
+    - summary: Added a note to the README on constructing Async httpx objects to pass into main Async clients.
+      type: chore
+  createdAt: "2025-09-23"
+  irVersion: 59
+
 - version: 4.29.2-rc0
   changelogEntry:
     - summary: |

--- a/seed/python-sdk/accept-header/README.md
+++ b/seed/python-sdk/accept-header/README.md
@@ -31,7 +31,7 @@ client.service.endpoint()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/alias-extends/no-custom-config/README.md
+++ b/seed/python-sdk/alias-extends/no-custom-config/README.md
@@ -33,7 +33,7 @@ client.extended_inline_request_body(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/README.md
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/README.md
@@ -33,7 +33,7 @@ client.extended_inline_request_body(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/alias/README.md
+++ b/seed/python-sdk/alias/README.md
@@ -32,7 +32,7 @@ client.get(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/any-auth/README.md
+++ b/seed/python-sdk/any-auth/README.md
@@ -36,7 +36,7 @@ client.auth.get_token(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/api-wide-base-path/README.md
+++ b/seed/python-sdk/api-wide-base-path/README.md
@@ -34,7 +34,7 @@ client.service.post(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/audiences/README.md
+++ b/seed/python-sdk/audiences/README.md
@@ -35,7 +35,7 @@ client.foo.find(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/auth-environment-variables/README.md
+++ b/seed/python-sdk/auth-environment-variables/README.md
@@ -32,7 +32,7 @@ client.service.get_with_api_key()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/basic-auth-environment-variables/README.md
+++ b/seed/python-sdk/basic-auth-environment-variables/README.md
@@ -34,7 +34,7 @@ client.basic_auth.post_with_basic_auth(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/basic-auth/README.md
+++ b/seed/python-sdk/basic-auth/README.md
@@ -34,7 +34,7 @@ client.basic_auth.post_with_basic_auth(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/bearer-token-environment-variable/README.md
+++ b/seed/python-sdk/bearer-token-environment-variable/README.md
@@ -31,7 +31,7 @@ client.service.get_with_bearer_token()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/bytes-upload/README.md
+++ b/seed/python-sdk/bytes-upload/README.md
@@ -30,7 +30,7 @@ client.service.upload()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/client-side-params/README.md
+++ b/seed/python-sdk/client-side-params/README.md
@@ -36,7 +36,7 @@ client.service.search_resources(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/content-type/README.md
+++ b/seed/python-sdk/content-type/README.md
@@ -33,7 +33,7 @@ client.service.patch(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/cross-package-type-names/README.md
+++ b/seed/python-sdk/cross-package-type-names/README.md
@@ -34,7 +34,7 @@ client.foo.find(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/custom-auth/README.md
+++ b/seed/python-sdk/custom-auth/README.md
@@ -33,7 +33,7 @@ client.custom_auth.post_with_custom_auth(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/enum/no-custom-config/README.md
+++ b/seed/python-sdk/enum/no-custom-config/README.md
@@ -34,7 +34,7 @@ client.headers.send(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/enum/strenum/README.md
+++ b/seed/python-sdk/enum/strenum/README.md
@@ -34,7 +34,7 @@ client.headers.send(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/error-property/README.md
+++ b/seed/python-sdk/error-property/README.md
@@ -30,7 +30,7 @@ client.property_based_error.throw_error()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/errors/README.md
+++ b/seed/python-sdk/errors/README.md
@@ -32,7 +32,7 @@ client.simple.foo_without_endpoint_error(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/examples/client-filename/README.md
+++ b/seed/python-sdk/examples/client-filename/README.md
@@ -34,7 +34,7 @@ client.echo(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/examples/legacy-wire-tests/README.md
+++ b/seed/python-sdk/examples/legacy-wire-tests/README.md
@@ -34,7 +34,7 @@ client.echo(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/examples/no-custom-config/README.md
+++ b/seed/python-sdk/examples/no-custom-config/README.md
@@ -34,7 +34,7 @@ client.echo(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/examples/readme/README.md
+++ b/seed/python-sdk/examples/readme/README.md
@@ -65,7 +65,7 @@ client.service.create_movie(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/additional_init_exports/README.md
+++ b/seed/python-sdk/exhaustive/additional_init_exports/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/aliases_with_validation/README.md
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/aliases_without_validation/README.md
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/README.md
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/eager-imports/README.md
+++ b/seed/python-sdk/exhaustive/eager-imports/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/extra_dependencies/README.md
+++ b/seed/python-sdk/exhaustive/extra_dependencies/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/README.md
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/five-second-timeout/README.md
+++ b/seed/python-sdk/exhaustive/five-second-timeout/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/README.md
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/improved_imports/README.md
+++ b/seed/python-sdk/exhaustive/improved_imports/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/infinite-timeout/README.md
+++ b/seed/python-sdk/exhaustive/infinite-timeout/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/inline-path-params/README.md
+++ b/seed/python-sdk/exhaustive/inline-path-params/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/inline_request_params/README.md
+++ b/seed/python-sdk/exhaustive/inline_request_params/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/no-custom-config/README.md
+++ b/seed/python-sdk/exhaustive/no-custom-config/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/pydantic-v1/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v1/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/README.md
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/pyproject_extras/README.md
+++ b/seed/python-sdk/exhaustive/pyproject_extras/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/README.md
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/exhaustive/union-utils/README.md
+++ b/seed/python-sdk/exhaustive/union-utils/README.md
@@ -33,7 +33,7 @@ client.endpoints.container.get_and_return_list_of_primitives(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/extends/README.md
+++ b/seed/python-sdk/extends/README.md
@@ -34,7 +34,7 @@ client.extended_inline_request_body(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/extra-properties/README.md
+++ b/seed/python-sdk/extra-properties/README.md
@@ -32,7 +32,7 @@ client.user.create_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/file-download/default-chunk-size/README.md
+++ b/seed/python-sdk/file-download/default-chunk-size/README.md
@@ -30,7 +30,7 @@ client.service.simple()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/file-download/no-custom-config/README.md
+++ b/seed/python-sdk/file-download/no-custom-config/README.md
@@ -30,7 +30,7 @@ client.service.simple()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/README.md
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/README.md
@@ -30,7 +30,7 @@ client.service.simple()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/file-upload/no-custom-config/README.md
+++ b/seed/python-sdk/file-upload/no-custom-config/README.md
@@ -30,7 +30,7 @@ client.service.simple()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/file-upload/use_typeddict_requests/README.md
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/README.md
@@ -30,7 +30,7 @@ client.service.simple()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/folders/README.md
+++ b/seed/python-sdk/folders/README.md
@@ -30,7 +30,7 @@ client.foo()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/http-head/README.md
+++ b/seed/python-sdk/http-head/README.md
@@ -30,7 +30,7 @@ client.user.head()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/idempotency-headers/README.md
+++ b/seed/python-sdk/idempotency-headers/README.md
@@ -34,7 +34,7 @@ client.payment.create(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/imdb/README.md
+++ b/seed/python-sdk/imdb/README.md
@@ -34,7 +34,7 @@ client.imdb.create_movie(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/inferred-auth-explicit/README.md
+++ b/seed/python-sdk/inferred-auth-explicit/README.md
@@ -35,7 +35,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -35,7 +35,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/inferred-auth-implicit/README.md
+++ b/seed/python-sdk/inferred-auth-implicit/README.md
@@ -35,7 +35,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/license/README.md
+++ b/seed/python-sdk/license/README.md
@@ -30,7 +30,7 @@ client.get()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/literal/no-custom-config/README.md
+++ b/seed/python-sdk/literal/no-custom-config/README.md
@@ -32,7 +32,7 @@ client.headers.send(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/literal/use_typeddict_requests/README.md
+++ b/seed/python-sdk/literal/use_typeddict_requests/README.md
@@ -32,7 +32,7 @@ client.headers.send(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/mixed-case/README.md
+++ b/seed/python-sdk/mixed-case/README.md
@@ -32,7 +32,7 @@ client.service.get_resource(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/README.md
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/README.md
@@ -32,7 +32,7 @@ client.organization.create(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/README.md
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/README.md
@@ -32,7 +32,7 @@ client.organization.create(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/multi-line-docs/README.md
+++ b/seed/python-sdk/multi-line-docs/README.md
@@ -33,7 +33,7 @@ client.user.create_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/multi-url-environment-no-default/README.md
+++ b/seed/python-sdk/multi-url-environment-no-default/README.md
@@ -34,7 +34,7 @@ client.ec_2.boot_instance(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/multi-url-environment/README.md
+++ b/seed/python-sdk/multi-url-environment/README.md
@@ -32,7 +32,7 @@ client.ec_2.boot_instance(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/multiple-request-bodies/README.md
+++ b/seed/python-sdk/multiple-request-bodies/README.md
@@ -30,7 +30,7 @@ client.upload_json_document()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/no-environment/README.md
+++ b/seed/python-sdk/no-environment/README.md
@@ -31,7 +31,7 @@ client.dummy.get_dummy()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/nullable-optional/README.md
+++ b/seed/python-sdk/nullable-optional/README.md
@@ -44,7 +44,7 @@ client.nullable_optional.create_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/nullable/no-custom-config/README.md
+++ b/seed/python-sdk/nullable/no-custom-config/README.md
@@ -49,7 +49,7 @@ client.nullable.create_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/nullable/use-typeddict-requests/README.md
+++ b/seed/python-sdk/nullable/use-typeddict-requests/README.md
@@ -48,7 +48,7 @@ client.nullable.create_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/python-sdk/oauth-client-credentials-custom/README.md
@@ -38,7 +38,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/oauth-client-credentials-default/README.md
+++ b/seed/python-sdk/oauth-client-credentials-default/README.md
@@ -35,7 +35,7 @@ client.auth.get_token(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/README.md
@@ -36,7 +36,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/README.md
@@ -36,7 +36,7 @@ client.auth.get_token(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/README.md
@@ -37,7 +37,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/oauth-client-credentials/README.md
+++ b/seed/python-sdk/oauth-client-credentials/README.md
@@ -36,7 +36,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/optional/README.md
+++ b/seed/python-sdk/optional/README.md
@@ -32,7 +32,7 @@ client.optional.send_optional_body(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/package-yml/README.md
+++ b/seed/python-sdk/package-yml/README.md
@@ -33,7 +33,7 @@ client.echo(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/pagination/no-custom-config/README.md
+++ b/seed/python-sdk/pagination/no-custom-config/README.md
@@ -48,7 +48,7 @@ for page in response.iter_pages():
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/README.md
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/README.md
@@ -48,7 +48,7 @@ for page in response.iter_pages():
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/path-parameters/README.md
+++ b/seed/python-sdk/path-parameters/README.md
@@ -33,7 +33,7 @@ client.user.create_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/plain-text/README.md
+++ b/seed/python-sdk/plain-text/README.md
@@ -30,7 +30,7 @@ client.service.get_text()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/property-access/README.md
+++ b/seed/python-sdk/property-access/README.md
@@ -41,7 +41,7 @@ client.create_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/README.md
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/README.md
@@ -77,7 +77,7 @@ client.search(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/README.md
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/README.md
@@ -77,7 +77,7 @@ client.search(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/query-parameters/no-custom-config/README.md
+++ b/seed/python-sdk/query-parameters/no-custom-config/README.md
@@ -81,7 +81,7 @@ client.user.get_username(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/request-parameters/README.md
+++ b/seed/python-sdk/request-parameters/README.md
@@ -35,7 +35,7 @@ client.user.create_username(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/reserved-keywords/README.md
+++ b/seed/python-sdk/reserved-keywords/README.md
@@ -32,7 +32,7 @@ client.package.test(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/response-property/README.md
+++ b/seed/python-sdk/response-property/README.md
@@ -32,7 +32,7 @@ client.service.get_movie(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/server-sent-event-examples/README.md
+++ b/seed/python-sdk/server-sent-event-examples/README.md
@@ -34,7 +34,7 @@ for chunk in response.data:
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/server-sent-events/README.md
+++ b/seed/python-sdk/server-sent-events/README.md
@@ -34,7 +34,7 @@ for chunk in response.data:
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/simple-api/README.md
+++ b/seed/python-sdk/simple-api/README.md
@@ -34,7 +34,7 @@ client.user.get(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/README.md
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/README.md
@@ -32,7 +32,7 @@ client.get_account(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/single-url-environment-default/README.md
+++ b/seed/python-sdk/single-url-environment-default/README.md
@@ -30,7 +30,7 @@ client.dummy.get_dummy()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/single-url-environment-no-default/README.md
+++ b/seed/python-sdk/single-url-environment-no-default/README.md
@@ -32,7 +32,7 @@ client.dummy.get_dummy()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/streaming-parameter/README.md
+++ b/seed/python-sdk/streaming-parameter/README.md
@@ -33,7 +33,7 @@ client.dummy.generate(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/streaming/no-custom-config/README.md
+++ b/seed/python-sdk/streaming/no-custom-config/README.md
@@ -34,7 +34,7 @@ for chunk in response.data:
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/streaming/skip-pydantic-validation/README.md
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/README.md
@@ -34,7 +34,7 @@ for chunk in response.data:
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/trace/README.md
+++ b/seed/python-sdk/trace/README.md
@@ -39,7 +39,7 @@ client.admin.update_test_submission_status(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/undiscriminated-unions/README.md
+++ b/seed/python-sdk/undiscriminated-unions/README.md
@@ -32,7 +32,7 @@ client.union.get(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/unions/no-custom-config/README.md
+++ b/seed/python-sdk/unions/no-custom-config/README.md
@@ -32,7 +32,7 @@ client.bigunion.get(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/unions/union-naming-v1/README.md
+++ b/seed/python-sdk/unions/union-naming-v1/README.md
@@ -32,7 +32,7 @@ client.bigunion.get(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/unions/union-utils/README.md
+++ b/seed/python-sdk/unions/union-utils/README.md
@@ -32,7 +32,7 @@ client.bigunion.get(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/unknown/README.md
+++ b/seed/python-sdk/unknown/README.md
@@ -32,7 +32,7 @@ client.unknown.post(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/validation/no-custom-config/README.md
+++ b/seed/python-sdk/validation/no-custom-config/README.md
@@ -35,7 +35,7 @@ client.create(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/validation/with-defaults/README.md
+++ b/seed/python-sdk/validation/with-defaults/README.md
@@ -35,7 +35,7 @@ client.create(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/variables/README.md
+++ b/seed/python-sdk/variables/README.md
@@ -31,7 +31,7 @@ client.service.post()
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/version-no-default/README.md
+++ b/seed/python-sdk/version-no-default/README.md
@@ -32,7 +32,7 @@ client.user.get_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/version/README.md
+++ b/seed/python-sdk/version/README.md
@@ -32,7 +32,7 @@ client.user.get_user(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio

--- a/seed/python-sdk/websocket-inferred-auth/README.md
+++ b/seed/python-sdk/websocket-inferred-auth/README.md
@@ -35,7 +35,7 @@ client.auth.get_token_with_client_credentials(
 
 ## Async Client
 
-The SDK also exports an `async` client so that you can make non-blocking calls to our API.
+The SDK also exports an `async` client so that you can make non-blocking calls to our API. Note that if you are constructing an Async httpx client class to pass into this client, use `httpx.AsyncClient()` instead of `httpx.Client()` (e.g. for the `httpx_client` parameter of this client).
 
 ```python
 import asyncio


### PR DESCRIPTION
## Description
Fixes [FER-6649](https://linear.app/buildwithfern/issue/FER-6649/bloomberg-add-async-client-clarification-to-main-readme-generator). 

Simple update to README generated, see files changed.

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
