### PR TITLE
fix(typescript): Rely on the version of pnpm in _package.json_ instead of hardcoding the version in GitHub workflows

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.1.1
+  changelogEntry:
+    - summary: |
+        Rely on the version of pnpm in _package.json_ instead of hardcoding the version in GitHub workflows.
+      type: fix
+  createdAt: "2025-09-23"
+  irVersion: 60
+
 - version: 3.1.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
@@ -66,9 +66,8 @@ jobs:
             usePnpm
                 ? `
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10`
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4`
                 : ""
         }
 
@@ -98,9 +97,8 @@ ${getTestJob({ config, packageManager })}`;
             usePnpm
                 ? `
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10`
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4`
                 : ""
         }
 
@@ -143,9 +141,8 @@ ${getTestJob({ config, packageManager })}`;
             usePnpm
                 ? `
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10`
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4`
                 : ""
         }
       
@@ -183,9 +180,8 @@ function getTestJob({
             usePnpm
                 ? `
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10`
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4`
                 : ""
         }
 

--- a/seed/ts-sdk/accept-header/.github/workflows/ci.yml
+++ b/seed/ts-sdk/accept-header/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/alias-extends/.github/workflows/ci.yml
+++ b/seed/ts-sdk/alias-extends/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/alias/.github/workflows/ci.yml
+++ b/seed/ts-sdk/alias/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/any-auth/.github/workflows/ci.yml
+++ b/seed/ts-sdk/any-auth/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/api-wide-base-path/.github/workflows/ci.yml
+++ b/seed/ts-sdk/api-wide-base-path/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/audiences/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/audiences/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/audiences/with-partner-audience/.github/workflows/ci.yml
+++ b/seed/ts-sdk/audiences/with-partner-audience/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/auth-environment-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/auth-environment-variables/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/basic-auth-environment-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/basic-auth-environment-variables/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/basic-auth/.github/workflows/ci.yml
+++ b/seed/ts-sdk/basic-auth/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/bearer-token-environment-variable/.github/workflows/ci.yml
+++ b/seed/ts-sdk/bearer-token-environment-variable/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/bytes-upload/.github/workflows/ci.yml
+++ b/seed/ts-sdk/bytes-upload/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/circular-references-advanced/.github/workflows/ci.yml
+++ b/seed/ts-sdk/circular-references-advanced/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/circular-references/.github/workflows/ci.yml
+++ b/seed/ts-sdk/circular-references/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/client-side-params/.github/workflows/ci.yml
+++ b/seed/ts-sdk/client-side-params/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/cross-package-type-names/.github/workflows/ci.yml
+++ b/seed/ts-sdk/cross-package-type-names/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/custom-auth/.github/workflows/ci.yml
+++ b/seed/ts-sdk/custom-auth/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/empty-clients/.github/workflows/ci.yml
+++ b/seed/ts-sdk/empty-clients/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/enum/.github/workflows/ci.yml
+++ b/seed/ts-sdk/enum/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/error-property/union-utils/.github/workflows/ci.yml
+++ b/seed/ts-sdk/error-property/union-utils/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/errors/.github/workflows/ci.yml
+++ b/seed/ts-sdk/errors/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/examples/examples-with-api-reference/.github/workflows/ci.yml
+++ b/seed/ts-sdk/examples/examples-with-api-reference/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/examples/retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/examples/retain-original-casing/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/bigint/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/bigint/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/jsr/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/jsr/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -91,9 +88,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/never-throw-errors/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/node-fetch/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/node-fetch/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/package-path/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/package-path/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/serde-layer/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/serde-layer/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/use-jest/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/use-jest/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/exhaustive/with-audiences/.github/workflows/ci.yml
+++ b/seed/ts-sdk/exhaustive/with-audiences/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/extends/.github/workflows/ci.yml
+++ b/seed/ts-sdk/extends/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/extra-properties/.github/workflows/ci.yml
+++ b/seed/ts-sdk/extra-properties/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-download/file-download-response-headers/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-download/file-download-response-headers/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-download/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-download/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-download/stream/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-download/stream/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-download/wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-download/wrapper/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-upload/form-data-node16/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/form-data-node16/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-upload/inline/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/inline/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-upload/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-upload/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/serde/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-upload/use-jest/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/use-jest/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/file-upload/wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/file-upload/wrapper/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/folders/.github/workflows/ci.yml
+++ b/seed/ts-sdk/folders/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/http-head/.github/workflows/ci.yml
+++ b/seed/ts-sdk/http-head/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/idempotency-headers/.github/workflows/ci.yml
+++ b/seed/ts-sdk/idempotency-headers/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/imdb/branded-string-aliases/.github/workflows/ci.yml
+++ b/seed/ts-sdk/imdb/branded-string-aliases/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/imdb/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/imdb/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/imdb/noScripts/.github/workflows/ci.yml
+++ b/seed/ts-sdk/imdb/noScripts/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/imdb/omit-undefined/.github/workflows/ci.yml
+++ b/seed/ts-sdk/imdb/omit-undefined/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/inferred-auth-explicit/.github/workflows/ci.yml
+++ b/seed/ts-sdk/inferred-auth-explicit/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/inferred-auth-implicit/.github/workflows/ci.yml
+++ b/seed/ts-sdk/inferred-auth-implicit/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/license/.github/workflows/ci.yml
+++ b/seed/ts-sdk/license/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/literal/.github/workflows/ci.yml
+++ b/seed/ts-sdk/literal/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/literals-unions/.github/workflows/ci.yml
+++ b/seed/ts-sdk/literals-unions/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/mixed-case/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/mixed-case/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/mixed-file-directory/.github/workflows/ci.yml
+++ b/seed/ts-sdk/mixed-file-directory/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/multi-line-docs/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multi-line-docs/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/multi-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multi-url-environment-no-default/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/multi-url-environment/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multi-url-environment/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/multiple-request-bodies/.github/workflows/ci.yml
+++ b/seed/ts-sdk/multiple-request-bodies/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/no-environment/.github/workflows/ci.yml
+++ b/seed/ts-sdk/no-environment/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/nullable-optional/.github/workflows/ci.yml
+++ b/seed/ts-sdk/nullable-optional/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/nullable/.github/workflows/ci.yml
+++ b/seed/ts-sdk/nullable/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials-custom/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-custom/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-default/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/oauth-client-credentials/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/oauth-client-credentials/serde/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/object/.github/workflows/ci.yml
+++ b/seed/ts-sdk/object/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/objects-with-imports/.github/workflows/ci.yml
+++ b/seed/ts-sdk/objects-with-imports/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/optional/.github/workflows/ci.yml
+++ b/seed/ts-sdk/optional/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/package-yml/.github/workflows/ci.yml
+++ b/seed/ts-sdk/package-yml/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/pagination-custom/.github/workflows/ci.yml
+++ b/seed/ts-sdk/pagination-custom/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/pagination/.github/workflows/ci.yml
+++ b/seed/ts-sdk/pagination/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-retain-original-casing/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/path-parameters/inline-path-parameters-serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters-serde/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/path-parameters/inline-path-parameters/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/inline-path-parameters/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/path-parameters/retain-original-casing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/plain-text/.github/workflows/ci.yml
+++ b/seed/ts-sdk/plain-text/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/.github/workflows/ci.yml
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/property-access/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/property-access/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/public-object/.github/workflows/ci.yml
+++ b/seed/ts-sdk/public-object/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/query-parameters-openapi/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters-openapi/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/query-parameters/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/query-parameters/serde-layer-query/.github/workflows/ci.yml
+++ b/seed/ts-sdk/query-parameters/serde-layer-query/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/request-parameters/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/.github/workflows/ci.yml
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/reserved-keywords/.github/workflows/ci.yml
+++ b/seed/ts-sdk/reserved-keywords/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/response-property/.github/workflows/ci.yml
+++ b/seed/ts-sdk/response-property/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/server-sent-event-examples/.github/workflows/ci.yml
+++ b/seed/ts-sdk/server-sent-event-examples/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/server-sent-events/.github/workflows/ci.yml
+++ b/seed/ts-sdk/server-sent-events/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/simple-api/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/simple-fhir/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-fhir/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/single-url-environment-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/single-url-environment-default/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/single-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/single-url-environment-no-default/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/streaming-parameter/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming-parameter/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/streaming/allow-custom-fetcher/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming/allow-custom-fetcher/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/streaming/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/streaming/no-serde-layer/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming/no-serde-layer/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/streaming/wrapper/.github/workflows/ci.yml
+++ b/seed/ts-sdk/streaming/wrapper/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/trace/exhaustive/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/exhaustive/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/trace/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/trace/serde-no-throwing/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/serde-no-throwing/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/trace/serde-trace/.github/workflows/ci.yml
+++ b/seed/ts-sdk/trace/serde-trace/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/ts-inline-types/inline/.github/workflows/ci.yml
+++ b/seed/ts-sdk/ts-inline-types/inline/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/ts-inline-types/no-inline/.github/workflows/ci.yml
+++ b/seed/ts-sdk/ts-inline-types/no-inline/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/.github/workflows/ci.yml
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/unions/.github/workflows/ci.yml
+++ b/seed/ts-sdk/unions/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/unknown/no-custom-config/.github/workflows/ci.yml
+++ b/seed/ts-sdk/unknown/no-custom-config/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/unknown/unknown-as-any/.github/workflows/ci.yml
+++ b/seed/ts-sdk/unknown/unknown-as-any/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/validation/.github/workflows/ci.yml
+++ b/seed/ts-sdk/validation/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/variables/.github/workflows/ci.yml
+++ b/seed/ts-sdk/variables/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/version-no-default/.github/workflows/ci.yml
+++ b/seed/ts-sdk/version-no-default/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/version/.github/workflows/ci.yml
+++ b/seed/ts-sdk/version/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/websocket/no-serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket/no-serde/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/websocket/no-websocket-clients/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket/no-websocket-clients/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install

--- a/seed/ts-sdk/websocket/serde/.github/workflows/ci.yml
+++ b/seed/ts-sdk/websocket/serde/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -33,9 +32,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
                 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install
@@ -54,9 +52,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Description

## Changes Made
Rely on the version of pnpm in _package.json_ instead of hardcoding the version in GitHub workflows

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
