### PR TITLE
feat(rust): Add documentation comments and remove warning for unused imports/exports

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{Utils::join_url, ApiError, ClientConfig, RequestOptions};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/generators/rust/base/src/asIs/mod.rs
+++ b/generators/rust/base/src/asIs/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::Utils;
+pub use utils::*;

--- a/generators/rust/base/src/asIs/mod.rs
+++ b/generators/rust/base/src/asIs/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::*;
+pub use utils::join_url;

--- a/generators/rust/base/src/asIs/request_options.rs
+++ b/generators/rust/base/src/asIs/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/generators/rust/base/src/asIs/utils.rs
+++ b/generators/rust/base/src/asIs/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/generators/rust/codegen/package.json
+++ b/generators/rust/codegen/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
     "compile": "tsc --build",

--- a/generators/rust/codegen/package.json
+++ b/generators/rust/codegen/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && tsc --build --clean",
     "compile": "tsc --build",
@@ -37,6 +39,6 @@
     "@types/node": "^18.7.18",
     "depcheck": "^1.4.6",
     "typescript": "5.8.3",
-    "vitest": "^2.0.5"
+    "vitest": "^2.1.9"
   }
 }

--- a/generators/rust/codegen/src/ast/Client.ts
+++ b/generators/rust/codegen/src/ast/Client.ts
@@ -1,4 +1,5 @@
 import { AstNode } from "./AstNode";
+import { DocComment } from "./DocComment";
 import { Writer } from "./Writer";
 
 /**
@@ -25,6 +26,7 @@ export declare namespace Client {
         returnType?: string;
         isAsync?: boolean;
         body?: string;
+        docs?: DocComment;
     }
 }
 
@@ -90,6 +92,11 @@ export class Client extends AstNode {
     }
 
     private writeMethod(writer: Writer, method: Client.SimpleMethod): void {
+        // Write method documentation first
+        if (method.docs) {
+            method.docs.write(writer);
+        }
+
         const params = method.parameters?.join(", ") || "";
         const returnType = method.returnType || "String";
         const asyncKeyword = method.isAsync ? "async " : "";

--- a/generators/rust/codegen/src/ast/DocComment.ts
+++ b/generators/rust/codegen/src/ast/DocComment.ts
@@ -1,0 +1,126 @@
+import { AstNode } from "./AstNode";
+import { Writer } from "./Writer";
+
+export declare namespace DocComment {
+    interface Parameter {
+        name: string;
+        description: string;
+    }
+
+    interface Args {
+        summary: string;
+        description?: string;
+        parameters?: Parameter[];
+        returns?: string;
+        errors?: string[];
+        examples?: string[];
+    }
+}
+
+export class DocComment extends AstNode {
+    private readonly summary: string;
+    private readonly description?: string;
+    private readonly parameters: DocComment.Parameter[];
+    private readonly returns?: string;
+    private readonly errors: string[];
+    private readonly examples: string[];
+
+    public constructor({ summary, description, parameters, returns, errors, examples }: DocComment.Args) {
+        super();
+        this.summary = this.sanitizeText(summary);
+        this.description = description ? this.sanitizeText(description) : undefined;
+        this.parameters = (parameters ?? []).map((param) => ({
+            name: param.name,
+            description: this.sanitizeText(param.description)
+        }));
+        this.returns = returns ? this.sanitizeText(returns) : undefined;
+        this.errors = (errors ?? []).map((e) => this.sanitizeText(e));
+        this.examples = (examples ?? []).map((e) => this.sanitizeText(e));
+    }
+
+    public write(writer: Writer): void {
+        // Write summary
+        this.writeMultilineText(writer, this.summary);
+
+        // Write description if present
+        if (this.description) {
+            writer.write("///");
+            writer.newLine();
+            this.writeMultilineText(writer, this.description);
+        }
+
+        // Write parameters using Rust documentation conventions
+        if (this.parameters.length > 0) {
+            writer.write("///");
+            writer.newLine();
+            writer.write("/// # Arguments");
+            writer.newLine();
+            writer.write("///");
+            writer.newLine();
+
+            this.parameters.forEach((param) => {
+                const paramLines = param.description.split("\n");
+                paramLines.forEach((line, lineIdx) => {
+                    if (lineIdx === 0) {
+                        writer.write(`/// * \`${param.name}\` - ${line.trim()}`);
+                    } else {
+                        writer.write(`/// ${line.trim()}`);
+                    }
+                    writer.newLine();
+                });
+            });
+        }
+
+        // Write return information
+        if (this.returns) {
+            writer.write("///");
+            writer.newLine();
+            writer.write("/// # Returns");
+            writer.newLine();
+            writer.write("///");
+            writer.newLine();
+            const returnLines = this.returns.split("\n");
+            returnLines.forEach((line) => {
+                writer.write(`/// ${line.trim()}`);
+                writer.newLine();
+            });
+        }
+
+        // Write examples
+        if (this.examples.length > 0) {
+            writer.write("///");
+            writer.newLine();
+            writer.write("/// # Examples");
+            writer.newLine();
+            writer.write("///");
+            writer.newLine();
+            this.examples.forEach((example) => {
+                writer.write("/// ```rust");
+                writer.newLine();
+                this.writeMultilineText(writer, example);
+                writer.write("/// ```");
+                writer.newLine();
+            });
+        }
+    }
+
+    private writeMultilineText(writer: Writer, text: string): void {
+        const lines = text.split("\n");
+        for (const line of lines) {
+            writer.write("/// ");
+            writer.write(line.trim());
+            writer.newLine();
+        }
+    }
+
+    /**
+     * Sanitizes text content to ensure it doesn't break Rust doc comment syntax.
+     */
+    private sanitizeText(text: string): string {
+        return text
+            .replace(/\r\n/g, "\n")
+            .replace(/\r/g, "\n")
+            .replace(/\x00/g, "") // Remove null bytes
+            .trim();
+    }
+}

--- a/generators/rust/codegen/src/ast/DocComment.ts
+++ b/generators/rust/codegen/src/ast/DocComment.ts
@@ -22,7 +22,6 @@ export class DocComment extends AstNode {
     private readonly description?: string;
     private readonly parameters: DocComment.Parameter[];
     private readonly returns?: string;
-    private readonly errors: string[];
     private readonly examples: string[];
 
     public constructor({ summary, description, parameters, returns, errors, examples }: DocComment.Args) {
@@ -34,7 +33,6 @@ export class DocComment extends AstNode {
             description: this.sanitizeText(param.description)
         }));
         this.returns = returns ? this.sanitizeText(returns) : undefined;
-        this.errors = (errors ?? []).map((e) => this.sanitizeText(e));
         this.examples = (examples ?? []).map((e) => this.sanitizeText(e));
     }
 
@@ -117,10 +115,13 @@ export class DocComment extends AstNode {
      * Sanitizes text content to ensure it doesn't break Rust doc comment syntax.
      */
     private sanitizeText(text: string): string {
-        return text
-            .replace(/\r\n/g, "\n")
-            .replace(/\r/g, "\n")
-            .replace(/\x00/g, "") // Remove null bytes
-            .trim();
+        return (
+            text
+                .replace(/\r\n/g, "\n")
+                .replace(/\r/g, "\n")
+                // biome-ignore lint/suspicious/noControlCharactersInRegex: allow
+                .replace(/\x00/g, "") // Remove null bytes
+                .trim()
+        );
     }
 }

--- a/generators/rust/codegen/src/ast/Enum.ts
+++ b/generators/rust/codegen/src/ast/Enum.ts
@@ -1,5 +1,6 @@
 import { AstNode } from "./AstNode";
 import { Attribute } from "./Attribute";
+import { DocComment } from "./DocComment";
 import { EnumVariant } from "./EnumVariant";
 import { Visibility } from "./types";
 import { writeVisibility } from "./utils/writeVisibility";
@@ -11,6 +12,7 @@ export declare namespace Enum {
         visibility?: Visibility;
         attributes?: Attribute[];
         variants: EnumVariant[];
+        docs?: DocComment;
     }
 }
 
@@ -19,16 +21,23 @@ export class Enum extends AstNode {
     public readonly visibility?: Visibility;
     public readonly attributes?: Attribute[];
     public readonly variants: EnumVariant[];
+    public readonly docs?: DocComment;
 
-    public constructor({ name, visibility, attributes, variants }: Enum.Args) {
+    public constructor({ name, visibility, attributes, variants, docs }: Enum.Args) {
         super();
         this.name = name;
         this.visibility = visibility;
         this.attributes = attributes;
         this.variants = variants;
+        this.docs = docs;
     }
 
     public write(writer: Writer): void {
+        // Write documentation first
+        if (this.docs) {
+            this.docs.write(writer);
+        }
+
         // Write attributes above the enum
         if (this.attributes && this.attributes.length > 0) {
             this.attributes.forEach((attribute) => {

--- a/generators/rust/codegen/src/ast/Field.ts
+++ b/generators/rust/codegen/src/ast/Field.ts
@@ -1,5 +1,6 @@
 import { AstNode } from "./AstNode";
 import { Attribute } from "./Attribute";
+import { DocComment } from "./DocComment";
 import { Type } from "./Type";
 import { Visibility } from "./types";
 import { writeVisibility } from "./utils/writeVisibility";
@@ -11,6 +12,7 @@ export declare namespace Field {
         type: Type;
         visibility?: Visibility;
         attributes?: Attribute[];
+        docs?: DocComment;
     }
 }
 
@@ -19,16 +21,32 @@ export class Field extends AstNode {
     public readonly type: Type;
     public readonly visibility?: Visibility;
     public readonly attributes?: Attribute[];
+    public readonly docs?: DocComment;
 
-    public constructor({ name, type, visibility, attributes }: Field.Args) {
+    public constructor({ name, type, visibility, attributes, docs }: Field.Args) {
         super();
         this.name = name;
         this.type = type;
         this.visibility = visibility;
         this.attributes = attributes;
+        this.docs = docs;
     }
 
     public write(writer: Writer): void {
+        // Write documentation first (with proper indentation)
+        if (this.docs) {
+            // Create a temporary writer for the docs to get proper formatting
+            const docWriter = new Writer();
+            this.docs.write(docWriter);
+            const docString = docWriter.toString();
+            const docLines = docString.split("\n").filter((line) => line.trim());
+            docLines.forEach((line) => {
+                writer.write("    "); // Field indentation
+                writer.write(line.trim());
+                writer.newLine();
+            });
+        }
+
         // Write attributes on separate lines above the field
         if (this.attributes && this.attributes.length > 0) {
             this.attributes.forEach((attribute) => {

--- a/generators/rust/codegen/src/ast/Struct.ts
+++ b/generators/rust/codegen/src/ast/Struct.ts
@@ -1,5 +1,6 @@
 import { AstNode } from "./AstNode";
 import { Attribute } from "./Attribute";
+import { DocComment } from "./DocComment";
 import { Field } from "./Field";
 import { Visibility } from "./types";
 import { writeVisibility } from "./utils/writeVisibility";
@@ -11,6 +12,7 @@ export declare namespace Struct {
         visibility?: Visibility;
         attributes?: Attribute[];
         fields: Field[];
+        docs?: DocComment;
     }
 }
 
@@ -19,16 +21,23 @@ export class Struct extends AstNode {
     public readonly visibility?: Visibility;
     public readonly attributes?: Attribute[];
     public readonly fields: Field[];
+    public readonly docs?: DocComment;
 
-    public constructor({ name, visibility, attributes, fields }: Struct.Args) {
+    public constructor({ name, visibility, attributes, fields, docs }: Struct.Args) {
         super();
         this.name = name;
         this.visibility = visibility;
         this.attributes = attributes;
         this.fields = fields;
+        this.docs = docs;
     }
 
     public write(writer: Writer): void {
+        // Write documentation first
+        if (this.docs) {
+            this.docs.write(writer);
+        }
+
         // Write attributes above the struct
         if (this.attributes && this.attributes.length > 0) {
             this.attributes.forEach((attribute) => {

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/doc-comment.test.ts
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/doc-comment.test.ts
@@ -1,0 +1,211 @@
+import { rust } from "../../..";
+
+describe("DocComment", () => {
+    describe("write", () => {
+        it("should write basic doc comment with summary only", async () => {
+            const docComment = rust.docComment({
+                summary: "This is a basic function"
+            });
+
+            await expect(docComment.toString()).toMatchFileSnapshot("snapshots/basic_summary.rs");
+        });
+
+        it("should write doc comment with summary and description", async () => {
+            const docComment = rust.docComment({
+                summary: "Processes user data",
+                description: "This function takes user input and processes it according to the business rules."
+            });
+
+            await expect(docComment.toString()).toMatchFileSnapshot("snapshots/summary_and_description.rs");
+        });
+
+        it("should write doc comment with parameters", async () => {
+            const docComment = rust.docComment({
+                summary: "Creates a new user account",
+                parameters: [
+                    { name: "username", description: "The desired username for the account" },
+                    { name: "email", description: "User's email address" },
+                    { name: "is_active", description: "Whether the account should be active initially" }
+                ]
+            });
+
+            await expect(docComment.toString()).toMatchFileSnapshot("snapshots/with_parameters.rs");
+        });
+
+        it("should write doc comment with returns", async () => {
+            const docComment = rust.docComment({
+                summary: "Calculates the total price",
+                returns: "The total price including tax and fees"
+            });
+
+            await expect(docComment.toString()).toMatchFileSnapshot("snapshots/with_returns.rs");
+        });
+
+        it("should write doc comment with errors", async () => {
+            const docComment = rust.docComment({
+                summary: "Validates user input",
+                errors: [
+                    "Returns `ValidationError` if the input is invalid",
+                    "Returns `NetworkError` if the validation service is unavailable"
+                ]
+            });
+
+            await expect(docComment.toString()).toMatchFileSnapshot("snapshots/with_errors.rs");
+        });
+
+        it("should write doc comment with examples", async () => {
+            const docComment = rust.docComment({
+                summary: "Concatenates two strings",
+                examples: ['let result = concat_strings("hello", "world");\nassert_eq!(result, "helloworld");']
+            });
+
+            await expect(docComment.toString()).toMatchFileSnapshot("snapshots/with_examples.rs");
+        });
+
+        it("should write complete doc comment with all sections", async () => {
+            const docComment = rust.docComment({
+                summary: "Authenticates a user with the service",
+                description:
+                    "This method validates user credentials against the authentication service and returns a token if successful.",
+                parameters: [
+                    { name: "username", description: "The user's login name" },
+                    { name: "password", description: "The user's password" },
+                    { name: "options", description: "Additional authentication options" }
+                ],
+                returns: "Authentication token if successful",
+                errors: [
+                    "Returns `AuthError` if credentials are invalid",
+                    "Returns `NetworkError` if unable to reach the service",
+                    "Returns `TimeoutError` if the request times out"
+                ],
+                examples: [
+                    'let client = AuthClient::new();\nlet token = client.authenticate("user", "pass", None).await?;'
+                ]
+            });
+
+            await expect(docComment.toString()).toMatchFileSnapshot("snapshots/complete_doc_comment.rs");
+        });
+
+        describe("multiline handling", () => {
+            it("should handle multiline summary", async () => {
+                const docComment = rust.docComment({
+                    summary:
+                        "This is a very long summary that spans\nmultiple lines to test proper\nhandling of line breaks"
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/multiline_summary.rs");
+            });
+
+            it("should handle multiline description", async () => {
+                const docComment = rust.docComment({
+                    summary: "Process data",
+                    description:
+                        "This function processes data in multiple steps:\n\n1. Validates the input\n2. Transforms the data\n3. Returns the result"
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/multiline_description.rs");
+            });
+
+            it("should handle multiline parameters", async () => {
+                const docComment = rust.docComment({
+                    summary: "Get device information",
+                    parameters: [
+                        {
+                            name: "name_or_id",
+                            description:
+                                "Device name or ID. Device names must be URI-encoded if they contain\nnon-URI-safe characters. If a device is named with another device's ID,\nthe device with the matching name will be returned."
+                        },
+                        {
+                            name: "tolerance",
+                            description:
+                                "Minimum interval (in seconds) that ranges must be separated by to be considered discrete.\nCurrently, the minimum meaningful value is 14s and smaller values will be clamped to this value."
+                        }
+                    ]
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/multiline_parameters.rs");
+            });
+
+            it("should handle multiline returns", async () => {
+                const docComment = rust.docComment({
+                    summary: "Query data",
+                    returns:
+                        "A Result containing the queried data on success.\nReturns an empty Vec if no data matches the query criteria.\nThe data is sorted by timestamp in ascending order."
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/multiline_returns.rs");
+            });
+
+            it("should handle multiline errors", async () => {
+                const docComment = rust.docComment({
+                    summary: "Connect to database",
+                    errors: [
+                        "Returns `DatabaseError` if connection fails\ndue to network issues or invalid credentials",
+                        "Returns `TimeoutError` if the connection\nattempt exceeds the configured timeout"
+                    ]
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/multiline_errors.rs");
+            });
+        });
+
+        describe("text sanitization", () => {
+            it("should sanitize null bytes", async () => {
+                const docComment = rust.docComment({
+                    summary: "Function with null\x00bytes in description",
+                    description: "This has\x00null\x00bytes that should be removed"
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/sanitized_null_bytes.rs");
+            });
+
+            it("should sanitize carriage returns", async () => {
+                const docComment = rust.docComment({
+                    summary: "Function with\r\ncarriage returns",
+                    description: "This has\rcarriage\r\nreturns that should be normalized"
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/sanitized_carriage_returns.rs");
+            });
+
+            it("should handle special characters", async () => {
+                const docComment = rust.docComment({
+                    summary: "Function with special chars: @#$%^&*(){}[]|\\:;\"'<>,.?/",
+                    description: "Tests various special characters that might break formatting"
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/special_characters.rs");
+            });
+
+            it("should handle backticks and code formatting", async () => {
+                const docComment = rust.docComment({
+                    summary: "Use `cargo build` to compile",
+                    description: "This function uses `serde` for serialization and `tokio` for async operations",
+                    parameters: [{ name: "config", description: "Configuration with `debug` and `release` modes" }]
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/code_formatting.rs");
+            });
+        });
+
+        describe("edge cases", () => {
+            it("should handle empty lines in multiline text", async () => {
+                const docComment = rust.docComment({
+                    summary: "Function with empty lines",
+                    description: "First paragraph.\n\nSecond paragraph after empty line.\n\nThird paragraph."
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/empty_lines.rs");
+            });
+
+            it("should handle very long lines", async () => {
+                const docComment = rust.docComment({
+                    summary:
+                        "This is a very long line of documentation that should be wrapped properly to ensure it doesn't cause any syntax errors in the generated Rust code when the line exceeds reasonable length limits and needs to be broken into multiple comment lines for better readability"
+                });
+
+                await expect(docComment.toString()).toMatchFileSnapshot("snapshots/long_lines.rs");
+            });
+        });
+    });
+});

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/basic_summary.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/basic_summary.rs
@@ -1,0 +1,1 @@
+/// This is a basic function

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/code_formatting.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/code_formatting.rs
@@ -1,0 +1,7 @@
+/// Use `cargo build` to compile
+///
+/// This function uses `serde` for serialization and `tokio` for async operations
+///
+/// # Arguments
+///
+/// * `config` - Configuration with `debug` and `release` modes

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/complete_doc_comment.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/complete_doc_comment.rs
@@ -1,0 +1,20 @@
+/// Authenticates a user with the service
+///
+/// This method validates user credentials against the authentication service and returns a token if successful.
+///
+/// # Arguments
+///
+/// * `username` - The user's login name
+/// * `password` - The user's password
+/// * `options` - Additional authentication options
+///
+/// # Returns
+///
+/// Authentication token if successful
+///
+/// # Examples
+///
+/// ```rust
+/// let client = AuthClient::new();
+/// let token = client.authenticate("user", "pass", None).await?;
+/// ```

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/empty_lines.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/empty_lines.rs
@@ -1,0 +1,7 @@
+/// Function with empty lines
+///
+/// First paragraph.
+/// 
+/// Second paragraph after empty line.
+/// 
+/// Third paragraph.

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/long_lines.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/long_lines.rs
@@ -1,0 +1,1 @@
+/// This is a very long line of documentation that should be wrapped properly to ensure it doesn't cause any syntax errors in the generated Rust code when the line exceeds reasonable length limits and needs to be broken into multiple comment lines for better readability

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_description.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_description.rs
@@ -1,0 +1,7 @@
+/// Process data
+///
+/// This function processes data in multiple steps:
+/// 
+/// 1. Validates the input
+/// 2. Transforms the data
+/// 3. Returns the result

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_errors.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_errors.rs
@@ -1,0 +1,1 @@
+/// Connect to database

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_parameters.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_parameters.rs
@@ -1,0 +1,9 @@
+/// Get device information
+///
+/// # Arguments
+///
+/// * `name_or_id` - Device name or ID. Device names must be URI-encoded if they contain
+/// non-URI-safe characters. If a device is named with another device's ID,
+/// the device with the matching name will be returned.
+/// * `tolerance` - Minimum interval (in seconds) that ranges must be separated by to be considered discrete.
+/// Currently, the minimum meaningful value is 14s and smaller values will be clamped to this value.

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_returns.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_returns.rs
@@ -1,0 +1,7 @@
+/// Query data
+///
+/// # Returns
+///
+/// A Result containing the queried data on success.
+/// Returns an empty Vec if no data matches the query criteria.
+/// The data is sorted by timestamp in ascending order.

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_summary.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/multiline_summary.rs
@@ -1,0 +1,3 @@
+/// This is a very long summary that spans
+/// multiple lines to test proper
+/// handling of line breaks

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/sanitized_carriage_returns.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/sanitized_carriage_returns.rs
@@ -1,0 +1,6 @@
+/// Function with
+/// carriage returns
+///
+/// This has
+/// carriage
+/// returns that should be normalized

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/sanitized_null_bytes.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/sanitized_null_bytes.rs
@@ -1,0 +1,3 @@
+/// Function with nullbytes in description
+///
+/// This hasnullbytes that should be removed

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/special_characters.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/special_characters.rs
@@ -1,0 +1,3 @@
+/// Function with special chars: @#$%^&*(){}[]|\:;"'<>,.?/
+///
+/// Tests various special characters that might break formatting

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/summary_and_description.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/summary_and_description.rs
@@ -1,0 +1,3 @@
+/// Processes user data
+///
+/// This function takes user input and processes it according to the business rules.

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_errors.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_errors.rs
@@ -1,0 +1,1 @@
+/// Validates user input

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_examples.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_examples.rs
@@ -1,0 +1,8 @@
+/// Concatenates two strings
+///
+/// # Examples
+///
+/// ```rust
+/// let result = concat_strings("hello", "world");
+/// assert_eq!(result, "helloworld");
+/// ```

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_parameters.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_parameters.rs
@@ -1,0 +1,7 @@
+/// Creates a new user account
+///
+/// # Arguments
+///
+/// * `username` - The desired username for the account
+/// * `email` - User's email address
+/// * `is_active` - Whether the account should be active initially

--- a/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_returns.rs
+++ b/generators/rust/codegen/src/ast/__test__/doc-comment/snapshots/with_returns.rs
@@ -1,0 +1,5 @@
+/// Calculates the total price
+///
+/// # Returns
+///
+/// The total price including tax and fees

--- a/generators/rust/codegen/src/ast/index.ts
+++ b/generators/rust/codegen/src/ast/index.ts
@@ -2,6 +2,7 @@ export { AstNode } from "./AstNode";
 export { Attribute } from "./Attribute";
 export { Client } from "./Client";
 export { CodeBlock } from "./CodeBlock";
+export { DocComment } from "./DocComment";
 export { Enum } from "./Enum";
 export { EnumVariant } from "./EnumVariant";
 export { Expression } from "./Expression";

--- a/generators/rust/codegen/src/rust.ts
+++ b/generators/rust/codegen/src/rust.ts
@@ -3,6 +3,7 @@ import {
     Attribute,
     Client,
     CodeBlock,
+    DocComment,
     Enum,
     EnumVariant,
     Expression,
@@ -99,6 +100,10 @@ export function client(args: Client.Args): Client {
     return new Client(args);
 }
 
+export function docComment(args: DocComment.Args): DocComment {
+    return new DocComment(args);
+}
+
 // Factory function for Writer creation
 export function writer(): Writer {
     return new Writer();
@@ -119,6 +124,7 @@ export const rust = {
     ImplBlock,
     Module,
     Client,
+    DocComment,
     Expression,
     Statement,
     CodeBlock,
@@ -135,6 +141,7 @@ export const rust = {
     implBlock,
     module,
     client,
+    docComment,
     writer,
     visibility: {
         public: PUBLIC as Visibility,

--- a/generators/rust/codegen/tsconfig.json
+++ b/generators/rust/codegen/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["vitest/globals"]
   },
   "include": ["./src/**/*"]
 }

--- a/generators/rust/model/src/alias/AliasGenerator.ts
+++ b/generators/rust/model/src/alias/AliasGenerator.ts
@@ -4,13 +4,7 @@ import { Attribute, PUBLIC, rust } from "@fern-api/rust-codegen";
 import { AliasTypeDeclaration, TypeDeclaration, TypeReference } from "@fern-fern/ir-sdk/api";
 import { generateRustTypeForTypeReference } from "../converters";
 import { ModelGeneratorContext } from "../ModelGeneratorContext";
-import {
-    isChronoType,
-    isCollectionType,
-    isUnknownType,
-    isUuidType,
-    typeSupportsHashAndEq
-} from "../utils/primitiveTypeUtils";
+import { isChronoType, isCollectionType, isUuidType, typeSupportsHashAndEq } from "../utils/primitiveTypeUtils";
 
 export class AliasGenerator {
     private readonly typeDeclaration: TypeDeclaration;
@@ -91,10 +85,10 @@ export class AliasGenerator {
             writer.writeLine("use std::collections::HashMap;");
         }
 
-        // Add serde_json if aliasing unknown type
-        if (isUnknownType(innerType)) {
-            writer.writeLine("use serde_json::Value;");
-        }
+        // TODO: @iamnamananand996 build to use serde_json::Value ---> Value directly
+        // if (hasJsonValueFields(properties)) {
+        //     writer.writeLine("use serde_json::Value;");
+        // }
     }
 
     private generateNewtypeForTypeDeclaration(): rust.NewtypeStruct {

--- a/generators/rust/model/src/converters/getRustTypeForTypeReference.ts
+++ b/generators/rust/model/src/converters/getRustTypeForTypeReference.ts
@@ -75,25 +75,22 @@ export function generateRustTypeForTypeReference(typeReference: TypeReference): 
                     );
                 },
                 date: () => {
-                    // Use chrono::NaiveDate for date-only
+                    // Use NaiveDate for date-only (imported from chrono)
                     return rust.Type.reference(
                         rust.reference({
-                            name: "NaiveDate",
-                            module: "chrono"
+                            name: "NaiveDate"
                         })
                     );
                 },
                 dateTime: () => {
-                    // Use chrono::DateTime<Utc> for timestamps
+                    // Use DateTime<Utc> for timestamps (imported from chrono)
                     return rust.Type.reference(
                         rust.reference({
                             name: "DateTime",
-                            module: "chrono",
                             genericArgs: [
                                 rust.Type.reference(
                                     rust.reference({
-                                        name: "Utc",
-                                        module: "chrono"
+                                        name: "Utc"
                                     })
                                 )
                             ]

--- a/generators/rust/model/src/enum/EnumGenerator.ts
+++ b/generators/rust/model/src/enum/EnumGenerator.ts
@@ -64,7 +64,12 @@ export class EnumGenerator {
             name: this.typeDeclaration.name.name.pascalCase.unsafeName,
             visibility: PUBLIC,
             attributes: this.generateEnumAttributes(),
-            variants: this.enumTypeDeclaration.values.map((enumValue) => this.generateEnumVariant(enumValue))
+            variants: this.enumTypeDeclaration.values.map((enumValue) => this.generateEnumVariant(enumValue)),
+            docs: this.typeDeclaration.docs
+                ? rust.docComment({
+                      summary: this.typeDeclaration.docs
+                  })
+                : undefined
         });
     }
 
@@ -89,7 +94,12 @@ export class EnumGenerator {
 
         return rust.enumVariant({
             name: enumValue.name.name.pascalCase.unsafeName,
-            attributes: variantAttributes.length > 0 ? variantAttributes : undefined
+            attributes: variantAttributes.length > 0 ? variantAttributes : undefined,
+            docs: enumValue.docs
+                ? rust.docComment({
+                      summary: enumValue.docs
+                  })
+                : undefined
         });
     }
 

--- a/generators/rust/model/src/object/StructGenerator.ts
+++ b/generators/rust/model/src/object/StructGenerator.ts
@@ -91,6 +91,7 @@ export class StructGenerator {
         const hasDateOnly = hasDateFields(this.objectTypeDeclaration.properties);
         const hasDateTimeOnly = hasDateTimeOnlyFields(this.objectTypeDeclaration.properties);
 
+        // TODO: @iamnamananand996 - use AST mechanism for all imports
         if (hasDateOnly && hasDateTimeOnly) {
             // Both date and datetime types present
             writer.writeLine("use chrono::{DateTime, NaiveDate, Utc};");

--- a/generators/rust/model/src/object/StructGenerator.ts
+++ b/generators/rust/model/src/object/StructGenerator.ts
@@ -141,7 +141,12 @@ export class StructGenerator {
             name: this.typeDeclaration.name.name.pascalCase.unsafeName,
             visibility: PUBLIC,
             attributes: this.generateStructAttributes(),
-            fields
+            fields,
+            docs: this.typeDeclaration.docs
+                ? rust.docComment({
+                      summary: this.typeDeclaration.docs
+                  })
+                : undefined
         });
     }
 
@@ -175,7 +180,12 @@ export class StructGenerator {
             name: fieldName,
             type: fieldType,
             visibility: PUBLIC,
-            attributes: fieldAttributes
+            attributes: fieldAttributes,
+            docs: property.docs
+                ? rust.docComment({
+                      summary: property.docs
+                  })
+                : undefined
         });
     }
 

--- a/generators/rust/model/src/union/UndiscriminatedUnionGenerator.ts
+++ b/generators/rust/model/src/union/UndiscriminatedUnionGenerator.ts
@@ -69,6 +69,7 @@ export class UndiscriminatedUnionGenerator {
         const hasDateOnly = this.hasDateFields();
         const hasDateTimeOnly = this.hasDateTimeOnlyFields();
 
+        // TODO: @iamnamananand996 - use AST mechanism for all imports
         if (hasDateOnly && hasDateTimeOnly) {
             // Both date and datetime types present
             writer.writeLine("use chrono::{DateTime, NaiveDate, Utc};");

--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -64,6 +64,7 @@ export class UnionGenerator {
         const hasDateOnly = this.hasDateFields();
         const hasDateTimeOnly = this.hasDateTimeOnlyFields();
 
+        // TODO: @iamnamananand996 - use AST mechanism for all imports
         if (hasDateOnly && hasDateTimeOnly) {
             // Both date and datetime types present
             writer.writeLine("use chrono::{DateTime, NaiveDate, Utc};");

--- a/generators/rust/model/src/utils/structUtils.ts
+++ b/generators/rust/model/src/utils/structUtils.ts
@@ -162,6 +162,7 @@ export function writeStructUseStatements(
     const hasDateOnly = hasDateFields(properties);
     const hasDateTimeOnly = hasDateTimeOnlyFields(properties);
 
+    // TODO: @iamnamananand996 - use AST mechanism for all imports
     if (hasDateOnly && hasDateTimeOnly) {
         // Both date and datetime types present
         writer.writeLine("use chrono::{DateTime, NaiveDate, Utc};");

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -145,6 +145,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
 
     private generateApiModFile(context: SdkGeneratorContext): RustFile {
         const hasTypes = this.hasTypes(context);
+        const clientName = context.getClientName();
         const moduleDeclarations: ModuleDeclaration[] = [];
         const useStatements: UseStatement[] = [];
 
@@ -155,7 +156,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
         }
 
         // Add re-exports
-        useStatements.push(new UseStatement({ path: "resources", items: ["*"], isPublic: true }));
+        useStatements.push(new UseStatement({ path: "resources", items: [clientName], isPublic: true }));
         if (hasTypes) {
             useStatements.push(new UseStatement({ path: "types", items: ["*"], isPublic: true }));
         }

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -1,4 +1,4 @@
-use crate::{Utils::join_url, ApiError, ClientConfig, RequestOptions};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/generators/rust/sdk/src/__test__/snapshots/request-options-comprehensive.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/request-options-comprehensive.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.3.1
+- version: 0.3.0
   createdAt: "2025-09-24"
   changelogEntry:
     - type: feat

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.3.1
+  createdAt: "2025-09-24"
+  changelogEntry:
+    - type: feat
+      summary: Add documentation comments and remove warning for unused imports/exports
+  irVersion: 59
+
 - version: 0.2.1
   createdAt: "2025-09-23"
   changelogEntry:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1929,7 +1929,7 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^2.0.5
+        specifier: ^2.1.9
         version: 2.1.9(@types/node@18.15.3)(sass@1.93.0)
 
   generators/rust/dynamic-snippets:

--- a/seed/rust-model/alias/src/type_.rs
+++ b/seed/rust-model/alias/src/type_.rs
@@ -1,6 +1,7 @@
 use crate::type_id::TypeId;
 use serde::{Deserialize, Serialize};
 
+/// A simple type with just a name.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Type {
     pub id: TypeId,

--- a/seed/rust-model/any-auth/src/auth_token_response.rs
+++ b/seed/rust-model/any-auth/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/circular-references-advanced/src/ast_object_field_value.rs
+++ b/seed/rust-model/circular-references-advanced/src/ast_object_field_value.rs
@@ -2,6 +2,7 @@ use crate::ast_field_name::FieldName;
 use crate::ast_field_value::FieldValue;
 use serde::{Deserialize, Serialize};
 
+/// This type allows us to test a circular reference with a union type (see FieldValue).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObjectFieldValue {
     pub name: FieldName,

--- a/seed/rust-model/client-side-params/src/get_client_query_request.rs
+++ b/seed/rust-model/client-side-params/src/get_client_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetClientQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-model/client-side-params/src/get_connection_query_request.rs
+++ b/seed/rust-model/client-side-params/src/get_connection_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetConnectionQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-model/client-side-params/src/get_user_by_id_query_request.rs
+++ b/seed/rust-model/client-side-params/src/get_user_by_id_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetUserByIdQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-model/client-side-params/src/list_clients_query_request.rs
+++ b/seed/rust-model/client-side-params/src/list_clients_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListClientsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-model/client-side-params/src/list_connections_query_request.rs
+++ b/seed/rust-model/client-side-params/src/list_connections_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListConnectionsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub strategy: Option<String>,

--- a/seed/rust-model/client-side-params/src/list_users_query_request.rs
+++ b/seed/rust-model/client-side-params/src/list_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-model/client-side-params/src/types_client.rs
+++ b/seed/rust-model/client-side-params/src/types_client.rs
@@ -1,64 +1,95 @@
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
+/// Represents a client application
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Client {
+    /// The unique client identifier
     pub client_id: String,
+    /// The tenant name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tenant: Option<String>,
+    /// Name of the client
     pub name: String,
+    /// Free text description of the client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Whether this is a global client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global: Option<bool>,
+    /// The client secret (only for non-public clients)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_secret: Option<String>,
+    /// The type of application (spa, native, regular_web, non_interactive)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub app_type: Option<String>,
+    /// URL of the client logo
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logo_uri: Option<String>,
+    /// Whether this client is a first party client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_first_party: Option<bool>,
+    /// Whether this client conforms to OIDC specifications
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oidc_conformant: Option<bool>,
+    /// Allowed callback URLs
     #[serde(skip_serializing_if = "Option::is_none")]
     pub callbacks: Option<Vec<String>>,
+    /// Allowed origins for CORS
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_origins: Option<Vec<String>>,
+    /// Allowed web origins for CORS
     #[serde(skip_serializing_if = "Option::is_none")]
     pub web_origins: Option<Vec<String>>,
+    /// Allowed grant types
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grant_types: Option<Vec<String>>,
+    /// JWT configuration for the client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jwt_configuration: Option<HashMap<String, serde_json::Value>>,
+    /// Client signing keys
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signing_keys: Option<Vec<HashMap<String, serde_json::Value>>>,
+    /// Encryption key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encryption_key: Option<HashMap<String, serde_json::Value>>,
+    /// Whether SSO is enabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sso: Option<bool>,
+    /// Whether SSO is disabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sso_disabled: Option<bool>,
+    /// Whether to use cross-origin authentication
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cross_origin_auth: Option<bool>,
+    /// URL for cross-origin authentication
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cross_origin_loc: Option<String>,
+    /// Whether a custom login page is enabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_login_page_on: Option<bool>,
+    /// Custom login page URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_login_page: Option<String>,
+    /// Custom login page preview URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_login_page_preview: Option<String>,
+    /// Form template for WS-Federation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form_template: Option<String>,
+    /// Whether this is a Heroku application
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_heroku_app: Option<bool>,
+    /// Addons enabled for this client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addons: Option<HashMap<String, serde_json::Value>>,
+    /// Requested authentication method for the token endpoint
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_endpoint_auth_method: Option<String>,
+    /// Metadata associated with the client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_metadata: Option<HashMap<String, serde_json::Value>>,
+    /// Mobile app settings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mobile: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-model/client-side-params/src/types_connection.rs
+++ b/seed/rust-model/client-side-params/src/types_connection.rs
@@ -1,21 +1,31 @@
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
+/// Represents an identity provider connection
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Connection {
+    /// Connection identifier
     pub id: String,
+    /// Connection name
     pub name: String,
+    /// Display name for the connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// The identity provider identifier (auth0, google-oauth2, facebook, etc.)
     pub strategy: String,
+    /// Connection-specific configuration options
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, serde_json::Value>>,
+    /// List of client IDs that can use this connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled_clients: Option<Vec<String>>,
+    /// Applicable realms for enterprise connections
     #[serde(skip_serializing_if = "Option::is_none")]
     pub realms: Option<Vec<String>>,
+    /// Whether this is a domain connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_domain_connection: Option<bool>,
+    /// Additional metadata
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-model/client-side-params/src/types_paginated_client_response.rs
+++ b/seed/rust-model/client-side-params/src/types_paginated_client_response.rs
@@ -1,12 +1,18 @@
 use crate::types_client::Client;
 use serde::{Deserialize, Serialize};
 
+/// Paginated response for clients listing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaginatedClientResponse {
+    /// Starting index (zero-based)
     pub start: i32,
+    /// Number of items requested
     pub limit: i32,
+    /// Number of items returned
     pub length: i32,
+    /// Total number of items (when include_totals=true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<i32>,
+    /// List of clients
     pub clients: Vec<Client>,
 }

--- a/seed/rust-model/client-side-params/src/types_paginated_user_response.rs
+++ b/seed/rust-model/client-side-params/src/types_paginated_user_response.rs
@@ -1,6 +1,7 @@
 use crate::types_user::User;
 use serde::{Deserialize, Serialize};
 
+/// Response with pagination info like Auth0
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaginatedUserResponse {
     pub users: Vec<User>,

--- a/seed/rust-model/client-side-params/src/types_resource.rs
+++ b/seed/rust-model/client-side-params/src/types_resource.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
@@ -8,8 +8,8 @@ pub struct Resource {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-model/client-side-params/src/types_user.rs
+++ b/seed/rust-model/client-side-params/src/types_user.rs
@@ -1,8 +1,9 @@
 use crate::types_identity::Identity;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
+/// User object similar to Auth0 users
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub user_id: String,
@@ -14,8 +15,8 @@ pub struct User {
     pub phone_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone_verified: Option<bool>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identities: Option<Vec<Identity>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -33,7 +34,7 @@ pub struct User {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_ip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_login: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_login: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logins_count: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-model/content-type/src/named_mixed_patch_request.rs
+++ b/seed/rust-model/content-type/src/named_mixed_patch_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct NamedMixedPatchRequest {
     #[serde(rename = "appId")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-model/content-type/src/patch_complex_request.rs
+++ b/seed/rust-model/content-type/src/patch_complex_request.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PatchComplexRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/seed/rust-model/content-type/src/patch_proxy_request.rs
+++ b/seed/rust-model/content-type/src/patch_proxy_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct PatchProxyRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub application: Option<String>,

--- a/seed/rust-model/content-type/src/regular_patch_request.rs
+++ b/seed/rust-model/content-type/src/regular_patch_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct RegularPatchRequest {
     #[serde(rename = "field1")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-model/enum/src/operand.rs
+++ b/seed/rust-model/enum/src/operand.rs
@@ -1,12 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Tests enum name and value can be
+/// different.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Operand {
     #[serde(rename = ">")]
     GreaterThan,
     #[serde(rename = "=")]
     EqualTo,
+    /// The name and value should be similar
+    /// are similar for less than.
     #[serde(rename = "less_than")]
     LessThan,
 }

--- a/seed/rust-model/examples/src/get_metadata_query_request.rs
+++ b/seed/rust-model/examples/src/get_metadata_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetMetadataQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shallow: Option<bool>,

--- a/seed/rust-model/examples/src/types_migration_status.rs
+++ b/seed/rust-model/examples/src/types_migration_status.rs
@@ -3,8 +3,10 @@ use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum MigrationStatus {
+    /// The migration is running.
     #[serde(rename = "RUNNING")]
     Running,
+    /// The migration failed.
     #[serde(rename = "FAILED")]
     Failed,
     #[serde(rename = "FINISHED")]

--- a/seed/rust-model/examples/src/types_moment.rs
+++ b/seed/rust-model/examples/src/types_moment.rs
@@ -5,6 +5,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Moment {
     pub id: uuid::Uuid,
-    pub date: chrono::NaiveDate,
-    pub datetime: chrono::DateTime<chrono::Utc>,
+    pub date: NaiveDate,
+    pub datetime: DateTime<Utc>,
 }

--- a/seed/rust-model/examples/src/types_movie.rs
+++ b/seed/rust-model/examples/src/types_movie.rs
@@ -10,6 +10,7 @@ pub struct Movie {
     pub prequel: Option<MovieId>,
     pub title: String,
     pub from: String,
+    /// The rating scale is one to five stars
     pub rating: f64,
     pub r#type: String,
     pub tag: Tag,

--- a/seed/rust-model/examples/src/types_request.rs
+++ b/seed/rust-model/examples/src/types_request.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/seed/rust-model/examples/src/types_response.rs
+++ b/seed/rust-model/examples/src/types_response.rs
@@ -1,5 +1,4 @@
 use crate::identifier::Identifier;
-use serde_json::Value;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/seed/rust-model/exhaustive/src/types_docs_object_with_docs.rs
+++ b/seed/rust-model/exhaustive/src/types_docs_object_with_docs.rs
@@ -2,5 +2,60 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ObjectWithDocs {
+    /// Characters that could lead to broken generated SDKs:
+    ///
+    /// JSDoc (JavaScript/TypeScript):
+    /// - @: Used for JSDoc tags
+    /// - {: }: Used for type definitions
+    /// - <: >: HTML tags
+    /// - *: Can interfere with comment blocks
+    /// - /**: JSDoc comment start
+    /// - ** /: JSDoc comment end
+    /// - &: HTML entities
+    ///
+    /// XMLDoc (C#):
+    /// - <: >: XML tags
+    /// - &: ': ": <: >: XML special characters
+    /// - {: }: Used for interpolated strings
+    /// - ///: Comment marker
+    /// - /**: Block comment start
+    /// - ** /: Block comment end
+    ///
+    /// Javadoc (Java):
+    /// - @: Used for Javadoc tags
+    /// - <: >: HTML tags
+    /// - &: HTML entities
+    /// - *: Can interfere with comment blocks
+    /// - /**: Javadoc comment start
+    /// - ** /: Javadoc comment end
+    ///
+    /// Doxygen (C++):
+    /// - \: Used for Doxygen commands
+    /// - @: Alternative command prefix
+    /// - <: >: XML/HTML tags
+    /// - &: HTML entities
+    /// - /**: C-style comment start
+    /// - ** /: C-style comment end
+    ///
+    /// RDoc (Ruby):
+    /// - :: Used in symbol notation
+    /// - =: Section markers
+    /// - #: Comment marker
+    /// - =begin: Block comment start
+    /// - =end: Block comment end
+    /// - @: Instance variable prefix
+    /// - $: Global variable prefix
+    /// - %: String literal delimiter
+    /// - #{: String interpolation start
+    /// - }: String interpolation end
+    ///
+    /// PHPDoc (PHP):
+    /// - @: Used for PHPDoc tags
+    /// - {: }: Used for type definitions
+    /// - $: Variable prefix
+    /// - /**: PHPDoc comment start
+    /// - ** /: PHPDoc comment end
+    /// - *: Can interfere with comment blocks
+    /// - &: HTML entities
     pub string: String,
 }

--- a/seed/rust-model/exhaustive/src/types_object_object_with_optional_field.rs
+++ b/seed/rust-model/exhaustive/src/types_object_object_with_optional_field.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObjectWithOptionalField {
+    /// This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub string: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -16,9 +17,9 @@ pub struct ObjectWithOptionalField {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bool: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub datetime: Option<chrono::DateTime<chrono::Utc>>,
+    pub datetime: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub date: Option<chrono::NaiveDate>,
+    pub date: Option<NaiveDate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<uuid::Uuid>,
     #[serde(rename = "base64")]

--- a/seed/rust-model/imdb/src/imdb_movie.rs
+++ b/seed/rust-model/imdb/src/imdb_movie.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct Movie {
     pub id: MovieId,
     pub title: String,
+    /// The rating scale is one to five stars
     pub rating: f64,
 }

--- a/seed/rust-model/inferred-auth-explicit/src/auth_token_response.rs
+++ b/seed/rust-model/inferred-auth-explicit/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/inferred-auth-implicit-no-expiry/src/auth_token_response.rs
+++ b/seed/rust-model/inferred-auth-implicit-no-expiry/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/inferred-auth-implicit/src/auth_token_response.rs
+++ b/seed/rust-model/inferred-auth-implicit/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/license/src/type_.rs
+++ b/seed/rust-model/license/src/type_.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// A simple type with just a name.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Type {
     pub name: String,

--- a/seed/rust-model/mixed-case/src/list_resources_query_request.rs
+++ b/seed/rust-model/mixed-case/src/list_resources_query_request.rs
@@ -1,9 +1,9 @@
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListResourcesQueryRequest {
     pub page_limit: i32,
     #[serde(rename = "beforeDate")]
-    pub before_date: chrono::NaiveDate,
+    pub before_date: NaiveDate,
 }

--- a/seed/rust-model/mixed-file-directory/src/list_events_query_request.rs
+++ b/seed/rust-model/mixed-file-directory/src/list_events_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListEventsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-model/mixed-file-directory/src/list_query_request.rs
+++ b/seed/rust-model/mixed-file-directory/src/list_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-model/mixed-file-directory/src/user_events_metadata_metadata.rs
+++ b/seed/rust-model/mixed-file-directory/src/user_events_metadata_metadata.rs
@@ -1,5 +1,4 @@
 use crate::id::Id;
-use serde_json::Value;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/seed/rust-model/multi-line-docs/src/operand.rs
+++ b/seed/rust-model/multi-line-docs/src/operand.rs
@@ -1,12 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Tests enum name and value can be
+/// different.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Operand {
     #[serde(rename = ">")]
     GreaterThan,
     #[serde(rename = "=")]
     EqualTo,
+    /// The name and value should be similar
+    /// are similar for less than.
     #[serde(rename = "less_than")]
     LessThan,
 }

--- a/seed/rust-model/multi-line-docs/src/user_user.rs
+++ b/seed/rust-model/multi-line-docs/src/user_user.rs
@@ -1,9 +1,17 @@
 use serde::{Deserialize, Serialize};
 
+/// A user object. This type is used throughout the following APIs:
+/// - createUser
+/// - getUser
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct User {
     pub id: String,
+    /// The user's name. This name is unique to each user. A few examples are included below:
+    /// - Alice
+    /// - Bob
+    /// - Charlie
     pub name: String,
+    /// The user's age.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub age: Option<i32>,
 }

--- a/seed/rust-model/multiple-request-bodies/src/upload_document_request.rs
+++ b/seed/rust-model/multiple-request-bodies/src/upload_document_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct UploadDocumentRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,

--- a/seed/rust-model/nullable-optional/src/filter_by_role_query_request.rs
+++ b/seed/rust-model/nullable-optional/src/filter_by_role_query_request.rs
@@ -2,7 +2,7 @@ use crate::nullable_optional_user_role::UserRole;
 use crate::nullable_optional_user_status::UserStatus;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct FilterByRoleQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<UserRole>,

--- a/seed/rust-model/nullable-optional/src/list_users_query_request.rs
+++ b/seed/rust-model/nullable-optional/src/list_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-model/nullable-optional/src/nullable_optional_address.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_address.rs
@@ -2,6 +2,7 @@ use crate::nullable_optional_nullable_user_id::NullableUserId;
 use crate::nullable_optional_optional_user_id::OptionalUserId;
 use serde::{Deserialize, Serialize};
 
+/// Nested object for testing
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Address {
     pub street: String,

--- a/seed/rust-model/nullable-optional/src/nullable_optional_complex_profile.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_complex_profile.rs
@@ -6,6 +6,7 @@ use crate::nullable_optional_address::Address;
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
+/// Test object with nullable enums, unions, and arrays
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComplexProfile {
     pub id: String,

--- a/seed/rust-model/nullable-optional/src/nullable_optional_deserialization_test_request.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_deserialization_test_request.rs
@@ -7,6 +7,7 @@ use crate::nullable_optional_organization::Organization;
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
+/// Request body for testing deserialization of null values
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeserializationTestRequest {
     #[serde(rename = "requiredString")]

--- a/seed/rust-model/nullable-optional/src/nullable_optional_deserialization_test_response.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_deserialization_test_response.rs
@@ -1,12 +1,13 @@
 use crate::nullable_optional_deserialization_test_request::DeserializationTestRequest;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Response for deserialization test
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeserializationTestResponse {
     pub echo: DeserializationTestRequest,
     #[serde(rename = "processedAt")]
-    pub processed_at: chrono::DateTime<chrono::Utc>,
+    pub processed_at: DateTime<Utc>,
     #[serde(rename = "nullCount")]
     pub null_count: i32,
     #[serde(rename = "presentFieldsCount")]

--- a/seed/rust-model/nullable-optional/src/nullable_optional_update_user_request.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_update_user_request.rs
@@ -1,6 +1,7 @@
 use crate::nullable_optional_address::Address;
 use serde::{Deserialize, Serialize};
 
+/// For testing PATCH operations
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UpdateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-model/nullable-optional/src/nullable_optional_user_profile.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_user_profile.rs
@@ -1,8 +1,9 @@
 use crate::nullable_optional_address::Address;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
+/// Test object with nullable and optional fields
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserProfile {
     pub id: String,
@@ -18,7 +19,7 @@ pub struct UserProfile {
     pub nullable_boolean: Option<bool>,
     #[serde(rename = "nullableDate")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_date: Option<chrono::DateTime<chrono::Utc>>,
+    pub nullable_date: Option<DateTime<Utc>>,
     #[serde(rename = "nullableObject")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_object: Option<Address>,
@@ -39,7 +40,7 @@ pub struct UserProfile {
     pub optional_boolean: Option<bool>,
     #[serde(rename = "optionalDate")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_date: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_date: Option<DateTime<Utc>>,
     #[serde(rename = "optionalObject")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optional_object: Option<Address>,

--- a/seed/rust-model/nullable-optional/src/nullable_optional_user_response.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_user_response.rs
@@ -1,5 +1,5 @@
 use crate::nullable_optional_address::Address;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -11,10 +11,10 @@ pub struct UserResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
     #[serde(rename = "updatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<Address>,
 }

--- a/seed/rust-model/nullable-optional/src/nullable_optional_user_role.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_user_role.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Test enum for nullable enum fields
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum UserRole {
     #[serde(rename = "ADMIN")]

--- a/seed/rust-model/nullable-optional/src/nullable_optional_user_status.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_user_status.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Test enum with values for optional enum fields
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum UserStatus {
     #[serde(rename = "active")]

--- a/seed/rust-model/nullable-optional/src/update_complex_profile_request.rs
+++ b/seed/rust-model/nullable-optional/src/update_complex_profile_request.rs
@@ -4,7 +4,7 @@ use crate::nullable_optional_notification_method::NotificationMethod;
 use crate::nullable_optional_search_result::SearchResult;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UpdateComplexProfileRequest {
     #[serde(rename = "nullableRole")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-model/nullable-optional/src/update_tags_request.rs
+++ b/seed/rust-model/nullable-optional/src/update_tags_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct UpdateTagsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,

--- a/seed/rust-model/nullable/src/delete_user_request.rs
+++ b/seed/rust-model/nullable/src/delete_user_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct DeleteUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<Option<String>>,

--- a/seed/rust-model/nullable/src/get_users_query_request.rs
+++ b/seed/rust-model/nullable/src/get_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usernames: Option<String>,

--- a/seed/rust-model/nullable/src/nullable_metadata.rs
+++ b/seed/rust-model/nullable/src/nullable_metadata.rs
@@ -1,14 +1,14 @@
 use crate::nullable_status::Status;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {
     #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
     #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-model/nullable/src/nullable_status.rs
+++ b/seed/rust-model/nullable/src/nullable_status.rs
@@ -6,11 +6,11 @@ pub enum Status {
         Active,
 
         Archived {
-            value: Option<chrono::DateTime<chrono::Utc>>,
+            value: Option<DateTime<Utc>>,
         },
 
         #[serde(rename = "soft-deleted")]
         SoftDeleted {
-            value: Option<chrono::DateTime<chrono::Utc>>,
+            value: Option<DateTime<Utc>>,
         },
 }

--- a/seed/rust-model/oauth-client-credentials-custom/src/auth_token_response.rs
+++ b/seed/rust-model/oauth-client-credentials-custom/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/oauth-client-credentials-default/src/auth_token_response.rs
+++ b/seed/rust-model/oauth-client-credentials-default/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/oauth-client-credentials-environment-variables/src/auth_token_response.rs
+++ b/seed/rust-model/oauth-client-credentials-environment-variables/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/oauth-client-credentials-nested-root/src/auth_token_response.rs
+++ b/seed/rust-model/oauth-client-credentials-nested-root/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/oauth-client-credentials-with-variables/src/auth_token_response.rs
+++ b/seed/rust-model/oauth-client-credentials-with-variables/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/oauth-client-credentials/src/auth_token_response.rs
+++ b/seed/rust-model/oauth-client-credentials/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-model/object/src/type_.rs
+++ b/seed/rust-model/object/src/type_.rs
@@ -3,9 +3,9 @@ use chrono::{DateTime, NaiveDate, Utc};
 use std::collections::HashMap;
 use ordered_float::OrderedFloat;
 use uuid::Uuid;
-use serde_json::Value;
 use serde::{Deserialize, Serialize};
 
+/// Exercises all of the built-in types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Type {
     pub one: i32,
@@ -13,8 +13,8 @@ pub struct Type {
     pub three: String,
     pub four: bool,
     pub five: i64,
-    pub six: chrono::DateTime<chrono::Utc>,
-    pub seven: chrono::NaiveDate,
+    pub six: DateTime<Utc>,
+    pub seven: NaiveDate,
     pub eight: uuid::Uuid,
     pub nine: String,
     pub ten: Vec<i32>,
@@ -33,7 +33,7 @@ pub struct Type {
     pub twentytwo: f32,
     pub twentythree: num_bigint::BigInt,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub twentyfour: Option<chrono::DateTime<chrono::Utc>>,
+    pub twentyfour: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub twentyfive: Option<chrono::NaiveDate>,
+    pub twentyfive: Option<NaiveDate>,
 }

--- a/seed/rust-model/objects-with-imports/src/file_file_info.rs
+++ b/seed/rust-model/objects-with-imports/src/file_file_info.rs
@@ -3,8 +3,10 @@ use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum FileInfo {
+    /// A regular file (e.g. foo.txt).
     #[serde(rename = "REGULAR")]
     Regular,
+    /// A directory (e.g. foo/).
     #[serde(rename = "DIRECTORY")]
     Directory,
 }

--- a/seed/rust-model/pagination-custom/src/list_usernames_custom_query_request.rs
+++ b/seed/rust-model/pagination-custom/src/list_usernames_custom_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsernamesCustomQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub starting_after: Option<String>,

--- a/seed/rust-model/pagination/src/inline_users_inline_users_list_users_extended_optional_list_response.rs
+++ b/seed/rust-model/pagination/src/inline_users_inline_users_list_users_extended_optional_list_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedOptionalListResponse {
     #[serde(flatten)]
     pub user_optional_list_page_fields: UserOptionalListPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-model/pagination/src/inline_users_inline_users_list_users_extended_response.rs
+++ b/seed/rust-model/pagination/src/inline_users_inline_users_list_users_extended_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedResponse {
     #[serde(flatten)]
     pub user_page_fields: UserPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-model/pagination/src/inline_users_inline_users_list_users_pagination_response.rs
+++ b/seed/rust-model/pagination/src/inline_users_inline_users_list_users_pagination_response.rs
@@ -9,6 +9,7 @@ pub struct ListUsersPaginationResponse {
     pub has_next_page: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<Page>,
+    /// The totall number of /users
     pub total_count: i32,
     pub data: Users,
 }

--- a/seed/rust-model/pagination/src/inline_users_inline_users_page.rs
+++ b/seed/rust-model/pagination/src/inline_users_inline_users_page.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Page {
+    /// The current page
     pub page: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next: Option<NextPage>,

--- a/seed/rust-model/pagination/src/list_usernames_query_request.rs
+++ b/seed/rust-model/pagination/src/list_usernames_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsernamesQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub starting_after: Option<String>,

--- a/seed/rust-model/pagination/src/list_users_body_cursor_pagination_request.rs
+++ b/seed/rust-model/pagination/src/list_users_body_cursor_pagination_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_with_cursor::WithCursor;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersBodyCursorPaginationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagination: Option<WithCursor>,

--- a/seed/rust-model/pagination/src/list_users_body_offset_pagination_request.rs
+++ b/seed/rust-model/pagination/src/list_users_body_offset_pagination_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_with_page::WithPage;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersBodyOffsetPaginationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagination: Option<WithPage>,

--- a/seed/rust-model/pagination/src/list_with_cursor_pagination_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_cursor_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithCursorPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-model/pagination/src/list_with_double_offset_pagination_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_double_offset_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ListWithDoubleOffsetPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<f64>,

--- a/seed/rust-model/pagination/src/list_with_extended_results_and_optional_data_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_extended_results_and_optional_data_query_request.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithExtendedResultsAndOptionalDataQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<uuid::Uuid>,

--- a/seed/rust-model/pagination/src/list_with_extended_results_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_extended_results_query_request.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithExtendedResultsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<uuid::Uuid>,

--- a/seed/rust-model/pagination/src/list_with_global_config_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_global_config_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithGlobalConfigQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i32>,

--- a/seed/rust-model/pagination/src/list_with_mixed_type_cursor_pagination_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_mixed_type_cursor_pagination_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithMixedTypeCursorPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,

--- a/seed/rust-model/pagination/src/list_with_offset_pagination_has_next_page_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_offset_pagination_has_next_page_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithOffsetPaginationHasNextPageQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-model/pagination/src/list_with_offset_pagination_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_offset_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithOffsetPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-model/pagination/src/list_with_offset_step_pagination_query_request.rs
+++ b/seed/rust-model/pagination/src/list_with_offset_step_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithOffsetStepPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-model/pagination/src/users_list_users_extended_optional_list_response.rs
+++ b/seed/rust-model/pagination/src/users_list_users_extended_optional_list_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedOptionalListResponse {
     #[serde(flatten)]
     pub user_optional_list_page_fields: UserOptionalListPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-model/pagination/src/users_list_users_extended_response.rs
+++ b/seed/rust-model/pagination/src/users_list_users_extended_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedResponse {
     #[serde(flatten)]
     pub user_page_fields: UserPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-model/pagination/src/users_list_users_pagination_response.rs
+++ b/seed/rust-model/pagination/src/users_list_users_pagination_response.rs
@@ -9,6 +9,7 @@ pub struct ListUsersPaginationResponse {
     pub has_next_page: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<Page>,
+    /// The totall number of /users
     pub total_count: i32,
     pub data: Vec<User>,
 }

--- a/seed/rust-model/pagination/src/users_page.rs
+++ b/seed/rust-model/pagination/src/users_page.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Page {
+    /// The current page
     pub page: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next: Option<NextPage>,

--- a/seed/rust-model/path-parameters/src/search_organizations_query_request.rs
+++ b/seed/rust-model/path-parameters/src/search_organizations_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct SearchOrganizationsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-model/path-parameters/src/search_users_query_request.rs
+++ b/seed/rust-model/path-parameters/src/search_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct SearchUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-model/property-access/src/admin.rs
+++ b/seed/rust-model/property-access/src/admin.rs
@@ -1,10 +1,12 @@
 use crate::user::User;
 use serde::{Deserialize, Serialize};
 
+/// Admin user object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Admin {
     #[serde(flatten)]
     pub user_fields: User,
+    /// The level of admin privileges.
     #[serde(rename = "adminLevel")]
     pub admin_level: String,
 }

--- a/seed/rust-model/property-access/src/user.rs
+++ b/seed/rust-model/property-access/src/user.rs
@@ -1,10 +1,15 @@
 use crate::user_profile::UserProfile;
 use serde::{Deserialize, Serialize};
 
+/// User object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct User {
+    /// The unique identifier for the user.
     pub id: String,
+    /// The email address of the user.
     pub email: String,
+    /// The password for the user.
     pub password: String,
+    /// User profile object
     pub profile: UserProfile,
 }

--- a/seed/rust-model/property-access/src/user_profile.rs
+++ b/seed/rust-model/property-access/src/user_profile.rs
@@ -1,9 +1,13 @@
 use crate::user_profile_verification::UserProfileVerification;
 use serde::{Deserialize, Serialize};
 
+/// User profile object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UserProfile {
+    /// The name of the user.
     pub name: String,
+    /// User profile verification object
     pub verification: UserProfileVerification,
+    /// The social security number of the user.
     pub ssn: String,
 }

--- a/seed/rust-model/property-access/src/user_profile_verification.rs
+++ b/seed/rust-model/property-access/src/user_profile_verification.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+/// User profile verification object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UserProfileVerification {
+    /// User profile verification status
     pub verified: String,
 }

--- a/seed/rust-model/query-parameters-openapi-as-objects/src/search_query_request.rs
+++ b/seed/rust-model/query-parameters-openapi-as-objects/src/search_query_request.rs
@@ -2,7 +2,7 @@ use crate::user::User;
 use crate::nested_user::NestedUser;
 use crate::search_request_neighbor::SearchRequestNeighbor;
 use crate::search_request_neighbor_required::SearchRequestNeighborRequired;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ pub struct SearchQueryRequest {
     pub limit: i32,
     pub id: String,
     pub date: String,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
@@ -19,7 +19,7 @@ pub struct SearchQueryRequest {
     pub user_list: Option<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_value: Option<HashMap<String, Option<String>>>,

--- a/seed/rust-model/query-parameters-openapi/src/search_query_request.rs
+++ b/seed/rust-model/query-parameters-openapi/src/search_query_request.rs
@@ -1,7 +1,7 @@
 use crate::user::User;
 use crate::nested_user::NestedUser;
 use crate::search_request_neighbor_required::SearchRequestNeighborRequired;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +10,7 @@ pub struct SearchQueryRequest {
     pub limit: i32,
     pub id: String,
     pub date: String,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
@@ -18,7 +18,7 @@ pub struct SearchQueryRequest {
     pub user_list: Option<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_value: Option<HashMap<String, Option<String>>>,

--- a/seed/rust-model/query-parameters/src/get_username_query_request.rs
+++ b/seed/rust-model/query-parameters/src/get_username_query_request.rs
@@ -9,15 +9,15 @@ use serde::{Deserialize, Serialize};
 pub struct GetUsernameQueryRequest {
     pub limit: i32,
     pub id: uuid::Uuid,
-    pub date: chrono::NaiveDate,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub date: NaiveDate,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
     pub user_list: Vec<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     pub key_value: HashMap<String, String>,
     #[serde(rename = "optionalString")]

--- a/seed/rust-model/request-parameters/src/get_username_query_request.rs
+++ b/seed/rust-model/request-parameters/src/get_username_query_request.rs
@@ -9,15 +9,15 @@ use serde::{Deserialize, Serialize};
 pub struct GetUsernameQueryRequest {
     pub limit: i32,
     pub id: uuid::Uuid,
-    pub date: chrono::NaiveDate,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub date: NaiveDate,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
     pub user_list: Vec<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     pub key_value: HashMap<String, String>,
     #[serde(rename = "optionalString")]

--- a/seed/rust-model/trace/src/commons_list_type.rs
+++ b/seed/rust-model/trace/src/commons_list_type.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct ListType {
     #[serde(rename = "valueType")]
     pub value_type: VariableType,
+    /// Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false.
     #[serde(rename = "isFixedLength")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_fixed_length: Option<bool>,

--- a/seed/rust-model/trace/src/lang_server_lang_server_request.rs
+++ b/seed/rust-model/trace/src/lang_server_lang_server_request.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/seed/rust-model/trace/src/lang_server_lang_server_response.rs
+++ b/seed/rust-model/trace/src/lang_server_lang_server_response.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/seed/rust-model/trace/src/migration_migration_status.rs
+++ b/seed/rust-model/trace/src/migration_migration_status.rs
@@ -3,8 +3,10 @@ use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum MigrationStatus {
+    /// The migration is running
     #[serde(rename = "RUNNING")]
     Running,
+    /// The migration is failed
     #[serde(rename = "FAILED")]
     Failed,
     #[serde(rename = "FINISHED")]

--- a/seed/rust-model/trace/src/playlist_update_playlist_request.rs
+++ b/seed/rust-model/trace/src/playlist_update_playlist_request.rs
@@ -4,5 +4,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UpdatePlaylistRequest {
     pub name: String,
+    /// The problems that make up the playlist.
     pub problems: Vec<ProblemId>,
 }

--- a/seed/rust-model/trace/src/submission_execution_session_state.rs
+++ b/seed/rust-model/trace/src/submission_execution_session_state.rs
@@ -7,6 +7,7 @@ pub struct ExecutionSessionState {
     #[serde(rename = "lastTimeContacted")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_time_contacted: Option<String>,
+    /// The auto-generated session id. Formatted as a uuid.
     #[serde(rename = "sessionId")]
     pub session_id: String,
     #[serde(rename = "isWarmInstance")]

--- a/seed/rust-model/trace/src/submission_get_submission_state_response.rs
+++ b/seed/rust-model/trace/src/submission_get_submission_state_response.rs
@@ -1,13 +1,13 @@
 use crate::commons_language::Language;
 use crate::submission_submission_type_state::SubmissionTypeState;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetSubmissionStateResponse {
     #[serde(rename = "timeSubmitted")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub time_submitted: Option<chrono::DateTime<chrono::Utc>>,
+    pub time_submitted: Option<DateTime<Utc>>,
     pub submission: String,
     pub language: Language,
     #[serde(rename = "submissionTypeState")]

--- a/seed/rust-model/trace/src/submission_submission_type_enum.rs
+++ b/seed/rust-model/trace/src/submission_submission_type_enum.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Keep in sync with SubmissionType.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum SubmissionTypeEnum {
     #[serde(rename = "TEST")]

--- a/seed/rust-model/trace/src/submission_test_submission_update.rs
+++ b/seed/rust-model/trace/src/submission_test_submission_update.rs
@@ -1,11 +1,11 @@
 use crate::submission_test_submission_update_info::TestSubmissionUpdateInfo;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestSubmissionUpdate {
     #[serde(rename = "updateTime")]
-    pub update_time: chrono::DateTime<chrono::Utc>,
+    pub update_time: DateTime<Utc>,
     #[serde(rename = "updateInfo")]
     pub update_info: TestSubmissionUpdateInfo,
 }

--- a/seed/rust-model/trace/src/submission_trace_responses_page.rs
+++ b/seed/rust-model/trace/src/submission_trace_responses_page.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceResponsesPage {
+    /// If present, use this to load subsequent pages.
+    /// The offset is the id of the next trace response to load.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i32>,
     #[serde(rename = "traceResponses")]

--- a/seed/rust-model/trace/src/submission_trace_responses_page_v_2.rs
+++ b/seed/rust-model/trace/src/submission_trace_responses_page_v_2.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceResponsesPageV2 {
+    /// If present, use this to load subsequent pages.
+    /// The offset is the id of the next trace response to load.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i32>,
     #[serde(rename = "traceResponses")]

--- a/seed/rust-model/trace/src/submission_workspace_submission_update.rs
+++ b/seed/rust-model/trace/src/submission_workspace_submission_update.rs
@@ -1,11 +1,11 @@
 use crate::submission_workspace_submission_update_info::WorkspaceSubmissionUpdateInfo;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceSubmissionUpdate {
     #[serde(rename = "updateTime")]
-    pub update_time: chrono::DateTime<chrono::Utc>,
+    pub update_time: DateTime<Utc>,
     #[serde(rename = "updateInfo")]
     pub update_info: WorkspaceSubmissionUpdateInfo,
 }

--- a/seed/rust-model/trace/src/v_2_problem_void_function_definition_that_takes_actual_result.rs
+++ b/seed/rust-model/trace/src/v_2_problem_void_function_definition_that_takes_actual_result.rs
@@ -2,6 +2,7 @@ use crate::v_2_problem_parameter::Parameter;
 use crate::v_2_problem_function_implementation_for_multiple_languages::FunctionImplementationForMultipleLanguages;
 use serde::{Deserialize, Serialize};
 
+/// The generated signature will include an additional param, actualResult
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VoidFunctionDefinitionThatTakesActualResult {
     #[serde(rename = "additionalParameters")]

--- a/seed/rust-model/trace/src/v_2_v_3_problem_void_function_definition_that_takes_actual_result.rs
+++ b/seed/rust-model/trace/src/v_2_v_3_problem_void_function_definition_that_takes_actual_result.rs
@@ -2,6 +2,7 @@ use crate::v_2_problem_parameter::Parameter;
 use crate::v_2_problem_function_implementation_for_multiple_languages::FunctionImplementationForMultipleLanguages;
 use serde::{Deserialize, Serialize};
 
+/// The generated signature will include an additional param, actualResult
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VoidFunctionDefinitionThatTakesActualResult {
     #[serde(rename = "additionalParameters")]

--- a/seed/rust-model/unions/src/bigunion_big_union.rs
+++ b/seed/rust-model/unions/src/bigunion_big_union.rs
@@ -38,10 +38,10 @@ pub enum BigUnion {
             data: NormalSweet,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         ThankfulFactor {
@@ -49,10 +49,10 @@ pub enum BigUnion {
             data: ThankfulFactor,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         JumboEnd {
@@ -60,10 +60,10 @@ pub enum BigUnion {
             data: JumboEnd,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         HastyPain {
@@ -71,10 +71,10 @@ pub enum BigUnion {
             data: HastyPain,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         MistySnow {
@@ -82,10 +82,10 @@ pub enum BigUnion {
             data: MistySnow,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         DistinctFailure {
@@ -93,10 +93,10 @@ pub enum BigUnion {
             data: DistinctFailure,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         PracticalPrinciple {
@@ -104,10 +104,10 @@ pub enum BigUnion {
             data: PracticalPrinciple,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         LimpingStep {
@@ -115,10 +115,10 @@ pub enum BigUnion {
             data: LimpingStep,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         VibrantExcitement {
@@ -126,10 +126,10 @@ pub enum BigUnion {
             data: VibrantExcitement,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         ActiveDiamond {
@@ -137,10 +137,10 @@ pub enum BigUnion {
             data: ActiveDiamond,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         PopularLimit {
@@ -148,10 +148,10 @@ pub enum BigUnion {
             data: PopularLimit,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         FalseMirror {
@@ -159,10 +159,10 @@ pub enum BigUnion {
             data: FalseMirror,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         PrimaryBlock {
@@ -170,10 +170,10 @@ pub enum BigUnion {
             data: PrimaryBlock,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         RotatingRatio {
@@ -181,10 +181,10 @@ pub enum BigUnion {
             data: RotatingRatio,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         ColorfulCover {
@@ -192,10 +192,10 @@ pub enum BigUnion {
             data: ColorfulCover,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         DisloyalValue {
@@ -203,10 +203,10 @@ pub enum BigUnion {
             data: DisloyalValue,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         GruesomeCoach {
@@ -214,10 +214,10 @@ pub enum BigUnion {
             data: GruesomeCoach,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         TotalWork {
@@ -225,10 +225,10 @@ pub enum BigUnion {
             data: TotalWork,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         HarmoniousPlay {
@@ -236,10 +236,10 @@ pub enum BigUnion {
             data: HarmoniousPlay,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         UniqueStress {
@@ -247,10 +247,10 @@ pub enum BigUnion {
             data: UniqueStress,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         UnwillingSmoke {
@@ -258,10 +258,10 @@ pub enum BigUnion {
             data: UnwillingSmoke,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         FrozenSleep {
@@ -269,10 +269,10 @@ pub enum BigUnion {
             data: FrozenSleep,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         DiligentDeal {
@@ -280,10 +280,10 @@ pub enum BigUnion {
             data: DiligentDeal,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         AttractiveScript {
@@ -291,10 +291,10 @@ pub enum BigUnion {
             data: AttractiveScript,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         HoarseMouse {
@@ -302,10 +302,10 @@ pub enum BigUnion {
             data: HoarseMouse,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         CircularCard {
@@ -313,10 +313,10 @@ pub enum BigUnion {
             data: CircularCard,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         PotableBad {
@@ -324,10 +324,10 @@ pub enum BigUnion {
             data: PotableBad,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         TriangularRepair {
@@ -335,10 +335,10 @@ pub enum BigUnion {
             data: TriangularRepair,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 
         GaseousRoad {
@@ -346,10 +346,10 @@ pub enum BigUnion {
             data: GaseousRoad,
             id: String,
             #[serde(rename = "created-at")]
-            created_at: chrono::DateTime<chrono::Utc>,
+            created_at: DateTime<Utc>,
             #[serde(rename = "archived-at")]
             #[serde(skip_serializing_if = "Option::is_none")]
-            archived_at: Option<chrono::DateTime<chrono::Utc>>,
+            archived_at: Option<DateTime<Utc>>,
         },
 }
 
@@ -388,7 +388,7 @@ impl BigUnion {
                 }
     }
 
-    pub fn get_created_at(&self) -> &chrono::DateTime<chrono::Utc> {
+    pub fn get_created_at(&self) -> &DateTime<Utc> {
         match self {
                     Self::NormalSweet { created_at, .. } => created_at,
                     Self::ThankfulFactor { created_at, .. } => created_at,
@@ -422,7 +422,7 @@ impl BigUnion {
                 }
     }
 
-    pub fn get_archived_at(&self) -> &Option<chrono::DateTime<chrono::Utc>> {
+    pub fn get_archived_at(&self) -> &Option<DateTime<Utc>> {
         match self {
                     Self::NormalSweet { archived_at, .. } => archived_at,
                     Self::ThankfulFactor { archived_at, .. } => archived_at,

--- a/seed/rust-model/unions/src/types_union_with_optional_time.rs
+++ b/seed/rust-model/unions/src/types_union_with_optional_time.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type")]
 pub enum UnionWithOptionalTime {
         Date {
-            value: Option<chrono::NaiveDate>,
+            value: Option<NaiveDate>,
         },
 
         Datetime {
-            value: Option<chrono::DateTime<chrono::Utc>>,
+            value: Option<DateTime<Utc>>,
         },
 }

--- a/seed/rust-model/unions/src/types_union_with_time.rs
+++ b/seed/rust-model/unions/src/types_union_with_time.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -9,10 +9,10 @@ pub enum UnionWithTime {
         },
 
         Date {
-            value: chrono::NaiveDate,
+            value: NaiveDate,
         },
 
         Datetime {
-            value: chrono::DateTime<chrono::Utc>,
+            value: DateTime<Utc>,
         },
 }

--- a/seed/rust-model/unknown/src/unknown_my_alias.rs
+++ b/seed/rust-model/unknown/src/unknown_my_alias.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MyAlias(pub serde_json::Value);

--- a/seed/rust-model/unknown/src/unknown_my_object.rs
+++ b/seed/rust-model/unknown/src/unknown_my_object.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/seed/rust-model/validation/src/type_.rs
+++ b/seed/rust-model/validation/src/type_.rs
@@ -1,6 +1,7 @@
 use crate::shape::Shape;
 use serde::{Deserialize, Serialize};
 
+/// Defines properties with default values and validation rules.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Type {
     pub decimal: f64,

--- a/seed/rust-model/websocket-inferred-auth/src/auth_token_response.rs
+++ b/seed/rust-model/websocket-inferred-auth/src/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/accept-header/src/api/mod.rs
+++ b/seed/rust-sdk/accept-header/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::AcceptClient;

--- a/seed/rust-sdk/accept-header/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/accept-header/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/accept-header/src/core/mod.rs
+++ b/seed/rust-sdk/accept-header/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/accept-header/src/core/mod.rs
+++ b/seed/rust-sdk/accept-header/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/accept-header/src/core/request_options.rs
+++ b/seed/rust-sdk/accept-header/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/accept-header/src/core/utils.rs
+++ b/seed/rust-sdk/accept-header/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/alias-extends/src/api/mod.rs
+++ b/seed/rust-sdk/alias-extends/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::AliasExtendsClient;
 pub use types::*;

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/alias-extends/src/core/mod.rs
+++ b/seed/rust-sdk/alias-extends/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/alias-extends/src/core/mod.rs
+++ b/seed/rust-sdk/alias-extends/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/alias-extends/src/core/request_options.rs
+++ b/seed/rust-sdk/alias-extends/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/alias-extends/src/core/utils.rs
+++ b/seed/rust-sdk/alias-extends/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/alias/src/api/mod.rs
+++ b/seed/rust-sdk/alias/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::AliasClient;
 pub use types::*;

--- a/seed/rust-sdk/alias/src/api/types/type_.rs
+++ b/seed/rust-sdk/alias/src/api/types/type_.rs
@@ -1,6 +1,7 @@
 use crate::type_id::TypeId;
 use serde::{Deserialize, Serialize};
 
+/// A simple type with just a name.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Type {
     pub id: TypeId,

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/alias/src/core/mod.rs
+++ b/seed/rust-sdk/alias/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/alias/src/core/mod.rs
+++ b/seed/rust-sdk/alias/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/alias/src/core/request_options.rs
+++ b/seed/rust-sdk/alias/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/alias/src/core/utils.rs
+++ b/seed/rust-sdk/alias/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/any-auth/src/api/mod.rs
+++ b/seed/rust-sdk/any-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::AnyAuthClient;
 pub use types::*;

--- a/seed/rust-sdk/any-auth/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/any-auth/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/any-auth/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/any-auth/src/api/resources/user/user.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/any-auth/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/any-auth/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/any-auth/src/core/mod.rs
+++ b/seed/rust-sdk/any-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/any-auth/src/core/mod.rs
+++ b/seed/rust-sdk/any-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/any-auth/src/core/request_options.rs
+++ b/seed/rust-sdk/any-auth/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/any-auth/src/core/utils.rs
+++ b/seed/rust-sdk/any-auth/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/api-wide-base-path/src/api/mod.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::ApiWideBasePathClient;

--- a/seed/rust-sdk/api-wide-base-path/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/api-wide-base-path/src/core/mod.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/api-wide-base-path/src/core/mod.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/api-wide-base-path/src/core/request_options.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/api-wide-base-path/src/core/utils.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/audiences/src/api/mod.rs
+++ b/seed/rust-sdk/audiences/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::AudiencesClient;
 pub use types::*;

--- a/seed/rust-sdk/audiences/src/api/resources/commons/commons.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/commons/commons.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_a/folder_a.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_a/folder_a.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderAClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_a/service/folder_a_service.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_a/service/folder_a_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderAServiceClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_b/common/folder_b_common.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_b/common/folder_b_common.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderBCommonClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_b/folder_b.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_b/folder_b.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderBClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_c/common/folder_c_common.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_c/common/folder_c_common.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderCCommonClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_c/folder_c.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_c/folder_c.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderCClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_d/folder_d.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_d/folder_d.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderDClient {

--- a/seed/rust-sdk/audiences/src/api/resources/folder_d/service/folder_d_service.rs
+++ b/seed/rust-sdk/audiences/src/api/resources/folder_d/service/folder_d_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderDServiceClient {

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/audiences/src/core/mod.rs
+++ b/seed/rust-sdk/audiences/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/audiences/src/core/mod.rs
+++ b/seed/rust-sdk/audiences/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/audiences/src/core/request_options.rs
+++ b/seed/rust-sdk/audiences/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/audiences/src/core/utils.rs
+++ b/seed/rust-sdk/audiences/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/auth-environment-variables/src/api/mod.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::AuthEnvironmentVariablesClient;

--- a/seed/rust-sdk/auth-environment-variables/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {
@@ -12,6 +12,15 @@ impl ServiceClient {
         })
     }
 
+    /// GET request with custom api key
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_api_key(
         &self,
         options: Option<RequestOptions>,
@@ -21,6 +30,15 @@ impl ServiceClient {
             .await
     }
 
+    /// GET request with custom api key
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_header(
         &self,
         options: Option<RequestOptions>,

--- a/seed/rust-sdk/auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/auth-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/auth-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/auth-environment-variables/src/core/request_options.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/auth-environment-variables/src/core/utils.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/basic-auth-environment-variables/src/api/mod.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::BasicAuthEnvironmentVariablesClient;
 pub use types::*;

--- a/seed/rust-sdk/basic-auth-environment-variables/src/api/resources/basic_auth/basic_auth.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/api/resources/basic_auth/basic_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct BasicAuthClient {
@@ -13,6 +13,15 @@ impl BasicAuthClient {
         })
     }
 
+    /// GET request with basic auth scheme
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_basic_auth(
         &self,
         options: Option<RequestOptions>,
@@ -22,6 +31,15 @@ impl BasicAuthClient {
             .await
     }
 
+    /// POST request with basic auth scheme
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn post_with_basic_auth(
         &self,
         request: &serde_json::Value,

--- a/seed/rust-sdk/basic-auth-environment-variables/src/api/resources/errors/errors.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/api/resources/errors/errors.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ErrorsClient {

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/request_options.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/utils.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/basic-auth/src/api/mod.rs
+++ b/seed/rust-sdk/basic-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::BasicAuthClient;
 pub use types::*;

--- a/seed/rust-sdk/basic-auth/src/api/resources/basic_auth/basic_auth.rs
+++ b/seed/rust-sdk/basic-auth/src/api/resources/basic_auth/basic_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct BasicAuthClient {
@@ -13,6 +13,15 @@ impl BasicAuthClient {
         })
     }
 
+    /// GET request with basic auth scheme
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_basic_auth(
         &self,
         options: Option<RequestOptions>,
@@ -22,6 +31,15 @@ impl BasicAuthClient {
             .await
     }
 
+    /// POST request with basic auth scheme
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn post_with_basic_auth(
         &self,
         request: &serde_json::Value,

--- a/seed/rust-sdk/basic-auth/src/api/resources/errors/errors.rs
+++ b/seed/rust-sdk/basic-auth/src/api/resources/errors/errors.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ErrorsClient {

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/basic-auth/src/core/mod.rs
+++ b/seed/rust-sdk/basic-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/basic-auth/src/core/mod.rs
+++ b/seed/rust-sdk/basic-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/basic-auth/src/core/request_options.rs
+++ b/seed/rust-sdk/basic-auth/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/basic-auth/src/core/utils.rs
+++ b/seed/rust-sdk/basic-auth/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/bearer-token-environment-variable/src/api/mod.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::BearerTokenEnvironmentVariableClient;

--- a/seed/rust-sdk/bearer-token-environment-variable/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {
@@ -12,6 +12,15 @@ impl ServiceClient {
         })
     }
 
+    /// GET request with custom api key
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_bearer_token(
         &self,
         options: Option<RequestOptions>,

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/mod.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/mod.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/request_options.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/utils.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/bytes-download/src/api/mod.rs
+++ b/seed/rust-sdk/bytes-download/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::BytesDownloadClient;

--- a/seed/rust-sdk/bytes-download/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/bytes-download/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/bytes-download/src/core/mod.rs
+++ b/seed/rust-sdk/bytes-download/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/bytes-download/src/core/mod.rs
+++ b/seed/rust-sdk/bytes-download/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/bytes-download/src/core/request_options.rs
+++ b/seed/rust-sdk/bytes-download/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/bytes-download/src/core/utils.rs
+++ b/seed/rust-sdk/bytes-download/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/bytes-upload/src/api/mod.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::BytesUploadClient;

--- a/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/bytes-upload/src/core/mod.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/bytes-upload/src/core/mod.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/bytes-upload/src/core/request_options.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/bytes-upload/src/core/utils.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/mod.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/circular-references-advanced/src/api/resources/a/a.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/resources/a/a.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AClient {

--- a/seed/rust-sdk/circular-references-advanced/src/api/resources/ast/ast.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/resources/ast/ast.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AstClient {

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_object_field_value.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_object_field_value.rs
@@ -2,6 +2,7 @@ use crate::ast_field_name::FieldName;
 use crate::ast_field_value::FieldValue;
 use serde::{Deserialize, Serialize};
 
+/// This type allows us to test a circular reference with a union type (see FieldValue).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObjectFieldValue {
     pub name: FieldName,

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/circular-references-advanced/src/core/request_options.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/circular-references-advanced/src/core/utils.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/circular-references/src/api/mod.rs
+++ b/seed/rust-sdk/circular-references/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/circular-references/src/api/resources/a/a.rs
+++ b/seed/rust-sdk/circular-references/src/api/resources/a/a.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AClient {

--- a/seed/rust-sdk/circular-references/src/api/resources/ast/ast.rs
+++ b/seed/rust-sdk/circular-references/src/api/resources/ast/ast.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AstClient {

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/circular-references/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/circular-references/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/circular-references/src/core/request_options.rs
+++ b/seed/rust-sdk/circular-references/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/circular-references/src/core/utils.rs
+++ b/seed/rust-sdk/circular-references/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/client-side-params/src/api/mod.rs
+++ b/seed/rust-sdk/client-side-params/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ClientSideParamsClient;
 pub use types::*;

--- a/seed/rust-sdk/client-side-params/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/client-side-params/src/api/resources/service/service.rs
@@ -13,6 +13,22 @@ impl ServiceClient {
         })
     }
 
+    /// List resources with pagination
+    ///
+    /// # Arguments
+    ///
+    /// * `page` - Zero-indexed page number
+    /// * `per_page` - Number of items per page
+    /// * `sort` - Sort field
+    /// * `order` - Sort order (asc or desc)
+    /// * `include_totals` - Whether to include total count
+    /// * `fields` - Comma-separated list of fields to include
+    /// * `search` - Search query
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn list_resources(
         &self,
         request: &ListResourcesQueryRequest,
@@ -37,6 +53,17 @@ impl ServiceClient {
             .await
     }
 
+    /// Get a single resource
+    ///
+    /// # Arguments
+    ///
+    /// * `include_metadata` - Include metadata in response
+    /// * `format` - Response format
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_resource(
         &self,
         resource_id: &String,
@@ -57,6 +84,17 @@ impl ServiceClient {
             .await
     }
 
+    /// Search resources with complex parameters
+    ///
+    /// # Arguments
+    ///
+    /// * `limit` - Maximum results to return
+    /// * `offset` - Offset for pagination
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn search_resources(
         &self,
         request: &SearchResourcesRequest,
@@ -76,6 +114,23 @@ impl ServiceClient {
             .await
     }
 
+    /// List or search for users
+    ///
+    /// # Arguments
+    ///
+    /// * `page` - Page index of the results to return. First page is 0.
+    /// * `per_page` - Number of results per page.
+    /// * `include_totals` - Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
+    /// * `sort` - Field to sort by. Use field:order where order is 1 for ascending and -1 for descending.
+    /// * `connection` - Connection filter
+    /// * `q` - Query string following Lucene query string syntax
+    /// * `search_engine` - Search engine version (v1, v2, or v3)
+    /// * `fields` - Comma-separated list of fields to include or exclude
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn list_users(
         &self,
         request: &ListUsersQueryRequest,
@@ -101,6 +156,17 @@ impl ServiceClient {
             .await
     }
 
+    /// Get a user by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `fields` - Comma-separated list of fields to include or exclude
+    /// * `include_fields` - true to include the fields specified, false to exclude them
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_user_by_id(
         &self,
         user_id: &String,
@@ -121,6 +187,15 @@ impl ServiceClient {
             .await
     }
 
+    /// Create a new user
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_user(
         &self,
         request: &CreateUserRequest,
@@ -137,6 +212,15 @@ impl ServiceClient {
             .await
     }
 
+    /// Update a user
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn update_user(
         &self,
         user_id: &String,
@@ -154,6 +238,15 @@ impl ServiceClient {
             .await
     }
 
+    /// Delete a user
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn delete_user(
         &self,
         user_id: &String,
@@ -170,6 +263,18 @@ impl ServiceClient {
             .await
     }
 
+    /// List all connections
+    ///
+    /// # Arguments
+    ///
+    /// * `strategy` - Filter by strategy type (e.g., auth0, google-oauth2, samlp)
+    /// * `name` - Filter by connection name
+    /// * `fields` - Comma-separated list of fields to include
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn list_connections(
         &self,
         request: &ListConnectionsQueryRequest,
@@ -190,6 +295,16 @@ impl ServiceClient {
             .await
     }
 
+    /// Get a connection by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `fields` - Comma-separated list of fields to include
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_connection(
         &self,
         connection_id: &String,
@@ -209,6 +324,23 @@ impl ServiceClient {
             .await
     }
 
+    /// List all clients/applications
+    ///
+    /// # Arguments
+    ///
+    /// * `fields` - Comma-separated list of fields to include
+    /// * `include_fields` - Whether specified fields are included or excluded
+    /// * `page` - Page number (zero-based)
+    /// * `per_page` - Number of results per page
+    /// * `include_totals` - Include total count in response
+    /// * `is_global` - Filter by global clients
+    /// * `is_first_party` - Filter by first party clients
+    /// * `app_type` - Filter by application type (spa, native, regular_web, non_interactive)
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn list_clients(
         &self,
         request: &ListClientsQueryRequest,
@@ -234,6 +366,17 @@ impl ServiceClient {
             .await
     }
 
+    /// Get a client by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `fields` - Comma-separated list of fields to include
+    /// * `include_fields` - Whether specified fields are included or excluded
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_client(
         &self,
         client_id: &String,

--- a/seed/rust-sdk/client-side-params/src/api/resources/types/types.rs
+++ b/seed/rust-sdk/client-side-params/src/api/resources/types/types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesClient {

--- a/seed/rust-sdk/client-side-params/src/api/types/get_client_query_request.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/get_client_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetClientQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-sdk/client-side-params/src/api/types/get_connection_query_request.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/get_connection_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetConnectionQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-sdk/client-side-params/src/api/types/get_user_by_id_query_request.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/get_user_by_id_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetUserByIdQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-sdk/client-side-params/src/api/types/list_clients_query_request.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/list_clients_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListClientsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<String>,

--- a/seed/rust-sdk/client-side-params/src/api/types/list_connections_query_request.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/list_connections_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListConnectionsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub strategy: Option<String>,

--- a/seed/rust-sdk/client-side-params/src/api/types/list_users_query_request.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/list_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-sdk/client-side-params/src/api/types/types_client.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/types_client.rs
@@ -1,64 +1,95 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Represents a client application
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Client {
+    /// The unique client identifier
     pub client_id: String,
+    /// The tenant name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tenant: Option<String>,
+    /// Name of the client
     pub name: String,
+    /// Free text description of the client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Whether this is a global client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global: Option<bool>,
+    /// The client secret (only for non-public clients)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_secret: Option<String>,
+    /// The type of application (spa, native, regular_web, non_interactive)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub app_type: Option<String>,
+    /// URL of the client logo
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logo_uri: Option<String>,
+    /// Whether this client is a first party client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_first_party: Option<bool>,
+    /// Whether this client conforms to OIDC specifications
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oidc_conformant: Option<bool>,
+    /// Allowed callback URLs
     #[serde(skip_serializing_if = "Option::is_none")]
     pub callbacks: Option<Vec<String>>,
+    /// Allowed origins for CORS
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_origins: Option<Vec<String>>,
+    /// Allowed web origins for CORS
     #[serde(skip_serializing_if = "Option::is_none")]
     pub web_origins: Option<Vec<String>>,
+    /// Allowed grant types
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grant_types: Option<Vec<String>>,
+    /// JWT configuration for the client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jwt_configuration: Option<HashMap<String, serde_json::Value>>,
+    /// Client signing keys
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signing_keys: Option<Vec<HashMap<String, serde_json::Value>>>,
+    /// Encryption key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encryption_key: Option<HashMap<String, serde_json::Value>>,
+    /// Whether SSO is enabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sso: Option<bool>,
+    /// Whether SSO is disabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sso_disabled: Option<bool>,
+    /// Whether to use cross-origin authentication
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cross_origin_auth: Option<bool>,
+    /// URL for cross-origin authentication
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cross_origin_loc: Option<String>,
+    /// Whether a custom login page is enabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_login_page_on: Option<bool>,
+    /// Custom login page URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_login_page: Option<String>,
+    /// Custom login page preview URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_login_page_preview: Option<String>,
+    /// Form template for WS-Federation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form_template: Option<String>,
+    /// Whether this is a Heroku application
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_heroku_app: Option<bool>,
+    /// Addons enabled for this client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addons: Option<HashMap<String, serde_json::Value>>,
+    /// Requested authentication method for the token endpoint
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_endpoint_auth_method: Option<String>,
+    /// Metadata associated with the client
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_metadata: Option<HashMap<String, serde_json::Value>>,
+    /// Mobile app settings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mobile: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-sdk/client-side-params/src/api/types/types_connection.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/types_connection.rs
@@ -1,21 +1,31 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Represents an identity provider connection
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Connection {
+    /// Connection identifier
     pub id: String,
+    /// Connection name
     pub name: String,
+    /// Display name for the connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// The identity provider identifier (auth0, google-oauth2, facebook, etc.)
     pub strategy: String,
+    /// Connection-specific configuration options
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, serde_json::Value>>,
+    /// List of client IDs that can use this connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled_clients: Option<Vec<String>>,
+    /// Applicable realms for enterprise connections
     #[serde(skip_serializing_if = "Option::is_none")]
     pub realms: Option<Vec<String>>,
+    /// Whether this is a domain connection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_domain_connection: Option<bool>,
+    /// Additional metadata
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-sdk/client-side-params/src/api/types/types_paginated_client_response.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/types_paginated_client_response.rs
@@ -1,12 +1,18 @@
 use crate::types_client::Client;
 use serde::{Deserialize, Serialize};
 
+/// Paginated response for clients listing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaginatedClientResponse {
+    /// Starting index (zero-based)
     pub start: i32,
+    /// Number of items requested
     pub limit: i32,
+    /// Number of items returned
     pub length: i32,
+    /// Total number of items (when include_totals=true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<i32>,
+    /// List of clients
     pub clients: Vec<Client>,
 }

--- a/seed/rust-sdk/client-side-params/src/api/types/types_paginated_user_response.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/types_paginated_user_response.rs
@@ -1,6 +1,7 @@
 use crate::types_user::User;
 use serde::{Deserialize, Serialize};
 
+/// Response with pagination info like Auth0
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaginatedUserResponse {
     pub users: Vec<User>,

--- a/seed/rust-sdk/client-side-params/src/api/types/types_resource.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/types_resource.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -8,8 +8,8 @@ pub struct Resource {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
 }

--- a/seed/rust-sdk/client-side-params/src/api/types/types_user.rs
+++ b/seed/rust-sdk/client-side-params/src/api/types/types_user.rs
@@ -1,8 +1,9 @@
 use crate::types_identity::Identity;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// User object similar to Auth0 users
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub user_id: String,
@@ -14,8 +15,8 @@ pub struct User {
     pub phone_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone_verified: Option<bool>,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identities: Option<Vec<Identity>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -33,7 +34,7 @@ pub struct User {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_ip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_login: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_login: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logins_count: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/client-side-params/src/core/mod.rs
+++ b/seed/rust-sdk/client-side-params/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/client-side-params/src/core/mod.rs
+++ b/seed/rust-sdk/client-side-params/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/client-side-params/src/core/request_options.rs
+++ b/seed/rust-sdk/client-side-params/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/client-side-params/src/core/utils.rs
+++ b/seed/rust-sdk/client-side-params/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/content-type/src/api/mod.rs
+++ b/seed/rust-sdk/content-type/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::ContentTypesClient;

--- a/seed/rust-sdk/content-type/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/content-type/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {
@@ -28,6 +28,18 @@ impl ServiceClient {
             .await
     }
 
+    /// Update with JSON merge patch - complex types.
+    /// This endpoint demonstrates the distinction between:
+    /// - optional<T> fields (can be present or absent, but not null)
+    /// - optional<nullable<T>> fields (can be present, absent, or null)
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn patch_complex(
         &self,
         id: &String,
@@ -45,6 +57,16 @@ impl ServiceClient {
             .await
     }
 
+    /// Named request with mixed optional/nullable fields and merge-patch content type.
+    /// This should trigger the NPE issue when optional fields aren't initialized.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn named_patch_with_mixed(
         &self,
         id: &String,
@@ -62,6 +84,18 @@ impl ServiceClient {
             .await
     }
 
+    /// Test endpoint to verify Optional field initialization and JsonSetter with Nulls.SKIP.
+    /// This endpoint should:
+    /// 1. Not NPE when fields are not provided (tests initialization)
+    /// 2. Not NPE when fields are explicitly null in JSON (tests Nulls.SKIP)
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn optional_merge_patch_test(
         &self,
         request: &OptionalMergePatchRequest,
@@ -78,6 +112,15 @@ impl ServiceClient {
             .await
     }
 
+    /// Regular PATCH endpoint without merge-patch semantics
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn regular_patch(
         &self,
         id: &String,

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/content-type/src/core/mod.rs
+++ b/seed/rust-sdk/content-type/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/content-type/src/core/mod.rs
+++ b/seed/rust-sdk/content-type/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/content-type/src/core/request_options.rs
+++ b/seed/rust-sdk/content-type/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/content-type/src/core/utils.rs
+++ b/seed/rust-sdk/content-type/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/cross-package-type-names/src/api/mod.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::CrossPackageTypeNamesClient;
 pub use types::*;

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/commons/commons.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/commons/commons.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_a/folder_a.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_a/folder_a.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderAClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_a/service/folder_a_service.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_a/service/folder_a_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderAServiceClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_b/common/folder_b_common.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_b/common/folder_b_common.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderBCommonClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_b/folder_b.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_b/folder_b.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderBClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_c/common/folder_c_common.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_c/common/folder_c_common.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderCCommonClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_c/folder_c.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_c/folder_c.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderCClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_d/folder_d.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_d/folder_d.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderDClient {

--- a/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_d/service/folder_d_service.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/resources/folder_d/service/folder_d_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderDServiceClient {

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/cross-package-type-names/src/core/mod.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/cross-package-type-names/src/core/mod.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/cross-package-type-names/src/core/request_options.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/cross-package-type-names/src/core/utils.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/custom-auth/src/api/mod.rs
+++ b/seed/rust-sdk/custom-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::CustomAuthClient;
 pub use types::*;

--- a/seed/rust-sdk/custom-auth/src/api/resources/custom_auth/custom_auth.rs
+++ b/seed/rust-sdk/custom-auth/src/api/resources/custom_auth/custom_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CustomAuthClient {
@@ -13,6 +13,15 @@ impl CustomAuthClient {
         })
     }
 
+    /// GET request with custom auth scheme
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_custom_auth(
         &self,
         options: Option<RequestOptions>,
@@ -22,6 +31,15 @@ impl CustomAuthClient {
             .await
     }
 
+    /// POST request with custom auth scheme
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn post_with_custom_auth(
         &self,
         request: &serde_json::Value,

--- a/seed/rust-sdk/custom-auth/src/api/resources/errors/errors.rs
+++ b/seed/rust-sdk/custom-auth/src/api/resources/errors/errors.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ErrorsClient {

--- a/seed/rust-sdk/custom-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/custom-auth/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/custom-auth/src/core/mod.rs
+++ b/seed/rust-sdk/custom-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/custom-auth/src/core/mod.rs
+++ b/seed/rust-sdk/custom-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/custom-auth/src/core/request_options.rs
+++ b/seed/rust-sdk/custom-auth/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/custom-auth/src/core/utils.rs
+++ b/seed/rust-sdk/custom-auth/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/empty-clients/src/api/mod.rs
+++ b/seed/rust-sdk/empty-clients/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::EmptyClientsClient;
 pub use types::*;

--- a/seed/rust-sdk/empty-clients/src/api/resources/level_1/level_1.rs
+++ b/seed/rust-sdk/empty-clients/src/api/resources/level_1/level_1.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct Level1Client {

--- a/seed/rust-sdk/empty-clients/src/api/resources/level_1/level_2/level_1_level_2.rs
+++ b/seed/rust-sdk/empty-clients/src/api/resources/level_1/level_2/level_1_level_2.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct Level1Level2Client {

--- a/seed/rust-sdk/empty-clients/src/api/resources/level_1/level_2/types/level_1_level_2_types.rs
+++ b/seed/rust-sdk/empty-clients/src/api/resources/level_1/level_2/types/level_1_level_2_types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct Level1Level2TypesClient {

--- a/seed/rust-sdk/empty-clients/src/api/resources/level_1/types/level_1_types.rs
+++ b/seed/rust-sdk/empty-clients/src/api/resources/level_1/types/level_1_types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct Level1TypesClient {

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/empty-clients/src/core/mod.rs
+++ b/seed/rust-sdk/empty-clients/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/empty-clients/src/core/mod.rs
+++ b/seed/rust-sdk/empty-clients/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/empty-clients/src/core/request_options.rs
+++ b/seed/rust-sdk/empty-clients/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/empty-clients/src/core/utils.rs
+++ b/seed/rust-sdk/empty-clients/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/enum/src/api/mod.rs
+++ b/seed/rust-sdk/enum/src/api/mod.rs
@@ -1,6 +1,6 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{*};
+pub use resources::{EnumClient};
 pub use types::{*};
 

--- a/seed/rust-sdk/enum/src/api/resources/headers/headers.rs
+++ b/seed/rust-sdk/enum/src/api/resources/headers/headers.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
 use reqwest::{Method};
 use crate::api::{*};
 

--- a/seed/rust-sdk/enum/src/api/resources/inlined_request/inlined_request.rs
+++ b/seed/rust-sdk/enum/src/api/resources/inlined_request/inlined_request.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
 use reqwest::{Method};
 use crate::api::{*};
 

--- a/seed/rust-sdk/enum/src/api/resources/path_param/path_param.rs
+++ b/seed/rust-sdk/enum/src/api/resources/path_param/path_param.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
 use reqwest::{Method};
 use crate::api::{*};
 

--- a/seed/rust-sdk/enum/src/api/resources/query_param/query_param.rs
+++ b/seed/rust-sdk/enum/src/api/resources/query_param/query_param.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions, QueryBuilder};
 use reqwest::{Method};
 use crate::api::{*};
 

--- a/seed/rust-sdk/enum/src/api/resources/unknown/unknown.rs
+++ b/seed/rust-sdk/enum/src/api/resources/unknown/unknown.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
 use reqwest::{Method};
 use crate::api::{*};
 

--- a/seed/rust-sdk/enum/src/api/types/operand.rs
+++ b/seed/rust-sdk/enum/src/api/types/operand.rs
@@ -1,12 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Tests enum name and value can be
+/// different.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Operand {
     #[serde(rename = ">")]
     GreaterThan,
     #[serde(rename = "=")]
     EqualTo,
+    /// The name and value should be similar
+    /// are similar for less than.
     #[serde(rename = "less_than")]
     LessThan,
 }

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{Utils::join_url, ApiError, ClientConfig, RequestOptions};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/enum/src/core/mod.rs
+++ b/seed/rust-sdk/enum/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/enum/src/core/mod.rs
+++ b/seed/rust-sdk/enum/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/enum/src/core/request_options.rs
+++ b/seed/rust-sdk/enum/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/enum/src/core/utils.rs
+++ b/seed/rust-sdk/enum/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/error-property/src/api/mod.rs
+++ b/seed/rust-sdk/error-property/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ErrorPropertyClient;
 pub use types::*;

--- a/seed/rust-sdk/error-property/src/api/resources/errors/errors.rs
+++ b/seed/rust-sdk/error-property/src/api/resources/errors/errors.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ErrorsClient {

--- a/seed/rust-sdk/error-property/src/api/resources/property_based_error/property_based_error.rs
+++ b/seed/rust-sdk/error-property/src/api/resources/property_based_error/property_based_error.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct PropertyBasedErrorClient {
@@ -13,6 +13,15 @@ impl PropertyBasedErrorClient {
         })
     }
 
+    /// GET request that always throws an error
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn throw_error(&self, options: Option<RequestOptions>) -> Result<String, ApiError> {
         self.http_client
             .execute_request(Method::GET, "property-based-error", None, None, options)

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/error-property/src/core/mod.rs
+++ b/seed/rust-sdk/error-property/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/error-property/src/core/mod.rs
+++ b/seed/rust-sdk/error-property/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/error-property/src/core/request_options.rs
+++ b/seed/rust-sdk/error-property/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/error-property/src/core/utils.rs
+++ b/seed/rust-sdk/error-property/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/errors/src/api/mod.rs
+++ b/seed/rust-sdk/errors/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ErrorsClient;
 pub use types::*;

--- a/seed/rust-sdk/errors/src/api/resources/commons/commons.rs
+++ b/seed/rust-sdk/errors/src/api/resources/commons/commons.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsClient {

--- a/seed/rust-sdk/errors/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/errors/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/errors/src/core/mod.rs
+++ b/seed/rust-sdk/errors/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/errors/src/core/mod.rs
+++ b/seed/rust-sdk/errors/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/errors/src/core/request_options.rs
+++ b/seed/rust-sdk/errors/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/errors/src/core/utils.rs
+++ b/seed/rust-sdk/errors/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/examples/src/api/mod.rs
+++ b/seed/rust-sdk/examples/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ExamplesClient;
 pub use types::*;

--- a/seed/rust-sdk/examples/src/api/resources/commons/commons.rs
+++ b/seed/rust-sdk/examples/src/api/resources/commons/commons.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsClient {

--- a/seed/rust-sdk/examples/src/api/resources/commons/types/commons_types.rs
+++ b/seed/rust-sdk/examples/src/api/resources/commons/types/commons_types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsTypesClient {

--- a/seed/rust-sdk/examples/src/api/resources/file/file.rs
+++ b/seed/rust-sdk/examples/src/api/resources/file/file.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FileClient {

--- a/seed/rust-sdk/examples/src/api/resources/file/notification/file_notification.rs
+++ b/seed/rust-sdk/examples/src/api/resources/file/notification/file_notification.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FileNotificationClient {

--- a/seed/rust-sdk/examples/src/api/resources/file/notification/service/file_notification_service.rs
+++ b/seed/rust-sdk/examples/src/api/resources/file/notification/service/file_notification_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FileNotificationServiceClient {

--- a/seed/rust-sdk/examples/src/api/resources/file/service/file_service.rs
+++ b/seed/rust-sdk/examples/src/api/resources/file/service/file_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FileServiceClient {
@@ -13,6 +13,16 @@ impl FileServiceClient {
         })
     }
 
+    /// This endpoint returns a file by its name.
+    ///
+    /// # Arguments
+    ///
+    /// * `filename` - This is a filename
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_file(
         &self,
         filename: &String,

--- a/seed/rust-sdk/examples/src/api/resources/health/health.rs
+++ b/seed/rust-sdk/examples/src/api/resources/health/health.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct HealthClient {

--- a/seed/rust-sdk/examples/src/api/resources/health/service/health_service.rs
+++ b/seed/rust-sdk/examples/src/api/resources/health/service/health_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct HealthServiceClient {
@@ -13,6 +13,16 @@ impl HealthServiceClient {
         })
     }
 
+    /// This endpoint checks the health of a resource.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The id to check
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn check(
         &self,
         id: &String,
@@ -23,6 +33,15 @@ impl HealthServiceClient {
             .await
     }
 
+    /// This endpoint checks the health of the service.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn ping(&self, options: Option<RequestOptions>) -> Result<bool, ApiError> {
         self.http_client
             .execute_request(Method::GET, "/ping", None, None, options)

--- a/seed/rust-sdk/examples/src/api/resources/types/types.rs
+++ b/seed/rust-sdk/examples/src/api/resources/types/types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesClient {

--- a/seed/rust-sdk/examples/src/api/types/get_metadata_query_request.rs
+++ b/seed/rust-sdk/examples/src/api/types/get_metadata_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetMetadataQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shallow: Option<bool>,

--- a/seed/rust-sdk/examples/src/api/types/types_migration_status.rs
+++ b/seed/rust-sdk/examples/src/api/types/types_migration_status.rs
@@ -3,8 +3,10 @@ use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum MigrationStatus {
+    /// The migration is running.
     #[serde(rename = "RUNNING")]
     Running,
+    /// The migration failed.
     #[serde(rename = "FAILED")]
     Failed,
     #[serde(rename = "FINISHED")]

--- a/seed/rust-sdk/examples/src/api/types/types_moment.rs
+++ b/seed/rust-sdk/examples/src/api/types/types_moment.rs
@@ -5,6 +5,6 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Moment {
     pub id: uuid::Uuid,
-    pub date: chrono::NaiveDate,
-    pub datetime: chrono::DateTime<chrono::Utc>,
+    pub date: NaiveDate,
+    pub datetime: DateTime<Utc>,
 }

--- a/seed/rust-sdk/examples/src/api/types/types_movie.rs
+++ b/seed/rust-sdk/examples/src/api/types/types_movie.rs
@@ -10,6 +10,7 @@ pub struct Movie {
     pub prequel: Option<MovieId>,
     pub title: String,
     pub from: String,
+    /// The rating scale is one to five stars
     pub rating: f64,
     pub r#type: String,
     pub tag: Tag,

--- a/seed/rust-sdk/examples/src/api/types/types_request.rs
+++ b/seed/rust-sdk/examples/src/api/types/types_request.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Request {

--- a/seed/rust-sdk/examples/src/api/types/types_response.rs
+++ b/seed/rust-sdk/examples/src/api/types/types_response.rs
@@ -1,6 +1,5 @@
 use crate::identifier::Identifier;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Response {

--- a/seed/rust-sdk/examples/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/examples/src/core/mod.rs
+++ b/seed/rust-sdk/examples/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/examples/src/core/mod.rs
+++ b/seed/rust-sdk/examples/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/examples/src/core/request_options.rs
+++ b/seed/rust-sdk/examples/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/examples/src/core/utils.rs
+++ b/seed/rust-sdk/examples/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/exhaustive/src/api/mod.rs
+++ b/seed/rust-sdk/exhaustive/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ExhaustiveClient;
 pub use types::*;

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/container/endpoints_container.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/container/endpoints_container.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsContainerClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/content_type/endpoints_content_type.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/content_type/endpoints_content_type.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsContentTypeClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/endpoints.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/endpoints.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/enum_/endpoints_enum_.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/enum_/endpoints_enum_.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsEnumClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/http_methods/endpoints_http_methods.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/http_methods/endpoints_http_methods.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsHttpMethodsClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/object/endpoints_object.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/object/endpoints_object.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsObjectClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/params/endpoints_params.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/params/endpoints_params.rs
@@ -13,6 +13,15 @@ impl EndpointsParamsClient {
         })
     }
 
+    /// GET with path param
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_path(
         &self,
         param: &String,
@@ -29,6 +38,15 @@ impl EndpointsParamsClient {
             .await
     }
 
+    /// GET with path param
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_with_inline_path(
         &self,
         param: &String,
@@ -45,6 +63,15 @@ impl EndpointsParamsClient {
             .await
     }
 
+    /// GET with query param
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn get_with_query(
         &self,
         request: &GetWithQueryQueryRequest,
@@ -64,6 +91,15 @@ impl EndpointsParamsClient {
             .await
     }
 
+    /// GET with multiple of same query param
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn get_with_allow_multiple_query(
         &self,
         request: &GetWithAllowMultipleQueryQueryRequest,
@@ -83,6 +119,15 @@ impl EndpointsParamsClient {
             .await
     }
 
+    /// GET with path and query params
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn get_with_path_and_query(
         &self,
         param: &String,
@@ -102,6 +147,15 @@ impl EndpointsParamsClient {
             .await
     }
 
+    /// GET with path and query params
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn get_with_inline_path_and_query(
         &self,
         param: &String,
@@ -121,6 +175,15 @@ impl EndpointsParamsClient {
             .await
     }
 
+    /// PUT to update with path param
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn modify_with_path(
         &self,
         param: &String,
@@ -138,6 +201,15 @@ impl EndpointsParamsClient {
             .await
     }
 
+    /// PUT to update with path param
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn modify_with_inline_path(
         &self,
         param: &String,

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/primitive/endpoints_primitive.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/primitive/endpoints_primitive.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsPrimitiveClient {
@@ -95,9 +95,9 @@ impl EndpointsPrimitiveClient {
 
     pub async fn get_and_return_datetime(
         &self,
-        request: &chrono::DateTime<chrono::Utc>,
+        request: &DateTime<Utc>,
         options: Option<RequestOptions>,
-    ) -> Result<chrono::DateTime<chrono::Utc>, ApiError> {
+    ) -> Result<DateTime<Utc>, ApiError> {
         self.http_client
             .execute_request(
                 Method::POST,
@@ -111,9 +111,9 @@ impl EndpointsPrimitiveClient {
 
     pub async fn get_and_return_date(
         &self,
-        request: &chrono::NaiveDate,
+        request: &NaiveDate,
         options: Option<RequestOptions>,
-    ) -> Result<chrono::NaiveDate, ApiError> {
+    ) -> Result<NaiveDate, ApiError> {
         self.http_client
             .execute_request(
                 Method::POST,

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/put/endpoints_put.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/put/endpoints_put.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsPutClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/union_/endpoints_union_.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/union_/endpoints_union_.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsUnionClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/urls/endpoints_urls.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/urls/endpoints_urls.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct EndpointsUrlsClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/general_errors/general_errors.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/general_errors/general_errors.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct GeneralErrorsClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/inlined_requests/inlined_requests.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/inlined_requests/inlined_requests.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct InlinedRequestsClient {
@@ -13,6 +13,15 @@ impl InlinedRequestsClient {
         })
     }
 
+    /// POST with custom object in request body, response is an object
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn post_with_object_bodyand_response(
         &self,
         request: &PostWithObjectBody,

--- a/seed/rust-sdk/exhaustive/src/api/resources/no_auth/no_auth.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/no_auth/no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NoAuthClient {
@@ -13,6 +13,15 @@ impl NoAuthClient {
         })
     }
 
+    /// POST request with no auth
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn post_with_no_auth(
         &self,
         request: &serde_json::Value,

--- a/seed/rust-sdk/exhaustive/src/api/resources/no_req_body/no_req_body.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/no_req_body/no_req_body.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NoReqBodyClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/req_with_headers/req_with_headers.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/req_with_headers/req_with_headers.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ReqWithHeadersClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/types/docs/types_docs.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/types/docs/types_docs.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesDocsClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/types/enum_/types_enum_.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/types/enum_/types_enum_.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesEnumClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/types/object/types_object.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/types/object/types_object.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesObjectClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/types/types.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/types/types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesClient {

--- a/seed/rust-sdk/exhaustive/src/api/resources/types/union_/types_union_.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/types/union_/types_union_.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesUnionClient {

--- a/seed/rust-sdk/exhaustive/src/api/types/types_docs_object_with_docs.rs
+++ b/seed/rust-sdk/exhaustive/src/api/types/types_docs_object_with_docs.rs
@@ -2,5 +2,60 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ObjectWithDocs {
+    /// Characters that could lead to broken generated SDKs:
+    ///
+    /// JSDoc (JavaScript/TypeScript):
+    /// - @: Used for JSDoc tags
+    /// - {: }: Used for type definitions
+    /// - <: >: HTML tags
+    /// - *: Can interfere with comment blocks
+    /// - /**: JSDoc comment start
+    /// - ** /: JSDoc comment end
+    /// - &: HTML entities
+    ///
+    /// XMLDoc (C#):
+    /// - <: >: XML tags
+    /// - &: ': ": <: >: XML special characters
+    /// - {: }: Used for interpolated strings
+    /// - ///: Comment marker
+    /// - /**: Block comment start
+    /// - ** /: Block comment end
+    ///
+    /// Javadoc (Java):
+    /// - @: Used for Javadoc tags
+    /// - <: >: HTML tags
+    /// - &: HTML entities
+    /// - *: Can interfere with comment blocks
+    /// - /**: Javadoc comment start
+    /// - ** /: Javadoc comment end
+    ///
+    /// Doxygen (C++):
+    /// - \: Used for Doxygen commands
+    /// - @: Alternative command prefix
+    /// - <: >: XML/HTML tags
+    /// - &: HTML entities
+    /// - /**: C-style comment start
+    /// - ** /: C-style comment end
+    ///
+    /// RDoc (Ruby):
+    /// - :: Used in symbol notation
+    /// - =: Section markers
+    /// - #: Comment marker
+    /// - =begin: Block comment start
+    /// - =end: Block comment end
+    /// - @: Instance variable prefix
+    /// - $: Global variable prefix
+    /// - %: String literal delimiter
+    /// - #{: String interpolation start
+    /// - }: String interpolation end
+    ///
+    /// PHPDoc (PHP):
+    /// - @: Used for PHPDoc tags
+    /// - {: }: Used for type definitions
+    /// - $: Variable prefix
+    /// - /**: PHPDoc comment start
+    /// - ** /: PHPDoc comment end
+    /// - *: Can interfere with comment blocks
+    /// - &: HTML entities
     pub string: String,
 }

--- a/seed/rust-sdk/exhaustive/src/api/types/types_object_object_with_optional_field.rs
+++ b/seed/rust-sdk/exhaustive/src/api/types/types_object_object_with_optional_field.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObjectWithOptionalField {
+    /// This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub string: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -16,9 +17,9 @@ pub struct ObjectWithOptionalField {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bool: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub datetime: Option<chrono::DateTime<chrono::Utc>>,
+    pub datetime: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub date: Option<chrono::NaiveDate>,
+    pub date: Option<NaiveDate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<uuid::Uuid>,
     #[serde(rename = "base64")]

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/exhaustive/src/core/mod.rs
+++ b/seed/rust-sdk/exhaustive/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/exhaustive/src/core/mod.rs
+++ b/seed/rust-sdk/exhaustive/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/exhaustive/src/core/request_options.rs
+++ b/seed/rust-sdk/exhaustive/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/exhaustive/src/core/utils.rs
+++ b/seed/rust-sdk/exhaustive/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/extends/src/api/mod.rs
+++ b/seed/rust-sdk/extends/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ExtendsClient;
 pub use types::*;

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/extends/src/core/mod.rs
+++ b/seed/rust-sdk/extends/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/extends/src/core/mod.rs
+++ b/seed/rust-sdk/extends/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/extends/src/core/request_options.rs
+++ b/seed/rust-sdk/extends/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/extends/src/core/utils.rs
+++ b/seed/rust-sdk/extends/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/extra-properties/src/api/mod.rs
+++ b/seed/rust-sdk/extra-properties/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ExtraPropertiesClient;
 pub use types::*;

--- a/seed/rust-sdk/extra-properties/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/extra-properties/src/api/resources/user/user.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/extra-properties/src/core/mod.rs
+++ b/seed/rust-sdk/extra-properties/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/extra-properties/src/core/mod.rs
+++ b/seed/rust-sdk/extra-properties/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/extra-properties/src/core/request_options.rs
+++ b/seed/rust-sdk/extra-properties/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/extra-properties/src/core/utils.rs
+++ b/seed/rust-sdk/extra-properties/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/file-download/src/api/mod.rs
+++ b/seed/rust-sdk/file-download/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::FileDownloadClient;

--- a/seed/rust-sdk/file-download/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/file-download/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/file-download/src/core/mod.rs
+++ b/seed/rust-sdk/file-download/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/file-download/src/core/mod.rs
+++ b/seed/rust-sdk/file-download/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/file-download/src/core/request_options.rs
+++ b/seed/rust-sdk/file-download/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/file-download/src/core/utils.rs
+++ b/seed/rust-sdk/file-download/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/file-upload/src/api/mod.rs
+++ b/seed/rust-sdk/file-upload/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::FileUploadClient;
 pub use types::*;

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/file-upload/src/core/mod.rs
+++ b/seed/rust-sdk/file-upload/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/file-upload/src/core/mod.rs
+++ b/seed/rust-sdk/file-upload/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/file-upload/src/core/request_options.rs
+++ b/seed/rust-sdk/file-upload/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/file-upload/src/core/utils.rs
+++ b/seed/rust-sdk/file-upload/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/folders/src/api/mod.rs
+++ b/seed/rust-sdk/folders/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/folders/src/api/resources/a/a.rs
+++ b/seed/rust-sdk/folders/src/api/resources/a/a.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AClient {

--- a/seed/rust-sdk/folders/src/api/resources/a/b/a_b.rs
+++ b/seed/rust-sdk/folders/src/api/resources/a/b/a_b.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ABClient {

--- a/seed/rust-sdk/folders/src/api/resources/a/c/a_c.rs
+++ b/seed/rust-sdk/folders/src/api/resources/a/c/a_c.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ACClient {

--- a/seed/rust-sdk/folders/src/api/resources/a/d/a_d.rs
+++ b/seed/rust-sdk/folders/src/api/resources/a/d/a_d.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ADClient {

--- a/seed/rust-sdk/folders/src/api/resources/a/d/types/a_d_types.rs
+++ b/seed/rust-sdk/folders/src/api/resources/a/d/types/a_d_types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ADTypesClient {

--- a/seed/rust-sdk/folders/src/api/resources/folder/folder.rs
+++ b/seed/rust-sdk/folders/src/api/resources/folder/folder.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderClient {

--- a/seed/rust-sdk/folders/src/api/resources/folder/service/folder_service.rs
+++ b/seed/rust-sdk/folders/src/api/resources/folder/service/folder_service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FolderServiceClient {

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/folders/src/core/mod.rs
+++ b/seed/rust-sdk/folders/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/folders/src/core/mod.rs
+++ b/seed/rust-sdk/folders/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/folders/src/core/request_options.rs
+++ b/seed/rust-sdk/folders/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/folders/src/core/utils.rs
+++ b/seed/rust-sdk/folders/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/http-head/src/api/mod.rs
+++ b/seed/rust-sdk/http-head/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::HttpHeadClient;
 pub use types::*;

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/http-head/src/core/mod.rs
+++ b/seed/rust-sdk/http-head/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/http-head/src/core/mod.rs
+++ b/seed/rust-sdk/http-head/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/http-head/src/core/request_options.rs
+++ b/seed/rust-sdk/http-head/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/http-head/src/core/utils.rs
+++ b/seed/rust-sdk/http-head/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/idempotency-headers/src/api/mod.rs
+++ b/seed/rust-sdk/idempotency-headers/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::IdempotencyHeadersClient;
 pub use types::*;

--- a/seed/rust-sdk/idempotency-headers/src/api/resources/payment/payment.rs
+++ b/seed/rust-sdk/idempotency-headers/src/api/resources/payment/payment.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct PaymentClient {

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/idempotency-headers/src/core/mod.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/idempotency-headers/src/core/mod.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/idempotency-headers/src/core/request_options.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/idempotency-headers/src/core/utils.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/imdb/imdb/src/api/mod.rs
+++ b/seed/rust-sdk/imdb/imdb/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ImdbClient;
 pub use types::*;

--- a/seed/rust-sdk/imdb/imdb/src/api/resources/imdb/imdb.rs
+++ b/seed/rust-sdk/imdb/imdb/src/api/resources/imdb/imdb.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ImdbClient {
@@ -13,6 +13,15 @@ impl ImdbClient {
         })
     }
 
+    /// Add a movie to the database using the movies/* /... path.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_movie(
         &self,
         request: &CreateMovieRequest,

--- a/seed/rust-sdk/imdb/imdb/src/api/types/imdb_movie.rs
+++ b/seed/rust-sdk/imdb/imdb/src/api/types/imdb_movie.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct Movie {
     pub id: MovieId,
     pub title: String,
+    /// The rating scale is one to five stars
     pub rating: f64,
 }

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/imdb/imdb/src/core/mod.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/imdb/imdb/src/core/mod.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/imdb/imdb/src/core/request_options.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/imdb/imdb/src/core/utils.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/mod.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::InferredAuthExplicitClient;
 pub use types::*;

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/request_options.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/utils.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::InferredAuthImplicitNoExpiryClient;
 pub use types::*;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/request_options.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/utils.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::InferredAuthImplicitClient;
 pub use types::*;

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/request_options.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/utils.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/license/src/api/mod.rs
+++ b/seed/rust-sdk/license/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::LicenseClient;
 pub use types::*;

--- a/seed/rust-sdk/license/src/api/types/type_.rs
+++ b/seed/rust-sdk/license/src/api/types/type_.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// A simple type with just a name.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Type {
     pub name: String,

--- a/seed/rust-sdk/license/src/core/http_client.rs
+++ b/seed/rust-sdk/license/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/license/src/core/mod.rs
+++ b/seed/rust-sdk/license/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/license/src/core/mod.rs
+++ b/seed/rust-sdk/license/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/license/src/core/request_options.rs
+++ b/seed/rust-sdk/license/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/license/src/core/utils.rs
+++ b/seed/rust-sdk/license/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/literal/src/api/mod.rs
+++ b/seed/rust-sdk/literal/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::LiteralClient;
 pub use types::*;

--- a/seed/rust-sdk/literal/src/api/resources/headers/headers.rs
+++ b/seed/rust-sdk/literal/src/api/resources/headers/headers.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct HeadersClient {

--- a/seed/rust-sdk/literal/src/api/resources/inlined/inlined.rs
+++ b/seed/rust-sdk/literal/src/api/resources/inlined/inlined.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct InlinedClient {

--- a/seed/rust-sdk/literal/src/api/resources/path/path.rs
+++ b/seed/rust-sdk/literal/src/api/resources/path/path.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct PathClient {

--- a/seed/rust-sdk/literal/src/api/resources/reference/reference.rs
+++ b/seed/rust-sdk/literal/src/api/resources/reference/reference.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ReferenceClient {

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/literal/src/core/mod.rs
+++ b/seed/rust-sdk/literal/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/literal/src/core/mod.rs
+++ b/seed/rust-sdk/literal/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/literal/src/core/request_options.rs
+++ b/seed/rust-sdk/literal/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/literal/src/core/utils.rs
+++ b/seed/rust-sdk/literal/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/literals-unions/src/api/mod.rs
+++ b/seed/rust-sdk/literals-unions/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::LiteralsUnionsClient;
 pub use types::*;

--- a/seed/rust-sdk/literals-unions/src/api/resources/literals/literals.rs
+++ b/seed/rust-sdk/literals-unions/src/api/resources/literals/literals.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct LiteralsClient {

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/literals-unions/src/core/mod.rs
+++ b/seed/rust-sdk/literals-unions/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/literals-unions/src/core/mod.rs
+++ b/seed/rust-sdk/literals-unions/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/literals-unions/src/core/request_options.rs
+++ b/seed/rust-sdk/literals-unions/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/literals-unions/src/core/utils.rs
+++ b/seed/rust-sdk/literals-unions/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/mixed-case/src/api/mod.rs
+++ b/seed/rust-sdk/mixed-case/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::MixedCaseClient;
 pub use types::*;

--- a/seed/rust-sdk/mixed-case/src/api/types/list_resources_query_request.rs
+++ b/seed/rust-sdk/mixed-case/src/api/types/list_resources_query_request.rs
@@ -1,9 +1,9 @@
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListResourcesQueryRequest {
     pub page_limit: i32,
     #[serde(rename = "beforeDate")]
-    pub before_date: chrono::NaiveDate,
+    pub before_date: NaiveDate,
 }

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/mixed-case/src/core/mod.rs
+++ b/seed/rust-sdk/mixed-case/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/mixed-case/src/core/mod.rs
+++ b/seed/rust-sdk/mixed-case/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/mixed-case/src/core/request_options.rs
+++ b/seed/rust-sdk/mixed-case/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/mixed-case/src/core/utils.rs
+++ b/seed/rust-sdk/mixed-case/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/mixed-file-directory/src/api/mod.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::MixedFileDirectoryClient;
 pub use types::*;

--- a/seed/rust-sdk/mixed-file-directory/src/api/resources/organization/organization.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/resources/organization/organization.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct OrganizationClient {
@@ -13,6 +13,15 @@ impl OrganizationClient {
         })
     }
 
+    /// Create a new organization.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create(
         &self,
         request: &CreateOrganizationRequest,

--- a/seed/rust-sdk/mixed-file-directory/src/api/resources/user/events/metadata/user_events_metadata.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/resources/user/events/metadata/user_events_metadata.rs
@@ -13,6 +13,15 @@ impl UserEventsMetadataClient {
         })
     }
 
+    /// Get event metadata.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_metadata(
         &self,
         request: &GetMetadataQueryRequest,

--- a/seed/rust-sdk/mixed-file-directory/src/api/resources/user/events/user_events.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/resources/user/events/user_events.rs
@@ -15,6 +15,16 @@ impl UserEventsClient {
         })
     }
 
+    /// List all user events.
+    ///
+    /// # Arguments
+    ///
+    /// * `limit` - The maximum number of results to return.
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn list_events(
         &self,
         request: &ListEventsQueryRequest,

--- a/seed/rust-sdk/mixed-file-directory/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/resources/user/user.rs
@@ -15,6 +15,16 @@ impl UserClient {
         })
     }
 
+    /// List all users.
+    ///
+    /// # Arguments
+    ///
+    /// * `limit` - The maximum number of results to return.
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn list(
         &self,
         request: &ListQueryRequest,

--- a/seed/rust-sdk/mixed-file-directory/src/api/types/list_events_query_request.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/types/list_events_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListEventsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-sdk/mixed-file-directory/src/api/types/list_query_request.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/types/list_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-sdk/mixed-file-directory/src/api/types/user_events_metadata_metadata.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/types/user_events_metadata_metadata.rs
@@ -1,6 +1,5 @@
 use crate::id::Id;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/mixed-file-directory/src/core/mod.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/mixed-file-directory/src/core/mod.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/mixed-file-directory/src/core/request_options.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/mixed-file-directory/src/core/utils.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/multi-line-docs/src/api/mod.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::MultiLineDocsClient;
 pub use types::*;

--- a/seed/rust-sdk/multi-line-docs/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api/resources/user/user.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {
@@ -13,6 +13,18 @@ impl UserClient {
         })
     }
 
+    /// Retrieve a user.
+    /// This endpoint is used to retrieve a user.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The ID of the user to retrieve.
+    /// This ID is unique to each user.
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn get_user(
         &self,
         user_id: &String,
@@ -29,6 +41,16 @@ impl UserClient {
             .await
     }
 
+    /// Create a new user.
+    /// This endpoint is used to create a new user.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_user(
         &self,
         request: &CreateUserRequest,

--- a/seed/rust-sdk/multi-line-docs/src/api/types/operand.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api/types/operand.rs
@@ -1,12 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Tests enum name and value can be
+/// different.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Operand {
     #[serde(rename = ">")]
     GreaterThan,
     #[serde(rename = "=")]
     EqualTo,
+    /// The name and value should be similar
+    /// are similar for less than.
     #[serde(rename = "less_than")]
     LessThan,
 }

--- a/seed/rust-sdk/multi-line-docs/src/api/types/user_user.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api/types/user_user.rs
@@ -1,9 +1,17 @@
 use serde::{Deserialize, Serialize};
 
+/// A user object. This type is used throughout the following APIs:
+/// - createUser
+/// - getUser
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct User {
     pub id: String,
+    /// The user's name. This name is unique to each user. A few examples are included below:
+    /// - Alice
+    /// - Bob
+    /// - Charlie
     pub name: String,
+    /// The user's age.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub age: Option<i32>,
 }

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/multi-line-docs/src/core/mod.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/multi-line-docs/src/core/mod.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/multi-line-docs/src/core/request_options.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/multi-line-docs/src/core/utils.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/multi-url-environment-no-default/src/api/mod.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::MultiUrlEnvironmentNoDefaultClient;

--- a/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/ec_2/ec_2.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/ec_2/ec_2.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct Ec2Client {

--- a/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/s_3/s_3.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/api/resources/s_3/s_3.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct S3Client {

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/request_options.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/utils.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/multi-url-environment/src/api/mod.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::MultiUrlEnvironmentClient;

--- a/seed/rust-sdk/multi-url-environment/src/api/resources/ec_2/ec_2.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/resources/ec_2/ec_2.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct Ec2Client {

--- a/seed/rust-sdk/multi-url-environment/src/api/resources/s_3/s_3.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/resources/s_3/s_3.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct S3Client {

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/multi-url-environment/src/core/mod.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/multi-url-environment/src/core/mod.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/multi-url-environment/src/core/request_options.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/multi-url-environment/src/core/utils.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/multiple-request-bodies/src/api/mod.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/multiple-request-bodies/src/api/types/upload_document_request.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/api/types/upload_document_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct UploadDocumentRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/multiple-request-bodies/src/core/mod.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/multiple-request-bodies/src/core/mod.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/multiple-request-bodies/src/core/request_options.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/multiple-request-bodies/src/core/utils.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/no-environment/src/api/mod.rs
+++ b/seed/rust-sdk/no-environment/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::NoEnvironmentClient;

--- a/seed/rust-sdk/no-environment/src/api/resources/dummy/dummy.rs
+++ b/seed/rust-sdk/no-environment/src/api/resources/dummy/dummy.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/no-environment/src/core/mod.rs
+++ b/seed/rust-sdk/no-environment/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/no-environment/src/core/mod.rs
+++ b/seed/rust-sdk/no-environment/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/no-environment/src/core/request_options.rs
+++ b/seed/rust-sdk/no-environment/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/no-environment/src/core/utils.rs
+++ b/seed/rust-sdk/no-environment/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/nullable-optional/src/api/mod.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::NullableOptionalClient;
 pub use types::*;

--- a/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/resources/nullable_optional/nullable_optional.rs
@@ -13,6 +13,15 @@ impl NullableOptionalClient {
         })
     }
 
+    /// Get a user by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_user(
         &self,
         user_id: &String,
@@ -29,6 +38,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Create a new user
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_user(
         &self,
         request: &CreateUserRequest,
@@ -45,6 +63,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Update a user (partial update)
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn update_user(
         &self,
         user_id: &String,
@@ -62,6 +89,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// List all users
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn list_users(
         &self,
         request: &ListUsersQueryRequest,
@@ -83,6 +119,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Search users
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn search_users(
         &self,
         request: &SearchUsersQueryRequest,
@@ -104,6 +149,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Create a complex profile to test nullable enums and unions
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_complex_profile(
         &self,
         request: &ComplexProfile,
@@ -120,6 +174,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Get a complex profile by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_complex_profile(
         &self,
         profile_id: &String,
@@ -136,6 +199,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Update complex profile to test nullable field updates
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn update_complex_profile(
         &self,
         profile_id: &String,
@@ -153,6 +225,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Test endpoint for validating null deserialization
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn test_deserialization(
         &self,
         request: &DeserializationTestRequest,
@@ -169,6 +250,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Filter users by role with nullable enum
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn filter_by_role(
         &self,
         request: &FilterByRoleQueryRequest,
@@ -189,6 +279,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Get notification settings which may be null
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_notification_settings(
         &self,
         user_id: &String,
@@ -205,6 +304,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Update tags to test array handling
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn update_tags(
         &self,
         user_id: &String,
@@ -222,6 +330,15 @@ impl NullableOptionalClient {
             .await
     }
 
+    /// Get search results with nullable unions
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_search_results(
         &self,
         request: &SearchRequest,

--- a/seed/rust-sdk/nullable-optional/src/api/types/filter_by_role_query_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/filter_by_role_query_request.rs
@@ -2,7 +2,7 @@ use crate::nullable_optional_user_role::UserRole;
 use crate::nullable_optional_user_status::UserStatus;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct FilterByRoleQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<UserRole>,

--- a/seed/rust-sdk/nullable-optional/src/api/types/list_users_query_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/list_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_address.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_address.rs
@@ -2,6 +2,7 @@ use crate::nullable_optional_nullable_user_id::NullableUserId;
 use crate::nullable_optional_optional_user_id::OptionalUserId;
 use serde::{Deserialize, Serialize};
 
+/// Nested object for testing
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Address {
     pub street: String,

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_complex_profile.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_complex_profile.rs
@@ -6,6 +6,7 @@ use crate::nullable_optional_user_status::UserStatus;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Test object with nullable enums, unions, and arrays
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComplexProfile {
     pub id: String,

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_deserialization_test_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_deserialization_test_request.rs
@@ -7,6 +7,7 @@ use crate::nullable_optional_user_status::UserStatus;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Request body for testing deserialization of null values
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeserializationTestRequest {
     #[serde(rename = "requiredString")]

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_deserialization_test_response.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_deserialization_test_response.rs
@@ -1,12 +1,13 @@
 use crate::nullable_optional_deserialization_test_request::DeserializationTestRequest;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Response for deserialization test
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeserializationTestResponse {
     pub echo: DeserializationTestRequest,
     #[serde(rename = "processedAt")]
-    pub processed_at: chrono::DateTime<chrono::Utc>,
+    pub processed_at: DateTime<Utc>,
     #[serde(rename = "nullCount")]
     pub null_count: i32,
     #[serde(rename = "presentFieldsCount")]

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_update_user_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_update_user_request.rs
@@ -1,6 +1,7 @@
 use crate::nullable_optional_address::Address;
 use serde::{Deserialize, Serialize};
 
+/// For testing PATCH operations
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UpdateUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_profile.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_profile.rs
@@ -1,8 +1,9 @@
 use crate::nullable_optional_address::Address;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Test object with nullable and optional fields
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserProfile {
     pub id: String,
@@ -18,7 +19,7 @@ pub struct UserProfile {
     pub nullable_boolean: Option<bool>,
     #[serde(rename = "nullableDate")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_date: Option<chrono::DateTime<chrono::Utc>>,
+    pub nullable_date: Option<DateTime<Utc>>,
     #[serde(rename = "nullableObject")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable_object: Option<Address>,
@@ -39,7 +40,7 @@ pub struct UserProfile {
     pub optional_boolean: Option<bool>,
     #[serde(rename = "optionalDate")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_date: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_date: Option<DateTime<Utc>>,
     #[serde(rename = "optionalObject")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optional_object: Option<Address>,

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_response.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_response.rs
@@ -1,5 +1,5 @@
 use crate::nullable_optional_address::Address;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -11,10 +11,10 @@ pub struct UserResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
     #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
     #[serde(rename = "updatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<Address>,
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_role.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_role.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Test enum for nullable enum fields
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum UserRole {
     #[serde(rename = "ADMIN")]

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_status.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_user_status.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Test enum with values for optional enum fields
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum UserStatus {
     #[serde(rename = "active")]

--- a/seed/rust-sdk/nullable-optional/src/api/types/update_complex_profile_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/update_complex_profile_request.rs
@@ -4,7 +4,7 @@ use crate::nullable_optional_user_role::UserRole;
 use crate::nullable_optional_user_status::UserStatus;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UpdateComplexProfileRequest {
     #[serde(rename = "nullableRole")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-sdk/nullable-optional/src/api/types/update_tags_request.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/update_tags_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct UpdateTagsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/nullable-optional/src/core/mod.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/nullable-optional/src/core/mod.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/nullable-optional/src/core/request_options.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/nullable-optional/src/core/utils.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/nullable/src/api/mod.rs
+++ b/seed/rust-sdk/nullable/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::NullableClient;
 pub use types::*;

--- a/seed/rust-sdk/nullable/src/api/types/delete_user_request.rs
+++ b/seed/rust-sdk/nullable/src/api/types/delete_user_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct DeleteUserRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<Option<String>>,

--- a/seed/rust-sdk/nullable/src/api/types/get_users_query_request.rs
+++ b/seed/rust-sdk/nullable/src/api/types/get_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct GetUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usernames: Option<String>,

--- a/seed/rust-sdk/nullable/src/api/types/nullable_metadata.rs
+++ b/seed/rust-sdk/nullable/src/api/types/nullable_metadata.rs
@@ -1,14 +1,14 @@
 use crate::nullable_status::Status;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {
     #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub created_at: DateTime<Utc>,
     #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/seed/rust-sdk/nullable/src/api/types/nullable_status.rs
+++ b/seed/rust-sdk/nullable/src/api/types/nullable_status.rs
@@ -6,11 +6,11 @@ pub enum Status {
     Active,
 
     Archived {
-        value: Option<chrono::DateTime<chrono::Utc>>,
+        value: Option<DateTime<Utc>>,
     },
 
     #[serde(rename = "soft-deleted")]
     SoftDeleted {
-        value: Option<chrono::DateTime<chrono::Utc>>,
+        value: Option<DateTime<Utc>>,
     },
 }

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/nullable/src/core/mod.rs
+++ b/seed/rust-sdk/nullable/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/nullable/src/core/mod.rs
+++ b/seed/rust-sdk/nullable/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/nullable/src/core/request_options.rs
+++ b/seed/rust-sdk/nullable/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/nullable/src/core/utils.rs
+++ b/seed/rust-sdk/nullable/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::OauthClientCredentialsClient;
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/request_options.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::OauthClientCredentialsDefaultClient;
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/request_options.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::OauthClientCredentialsEnvironmentVariablesClient;
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/request_options.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::OauthClientCredentialsClient;
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/request_options.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::OauthClientCredentialsWithVariablesClient;
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/service/service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/request_options.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/oauth-client-credentials/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::OauthClientCredentialsClient;
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested/api/nested_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested/api/nested_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedApiClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested/nested.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested/nested.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested_no_auth/api/nested_no_auth_api.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthApiClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested_no_auth/nested_no_auth.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/resources/nested_no_auth/nested_no_auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct NestedNoAuthClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/api/resources/simple/simple.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/resources/simple/simple.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SimpleClient {

--- a/seed/rust-sdk/oauth-client-credentials/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/oauth-client-credentials/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/oauth-client-credentials/src/core/request_options.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/oauth-client-credentials/src/core/utils.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/object/src/api/mod.rs
+++ b/seed/rust-sdk/object/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ObjectClient;
 pub use types::*;

--- a/seed/rust-sdk/object/src/api/types/type_.rs
+++ b/seed/rust-sdk/object/src/api/types/type_.rs
@@ -2,10 +2,10 @@ use crate::name::Name;
 use chrono::{DateTime, NaiveDate, Utc};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::collections::HashMap;
 use uuid::Uuid;
 
+/// Exercises all of the built-in types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Type {
     pub one: i32,
@@ -13,8 +13,8 @@ pub struct Type {
     pub three: String,
     pub four: bool,
     pub five: i64,
-    pub six: chrono::DateTime<chrono::Utc>,
-    pub seven: chrono::NaiveDate,
+    pub six: DateTime<Utc>,
+    pub seven: NaiveDate,
     pub eight: uuid::Uuid,
     pub nine: String,
     pub ten: Vec<i32>,
@@ -33,7 +33,7 @@ pub struct Type {
     pub twentytwo: f32,
     pub twentythree: num_bigint::BigInt,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub twentyfour: Option<chrono::DateTime<chrono::Utc>>,
+    pub twentyfour: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub twentyfive: Option<chrono::NaiveDate>,
+    pub twentyfive: Option<NaiveDate>,
 }

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/object/src/core/mod.rs
+++ b/seed/rust-sdk/object/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/object/src/core/mod.rs
+++ b/seed/rust-sdk/object/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/object/src/core/request_options.rs
+++ b/seed/rust-sdk/object/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/object/src/core/utils.rs
+++ b/seed/rust-sdk/object/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/objects-with-imports/src/api/mod.rs
+++ b/seed/rust-sdk/objects-with-imports/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ObjectsWithImportsClient;
 pub use types::*;

--- a/seed/rust-sdk/objects-with-imports/src/api/resources/commons/commons.rs
+++ b/seed/rust-sdk/objects-with-imports/src/api/resources/commons/commons.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsClient {

--- a/seed/rust-sdk/objects-with-imports/src/api/resources/commons/metadata/commons_metadata.rs
+++ b/seed/rust-sdk/objects-with-imports/src/api/resources/commons/metadata/commons_metadata.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsMetadataClient {

--- a/seed/rust-sdk/objects-with-imports/src/api/resources/file/directory/file_directory.rs
+++ b/seed/rust-sdk/objects-with-imports/src/api/resources/file/directory/file_directory.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FileDirectoryClient {

--- a/seed/rust-sdk/objects-with-imports/src/api/resources/file/file.rs
+++ b/seed/rust-sdk/objects-with-imports/src/api/resources/file/file.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct FileClient {

--- a/seed/rust-sdk/objects-with-imports/src/api/types/file_file_info.rs
+++ b/seed/rust-sdk/objects-with-imports/src/api/types/file_file_info.rs
@@ -3,8 +3,10 @@ use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum FileInfo {
+    /// A regular file (e.g. foo.txt).
     #[serde(rename = "REGULAR")]
     Regular,
+    /// A directory (e.g. foo/).
     #[serde(rename = "DIRECTORY")]
     Directory,
 }

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/objects-with-imports/src/core/mod.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/objects-with-imports/src/core/mod.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/objects-with-imports/src/core/request_options.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/objects-with-imports/src/core/utils.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/optional/src/api/mod.rs
+++ b/seed/rust-sdk/optional/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::ObjectsWithImportsClient;

--- a/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
+++ b/seed/rust-sdk/optional/src/api/resources/optional/optional.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct OptionalClient {

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/optional/src/core/mod.rs
+++ b/seed/rust-sdk/optional/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/optional/src/core/mod.rs
+++ b/seed/rust-sdk/optional/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/optional/src/core/request_options.rs
+++ b/seed/rust-sdk/optional/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/optional/src/core/utils.rs
+++ b/seed/rust-sdk/optional/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/package-yml/src/api/mod.rs
+++ b/seed/rust-sdk/package-yml/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::PackageYmlClient;
 pub use types::*;

--- a/seed/rust-sdk/package-yml/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/package-yml/src/api/resources/service/service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/package-yml/src/core/mod.rs
+++ b/seed/rust-sdk/package-yml/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/package-yml/src/core/mod.rs
+++ b/seed/rust-sdk/package-yml/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/package-yml/src/core/request_options.rs
+++ b/seed/rust-sdk/package-yml/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/package-yml/src/core/utils.rs
+++ b/seed/rust-sdk/package-yml/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/pagination-custom/src/api/mod.rs
+++ b/seed/rust-sdk/pagination-custom/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::PaginationClient;
 pub use types::*;

--- a/seed/rust-sdk/pagination-custom/src/api/types/list_usernames_custom_query_request.rs
+++ b/seed/rust-sdk/pagination-custom/src/api/types/list_usernames_custom_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsernamesCustomQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub starting_after: Option<String>,

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/pagination-custom/src/core/mod.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/pagination-custom/src/core/mod.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/pagination-custom/src/core/request_options.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/pagination-custom/src/core/utils.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/pagination/src/api/mod.rs
+++ b/seed/rust-sdk/pagination/src/api/mod.rs
@@ -1,6 +1,6 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{*};
+pub use resources::{PaginationClient};
 pub use types::{*};
 

--- a/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
 use reqwest::{Method};
 use crate::api::{*};
 use crate::{AsyncPaginator, PaginationResult};

--- a/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions};
 use reqwest::{Method};
 use crate::api::{*};
 

--- a/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users/inline_users_inline_users.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users/inline_users_inline_users.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions, QueryBuilder};
 use reqwest::{Method};
 use crate::api::{*};
 use crate::{AsyncPaginator, PaginationResult};

--- a/seed/rust-sdk/pagination/src/api/resources/users/users.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/users/users.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions, QueryBuilder};
 use reqwest::{Method};
 use crate::api::{*};
 use crate::{AsyncPaginator, PaginationResult};

--- a/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_list_users_extended_optional_list_response.rs
+++ b/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_list_users_extended_optional_list_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedOptionalListResponse {
     #[serde(flatten)]
     pub user_optional_list_page_fields: UserOptionalListPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_list_users_extended_response.rs
+++ b/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_list_users_extended_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedResponse {
     #[serde(flatten)]
     pub user_page_fields: UserPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_list_users_pagination_response.rs
+++ b/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_list_users_pagination_response.rs
@@ -9,6 +9,7 @@ pub struct ListUsersPaginationResponse {
     pub has_next_page: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<Page>,
+    /// The totall number of /users
     pub total_count: i32,
     pub data: Users,
 }

--- a/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_page.rs
+++ b/seed/rust-sdk/pagination/src/api/types/inline_users_inline_users_page.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Page {
+    /// The current page
     pub page: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next: Option<NextPage>,

--- a/seed/rust-sdk/pagination/src/api/types/list_usernames_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_usernames_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsernamesQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub starting_after: Option<String>,

--- a/seed/rust-sdk/pagination/src/api/types/list_users_body_cursor_pagination_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_users_body_cursor_pagination_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_with_cursor::WithCursor;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersBodyCursorPaginationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagination: Option<WithCursor>,

--- a/seed/rust-sdk/pagination/src/api/types/list_users_body_offset_pagination_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_users_body_offset_pagination_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_with_page::WithPage;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListUsersBodyOffsetPaginationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagination: Option<WithPage>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_cursor_pagination_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_cursor_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithCursorPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_double_offset_pagination_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_double_offset_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ListWithDoubleOffsetPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<f64>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_extended_results_and_optional_data_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_extended_results_and_optional_data_query_request.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithExtendedResultsAndOptionalDataQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<uuid::Uuid>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_extended_results_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_extended_results_query_request.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithExtendedResultsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<uuid::Uuid>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_global_config_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_global_config_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithGlobalConfigQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i32>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_mixed_type_cursor_pagination_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_mixed_type_cursor_pagination_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithMixedTypeCursorPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_offset_pagination_has_next_page_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_offset_pagination_has_next_page_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithOffsetPaginationHasNextPageQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_offset_pagination_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_offset_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithOffsetPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-sdk/pagination/src/api/types/list_with_offset_step_pagination_query_request.rs
+++ b/seed/rust-sdk/pagination/src/api/types/list_with_offset_step_pagination_query_request.rs
@@ -1,7 +1,7 @@
 use crate::inline_users_inline_users_order::Order;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct ListWithOffsetStepPaginationQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,

--- a/seed/rust-sdk/pagination/src/api/types/users_list_users_extended_optional_list_response.rs
+++ b/seed/rust-sdk/pagination/src/api/types/users_list_users_extended_optional_list_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedOptionalListResponse {
     #[serde(flatten)]
     pub user_optional_list_page_fields: UserOptionalListPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-sdk/pagination/src/api/types/users_list_users_extended_response.rs
+++ b/seed/rust-sdk/pagination/src/api/types/users_list_users_extended_response.rs
@@ -5,5 +5,6 @@ use serde::{Deserialize, Serialize};
 pub struct ListUsersExtendedResponse {
     #[serde(flatten)]
     pub user_page_fields: UserPage,
+    /// The totall number of /users
     pub total_count: i32,
 }

--- a/seed/rust-sdk/pagination/src/api/types/users_list_users_pagination_response.rs
+++ b/seed/rust-sdk/pagination/src/api/types/users_list_users_pagination_response.rs
@@ -9,6 +9,7 @@ pub struct ListUsersPaginationResponse {
     pub has_next_page: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<Page>,
+    /// The totall number of /users
     pub total_count: i32,
     pub data: Vec<User>,
 }

--- a/seed/rust-sdk/pagination/src/api/types/users_page.rs
+++ b/seed/rust-sdk/pagination/src/api/types/users_page.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Page {
+    /// The current page
     pub page: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next: Option<NextPage>,

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{Utils::join_url, ApiError, ClientConfig, RequestOptions};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/pagination/src/core/mod.rs
+++ b/seed/rust-sdk/pagination/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/pagination/src/core/mod.rs
+++ b/seed/rust-sdk/pagination/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/pagination/src/core/request_options.rs
+++ b/seed/rust-sdk/pagination/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/pagination/src/core/utils.rs
+++ b/seed/rust-sdk/pagination/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/path-parameters/src/api/mod.rs
+++ b/seed/rust-sdk/path-parameters/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::PathParametersClient;
 pub use types::*;

--- a/seed/rust-sdk/path-parameters/src/api/types/search_organizations_query_request.rs
+++ b/seed/rust-sdk/path-parameters/src/api/types/search_organizations_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct SearchOrganizationsQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-sdk/path-parameters/src/api/types/search_users_query_request.rs
+++ b/seed/rust-sdk/path-parameters/src/api/types/search_users_query_request.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct SearchUsersQueryRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/path-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/path-parameters/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/path-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/path-parameters/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/path-parameters/src/core/request_options.rs
+++ b/seed/rust-sdk/path-parameters/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/path-parameters/src/core/utils.rs
+++ b/seed/rust-sdk/path-parameters/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/plain-text/src/api/mod.rs
+++ b/seed/rust-sdk/plain-text/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::PlainTextClient;

--- a/seed/rust-sdk/plain-text/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/plain-text/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/plain-text/src/core/mod.rs
+++ b/seed/rust-sdk/plain-text/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/plain-text/src/core/mod.rs
+++ b/seed/rust-sdk/plain-text/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/plain-text/src/core/request_options.rs
+++ b/seed/rust-sdk/plain-text/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/plain-text/src/core/utils.rs
+++ b/seed/rust-sdk/plain-text/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/property-access/src/api/mod.rs
+++ b/seed/rust-sdk/property-access/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::PropertyAccessClient;
 pub use types::*;

--- a/seed/rust-sdk/property-access/src/api/types/admin.rs
+++ b/seed/rust-sdk/property-access/src/api/types/admin.rs
@@ -1,10 +1,12 @@
 use crate::user::User;
 use serde::{Deserialize, Serialize};
 
+/// Admin user object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Admin {
     #[serde(flatten)]
     pub user_fields: User,
+    /// The level of admin privileges.
     #[serde(rename = "adminLevel")]
     pub admin_level: String,
 }

--- a/seed/rust-sdk/property-access/src/api/types/user.rs
+++ b/seed/rust-sdk/property-access/src/api/types/user.rs
@@ -1,10 +1,15 @@
 use crate::user_profile::UserProfile;
 use serde::{Deserialize, Serialize};
 
+/// User object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct User {
+    /// The unique identifier for the user.
     pub id: String,
+    /// The email address of the user.
     pub email: String,
+    /// The password for the user.
     pub password: String,
+    /// User profile object
     pub profile: UserProfile,
 }

--- a/seed/rust-sdk/property-access/src/api/types/user_profile.rs
+++ b/seed/rust-sdk/property-access/src/api/types/user_profile.rs
@@ -1,9 +1,13 @@
 use crate::user_profile_verification::UserProfileVerification;
 use serde::{Deserialize, Serialize};
 
+/// User profile object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UserProfile {
+    /// The name of the user.
     pub name: String,
+    /// User profile verification object
     pub verification: UserProfileVerification,
+    /// The social security number of the user.
     pub ssn: String,
 }

--- a/seed/rust-sdk/property-access/src/api/types/user_profile_verification.rs
+++ b/seed/rust-sdk/property-access/src/api/types/user_profile_verification.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+/// User profile verification object
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UserProfileVerification {
+    /// User profile verification status
     pub verified: String,
 }

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/property-access/src/core/mod.rs
+++ b/seed/rust-sdk/property-access/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/property-access/src/core/mod.rs
+++ b/seed/rust-sdk/property-access/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/property-access/src/core/request_options.rs
+++ b/seed/rust-sdk/property-access/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/property-access/src/core/utils.rs
+++ b/seed/rust-sdk/property-access/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/public-object/src/api/mod.rs
+++ b/seed/rust-sdk/public-object/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::PublicObjectClient;

--- a/seed/rust-sdk/public-object/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/public-object/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/public-object/src/core/mod.rs
+++ b/seed/rust-sdk/public-object/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/public-object/src/core/mod.rs
+++ b/seed/rust-sdk/public-object/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/public-object/src/core/request_options.rs
+++ b/seed/rust-sdk/public-object/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/public-object/src/core/utils.rs
+++ b/seed/rust-sdk/public-object/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/types/search_query_request.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/types/search_query_request.rs
@@ -2,7 +2,7 @@ use crate::nested_user::NestedUser;
 use crate::search_request_neighbor::SearchRequestNeighbor;
 use crate::search_request_neighbor_required::SearchRequestNeighborRequired;
 use crate::user::User;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -11,7 +11,7 @@ pub struct SearchQueryRequest {
     pub limit: i32,
     pub id: String,
     pub date: String,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
@@ -19,7 +19,7 @@ pub struct SearchQueryRequest {
     pub user_list: Option<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_value: Option<HashMap<String, Option<String>>>,

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/request_options.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/utils.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/query-parameters-openapi/src/api/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/query-parameters-openapi/src/api/types/search_query_request.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/api/types/search_query_request.rs
@@ -1,7 +1,7 @@
 use crate::nested_user::NestedUser;
 use crate::search_request_neighbor_required::SearchRequestNeighborRequired;
 use crate::user::User;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -10,7 +10,7 @@ pub struct SearchQueryRequest {
     pub limit: i32,
     pub id: String,
     pub date: String,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
@@ -18,7 +18,7 @@ pub struct SearchQueryRequest {
     pub user_list: Option<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_value: Option<HashMap<String, Option<String>>>,

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/query-parameters-openapi/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/query-parameters-openapi/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/query-parameters-openapi/src/core/request_options.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/query-parameters-openapi/src/core/utils.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/query-parameters/src/api/mod.rs
+++ b/seed/rust-sdk/query-parameters/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::QueryParametersClient;
 pub use types::*;

--- a/seed/rust-sdk/query-parameters/src/api/types/get_username_query_request.rs
+++ b/seed/rust-sdk/query-parameters/src/api/types/get_username_query_request.rs
@@ -9,15 +9,15 @@ use uuid::Uuid;
 pub struct GetUsernameQueryRequest {
     pub limit: i32,
     pub id: uuid::Uuid,
-    pub date: chrono::NaiveDate,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub date: NaiveDate,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
     pub user_list: Vec<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     pub key_value: HashMap<String, String>,
     #[serde(rename = "optionalString")]

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/query-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/query-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/query-parameters/src/core/request_options.rs
+++ b/seed/rust-sdk/query-parameters/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/query-parameters/src/core/utils.rs
+++ b/seed/rust-sdk/query-parameters/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/request-parameters/src/api/mod.rs
+++ b/seed/rust-sdk/request-parameters/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::RequestParametersClient;
 pub use types::*;

--- a/seed/rust-sdk/request-parameters/src/api/types/get_username_query_request.rs
+++ b/seed/rust-sdk/request-parameters/src/api/types/get_username_query_request.rs
@@ -9,15 +9,15 @@ use uuid::Uuid;
 pub struct GetUsernameQueryRequest {
     pub limit: i32,
     pub id: uuid::Uuid,
-    pub date: chrono::NaiveDate,
-    pub deadline: chrono::DateTime<chrono::Utc>,
+    pub date: NaiveDate,
+    pub deadline: DateTime<Utc>,
     pub bytes: String,
     pub user: User,
     #[serde(rename = "userList")]
     pub user_list: Vec<User>,
     #[serde(rename = "optionalDeadline")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    pub optional_deadline: Option<DateTime<Utc>>,
     #[serde(rename = "keyValue")]
     pub key_value: HashMap<String, String>,
     #[serde(rename = "optionalString")]

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/request-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/request-parameters/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/request-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/request-parameters/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/request-parameters/src/core/request_options.rs
+++ b/seed/rust-sdk/request-parameters/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/request-parameters/src/core/utils.rs
+++ b/seed/rust-sdk/request-parameters/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/reserved-keywords/src/api/mod.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/mod.rs
@@ -1,6 +1,6 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{*};
+pub use resources::{NurseryApiClient};
 pub use types::{*};
 

--- a/seed/rust-sdk/reserved-keywords/src/api/resources/package/package.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/resources/package/package.rs
@@ -1,4 +1,4 @@
-use crate::{ClientConfig, ApiError, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ClientConfig, ApiError, HttpClient, RequestOptions, QueryBuilder};
 use reqwest::{Method};
 use crate::api::{*};
 

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{Utils::join_url, ApiError, ClientConfig, RequestOptions};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/reserved-keywords/src/core/mod.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/reserved-keywords/src/core/mod.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/reserved-keywords/src/core/request_options.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/reserved-keywords/src/core/utils.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/response-property/src/api/mod.rs
+++ b/seed/rust-sdk/response-property/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ResponsePropertyClient;
 pub use types::*;

--- a/seed/rust-sdk/response-property/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/response-property/src/api/resources/service/service.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/response-property/src/core/mod.rs
+++ b/seed/rust-sdk/response-property/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/response-property/src/core/mod.rs
+++ b/seed/rust-sdk/response-property/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/response-property/src/core/request_options.rs
+++ b/seed/rust-sdk/response-property/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/response-property/src/core/utils.rs
+++ b/seed/rust-sdk/response-property/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/server-sent-event-examples/src/api/mod.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ServerSentEventsClient;
 pub use types::*;

--- a/seed/rust-sdk/server-sent-event-examples/src/api/resources/completions/completions.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/api/resources/completions/completions.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CompletionsClient {

--- a/seed/rust-sdk/server-sent-event-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/server-sent-event-examples/src/core/mod.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/server-sent-event-examples/src/core/mod.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/server-sent-event-examples/src/core/request_options.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/server-sent-event-examples/src/core/utils.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/server-sent-events/src/api/mod.rs
+++ b/seed/rust-sdk/server-sent-events/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ServerSentEventsClient;
 pub use types::*;

--- a/seed/rust-sdk/server-sent-events/src/api/resources/completions/completions.rs
+++ b/seed/rust-sdk/server-sent-events/src/api/resources/completions/completions.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CompletionsClient {

--- a/seed/rust-sdk/server-sent-events/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/server-sent-events/src/core/mod.rs
+++ b/seed/rust-sdk/server-sent-events/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/server-sent-events/src/core/mod.rs
+++ b/seed/rust-sdk/server-sent-events/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/server-sent-events/src/core/request_options.rs
+++ b/seed/rust-sdk/server-sent-events/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/server-sent-events/src/core/utils.rs
+++ b/seed/rust-sdk/server-sent-events/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/simple-api/src/api/mod.rs
+++ b/seed/rust-sdk/simple-api/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::SimpleApiClient;
 pub use types::*;

--- a/seed/rust-sdk/simple-api/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/simple-api/src/api/resources/user/user.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/simple-api/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/simple-api/src/core/mod.rs
+++ b/seed/rust-sdk/simple-api/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/simple-api/src/core/mod.rs
+++ b/seed/rust-sdk/simple-api/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/simple-api/src/core/request_options.rs
+++ b/seed/rust-sdk/simple-api/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/simple-api/src/core/utils.rs
+++ b/seed/rust-sdk/simple-api/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/simple-fhir/src/api/mod.rs
+++ b/seed/rust-sdk/simple-fhir/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/simple-fhir/src/core/mod.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/simple-fhir/src/core/mod.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/simple-fhir/src/core/request_options.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/simple-fhir/src/core/utils.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/single-url-environment-default/src/api/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::SingleUrlEnvironmentDefaultClient;

--- a/seed/rust-sdk/single-url-environment-default/src/api/resources/dummy/dummy.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/api/resources/dummy/dummy.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/single-url-environment-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/single-url-environment-default/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/single-url-environment-default/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/single-url-environment-default/src/core/request_options.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/single-url-environment-default/src/core/utils.rs
+++ b/seed/rust-sdk/single-url-environment-default/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/single-url-environment-no-default/src/api/mod.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::SingleUrlEnvironmentNoDefaultClient;

--- a/seed/rust-sdk/single-url-environment-no-default/src/api/resources/dummy/dummy.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/api/resources/dummy/dummy.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/request_options.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/utils.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/streaming-parameter/src/api/mod.rs
+++ b/seed/rust-sdk/streaming-parameter/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::StreamingClient;
 pub use types::*;

--- a/seed/rust-sdk/streaming-parameter/src/api/resources/dummy/dummy.rs
+++ b/seed/rust-sdk/streaming-parameter/src/api/resources/dummy/dummy.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/streaming-parameter/src/core/mod.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/streaming-parameter/src/core/mod.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/streaming-parameter/src/core/request_options.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/streaming-parameter/src/core/utils.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/streaming/src/api/mod.rs
+++ b/seed/rust-sdk/streaming/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::StreamingClient;
 pub use types::*;

--- a/seed/rust-sdk/streaming/src/api/resources/dummy/dummy.rs
+++ b/seed/rust-sdk/streaming/src/api/resources/dummy/dummy.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct DummyClient {

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/streaming/src/core/mod.rs
+++ b/seed/rust-sdk/streaming/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/streaming/src/core/mod.rs
+++ b/seed/rust-sdk/streaming/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/streaming/src/core/request_options.rs
+++ b/seed/rust-sdk/streaming/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/streaming/src/core/utils.rs
+++ b/seed/rust-sdk/streaming/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/trace/src/api/mod.rs
+++ b/seed/rust-sdk/trace/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::TraceClient;
 pub use types::*;

--- a/seed/rust-sdk/trace/src/api/resources/admin/admin.rs
+++ b/seed/rust-sdk/trace/src/api/resources/admin/admin.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AdminClient {

--- a/seed/rust-sdk/trace/src/api/resources/commons/commons.rs
+++ b/seed/rust-sdk/trace/src/api/resources/commons/commons.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct CommonsClient {

--- a/seed/rust-sdk/trace/src/api/resources/homepage/homepage.rs
+++ b/seed/rust-sdk/trace/src/api/resources/homepage/homepage.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct HomepageClient {

--- a/seed/rust-sdk/trace/src/api/resources/lang_server/lang_server.rs
+++ b/seed/rust-sdk/trace/src/api/resources/lang_server/lang_server.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct LangServerClient {

--- a/seed/rust-sdk/trace/src/api/resources/migration/migration.rs
+++ b/seed/rust-sdk/trace/src/api/resources/migration/migration.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct MigrationClient {

--- a/seed/rust-sdk/trace/src/api/resources/playlist/playlist.rs
+++ b/seed/rust-sdk/trace/src/api/resources/playlist/playlist.rs
@@ -13,6 +13,15 @@ impl PlaylistClient {
         })
     }
 
+    /// Create a new playlist
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_playlist(
         &self,
         service_param: i32,
@@ -33,6 +42,18 @@ impl PlaylistClient {
             .await
     }
 
+    /// Returns the user's playlists
+    ///
+    /// # Arguments
+    ///
+    /// * `other_field` - i'm another field
+    /// * `multi_line_docs` - I'm a multiline
+    /// description
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_playlists(
         &self,
         service_param: i32,
@@ -59,6 +80,15 @@ impl PlaylistClient {
             .await
     }
 
+    /// Returns a playlist
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_playlist(
         &self,
         service_param: i32,
@@ -76,6 +106,15 @@ impl PlaylistClient {
             .await
     }
 
+    /// Updates a playlist
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn update_playlist(
         &self,
         service_param: i32,
@@ -94,6 +133,15 @@ impl PlaylistClient {
             .await
     }
 
+    /// Deletes a playlist
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn delete_playlist(
         &self,
         service_param: i32,

--- a/seed/rust-sdk/trace/src/api/resources/problem/problem.rs
+++ b/seed/rust-sdk/trace/src/api/resources/problem/problem.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ProblemClient {
@@ -13,6 +13,15 @@ impl ProblemClient {
         })
     }
 
+    /// Creates a problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_problem(
         &self,
         request: &CreateProblemRequest,
@@ -29,6 +38,15 @@ impl ProblemClient {
             .await
     }
 
+    /// Updates a problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn update_problem(
         &self,
         problem_id: &ProblemId,
@@ -46,6 +64,15 @@ impl ProblemClient {
             .await
     }
 
+    /// Soft deletes a problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn delete_problem(
         &self,
         problem_id: &ProblemId,
@@ -62,6 +89,15 @@ impl ProblemClient {
             .await
     }
 
+    /// Returns default starter files for problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_default_starter_files(
         &self,
         request: &GetDefaultStarterFilesRequest,

--- a/seed/rust-sdk/trace/src/api/resources/submission/submission.rs
+++ b/seed/rust-sdk/trace/src/api/resources/submission/submission.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SubmissionClient {
@@ -13,6 +13,15 @@ impl SubmissionClient {
         })
     }
 
+    /// Returns sessionId and execution server URL for session. Spins up server.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn create_execution_session(
         &self,
         language: &Language,
@@ -29,6 +38,15 @@ impl SubmissionClient {
             .await
     }
 
+    /// Returns execution server URL for session. Returns empty if session isn't registered.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_execution_session(
         &self,
         session_id: &String,
@@ -45,6 +63,15 @@ impl SubmissionClient {
             .await
     }
 
+    /// Stops execution session.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// Empty response
     pub async fn stop_execution_session(
         &self,
         session_id: &String,

--- a/seed/rust-sdk/trace/src/api/resources/sysprop/sysprop.rs
+++ b/seed/rust-sdk/trace/src/api/resources/sysprop/sysprop.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct SyspropClient {

--- a/seed/rust-sdk/trace/src/api/resources/v_2/problem/v_2_problem.rs
+++ b/seed/rust-sdk/trace/src/api/resources/v_2/problem/v_2_problem.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct V2ProblemClient {
@@ -13,6 +13,15 @@ impl V2ProblemClient {
         })
     }
 
+    /// Returns lightweight versions of all problems
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_lightweight_problems(
         &self,
         options: Option<RequestOptions>,
@@ -28,6 +37,15 @@ impl V2ProblemClient {
             .await
     }
 
+    /// Returns latest versions of all problems
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_problems(
         &self,
         options: Option<RequestOptions>,
@@ -43,6 +61,15 @@ impl V2ProblemClient {
             .await
     }
 
+    /// Returns latest version of a problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_latest_problem(
         &self,
         problem_id: &ProblemId,
@@ -59,6 +86,15 @@ impl V2ProblemClient {
             .await
     }
 
+    /// Returns requested version of a problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_problem_version(
         &self,
         problem_id: &ProblemId,

--- a/seed/rust-sdk/trace/src/api/resources/v_2/v_2.rs
+++ b/seed/rust-sdk/trace/src/api/resources/v_2/v_2.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct V2Client {

--- a/seed/rust-sdk/trace/src/api/resources/v_2/v_3/problem/v_2_v_3_problem.rs
+++ b/seed/rust-sdk/trace/src/api/resources/v_2/v_3/problem/v_2_v_3_problem.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct V2V3ProblemClient {
@@ -13,6 +13,15 @@ impl V2V3ProblemClient {
         })
     }
 
+    /// Returns lightweight versions of all problems
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_lightweight_problems(
         &self,
         options: Option<RequestOptions>,
@@ -28,6 +37,15 @@ impl V2V3ProblemClient {
             .await
     }
 
+    /// Returns latest versions of all problems
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_problems(
         &self,
         options: Option<RequestOptions>,
@@ -43,6 +61,15 @@ impl V2V3ProblemClient {
             .await
     }
 
+    /// Returns latest version of a problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_latest_problem(
         &self,
         problem_id: &ProblemId,
@@ -59,6 +86,15 @@ impl V2V3ProblemClient {
             .await
     }
 
+    /// Returns requested version of a problem
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Additional request options such as headers, timeout, etc.
+    ///
+    /// # Returns
+    ///
+    /// JSON response from the API
     pub async fn get_problem_version(
         &self,
         problem_id: &ProblemId,

--- a/seed/rust-sdk/trace/src/api/resources/v_2/v_3/v_2_v_3.rs
+++ b/seed/rust-sdk/trace/src/api/resources/v_2/v_3/v_2_v_3.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct V2V3Client {

--- a/seed/rust-sdk/trace/src/api/types/commons_list_type.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_list_type.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct ListType {
     #[serde(rename = "valueType")]
     pub value_type: VariableType,
+    /// Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false.
     #[serde(rename = "isFixedLength")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_fixed_length: Option<bool>,

--- a/seed/rust-sdk/trace/src/api/types/lang_server_lang_server_request.rs
+++ b/seed/rust-sdk/trace/src/api/types/lang_server_lang_server_request.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LangServerRequest {

--- a/seed/rust-sdk/trace/src/api/types/lang_server_lang_server_response.rs
+++ b/seed/rust-sdk/trace/src/api/types/lang_server_lang_server_response.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LangServerResponse {

--- a/seed/rust-sdk/trace/src/api/types/migration_migration_status.rs
+++ b/seed/rust-sdk/trace/src/api/types/migration_migration_status.rs
@@ -3,8 +3,10 @@ use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum MigrationStatus {
+    /// The migration is running
     #[serde(rename = "RUNNING")]
     Running,
+    /// The migration is failed
     #[serde(rename = "FAILED")]
     Failed,
     #[serde(rename = "FINISHED")]

--- a/seed/rust-sdk/trace/src/api/types/playlist_update_playlist_request.rs
+++ b/seed/rust-sdk/trace/src/api/types/playlist_update_playlist_request.rs
@@ -4,5 +4,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct UpdatePlaylistRequest {
     pub name: String,
+    /// The problems that make up the playlist.
     pub problems: Vec<ProblemId>,
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_execution_session_state.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_execution_session_state.rs
@@ -7,6 +7,7 @@ pub struct ExecutionSessionState {
     #[serde(rename = "lastTimeContacted")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_time_contacted: Option<String>,
+    /// The auto-generated session id. Formatted as a uuid.
     #[serde(rename = "sessionId")]
     pub session_id: String,
     #[serde(rename = "isWarmInstance")]

--- a/seed/rust-sdk/trace/src/api/types/submission_get_submission_state_response.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_get_submission_state_response.rs
@@ -1,13 +1,13 @@
 use crate::commons_language::Language;
 use crate::submission_submission_type_state::SubmissionTypeState;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetSubmissionStateResponse {
     #[serde(rename = "timeSubmitted")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub time_submitted: Option<chrono::DateTime<chrono::Utc>>,
+    pub time_submitted: Option<DateTime<Utc>>,
     pub submission: String,
     pub language: Language,
     #[serde(rename = "submissionTypeState")]

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_type_enum.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_type_enum.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Keep in sync with SubmissionType.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum SubmissionTypeEnum {
     #[serde(rename = "TEST")]

--- a/seed/rust-sdk/trace/src/api/types/submission_test_submission_update.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_test_submission_update.rs
@@ -1,11 +1,11 @@
 use crate::submission_test_submission_update_info::TestSubmissionUpdateInfo;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestSubmissionUpdate {
     #[serde(rename = "updateTime")]
-    pub update_time: chrono::DateTime<chrono::Utc>,
+    pub update_time: DateTime<Utc>,
     #[serde(rename = "updateInfo")]
     pub update_info: TestSubmissionUpdateInfo,
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_trace_responses_page.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_trace_responses_page.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceResponsesPage {
+    /// If present, use this to load subsequent pages.
+    /// The offset is the id of the next trace response to load.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i32>,
     #[serde(rename = "traceResponses")]

--- a/seed/rust-sdk/trace/src/api/types/submission_trace_responses_page_v_2.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_trace_responses_page_v_2.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceResponsesPageV2 {
+    /// If present, use this to load subsequent pages.
+    /// The offset is the id of the next trace response to load.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<i32>,
     #[serde(rename = "traceResponses")]

--- a/seed/rust-sdk/trace/src/api/types/submission_workspace_submission_update.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_workspace_submission_update.rs
@@ -1,11 +1,11 @@
 use crate::submission_workspace_submission_update_info::WorkspaceSubmissionUpdateInfo;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceSubmissionUpdate {
     #[serde(rename = "updateTime")]
-    pub update_time: chrono::DateTime<chrono::Utc>,
+    pub update_time: DateTime<Utc>,
     #[serde(rename = "updateInfo")]
     pub update_info: WorkspaceSubmissionUpdateInfo,
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_problem_void_function_definition_that_takes_actual_result.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_problem_void_function_definition_that_takes_actual_result.rs
@@ -2,6 +2,7 @@ use crate::v_2_problem_function_implementation_for_multiple_languages::FunctionI
 use crate::v_2_problem_parameter::Parameter;
 use serde::{Deserialize, Serialize};
 
+/// The generated signature will include an additional param, actualResult
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VoidFunctionDefinitionThatTakesActualResult {
     #[serde(rename = "additionalParameters")]

--- a/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_void_function_definition_that_takes_actual_result.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_void_function_definition_that_takes_actual_result.rs
@@ -2,6 +2,7 @@ use crate::v_2_problem_function_implementation_for_multiple_languages::FunctionI
 use crate::v_2_problem_parameter::Parameter;
 use serde::{Deserialize, Serialize};
 
+/// The generated signature will include an additional param, actualResult
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VoidFunctionDefinitionThatTakesActualResult {
     #[serde(rename = "additionalParameters")]

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/trace/src/core/mod.rs
+++ b/seed/rust-sdk/trace/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/trace/src/core/mod.rs
+++ b/seed/rust-sdk/trace/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/trace/src/core/request_options.rs
+++ b/seed/rust-sdk/trace/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/trace/src/core/utils.rs
+++ b/seed/rust-sdk/trace/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/undiscriminated-unions/src/api/mod.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::UndiscriminatedUnionsClient;
 pub use types::*;

--- a/seed/rust-sdk/undiscriminated-unions/src/api/resources/union_/union_.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/resources/union_/union_.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UnionClient {

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/undiscriminated-unions/src/core/mod.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/undiscriminated-unions/src/core/mod.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/undiscriminated-unions/src/core/request_options.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/undiscriminated-unions/src/core/utils.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/unions/src/api/mod.rs
+++ b/seed/rust-sdk/unions/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::UnionsClient;
 pub use types::*;

--- a/seed/rust-sdk/unions/src/api/resources/bigunion/bigunion.rs
+++ b/seed/rust-sdk/unions/src/api/resources/bigunion/bigunion.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct BigunionClient {

--- a/seed/rust-sdk/unions/src/api/resources/types/types.rs
+++ b/seed/rust-sdk/unions/src/api/resources/types/types.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct TypesClient {

--- a/seed/rust-sdk/unions/src/api/resources/union_/union_.rs
+++ b/seed/rust-sdk/unions/src/api/resources/union_/union_.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UnionClient {

--- a/seed/rust-sdk/unions/src/api/types/bigunion_big_union.rs
+++ b/seed/rust-sdk/unions/src/api/types/bigunion_big_union.rs
@@ -38,10 +38,10 @@ pub enum BigUnion {
         data: NormalSweet,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     ThankfulFactor {
@@ -49,10 +49,10 @@ pub enum BigUnion {
         data: ThankfulFactor,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     JumboEnd {
@@ -60,10 +60,10 @@ pub enum BigUnion {
         data: JumboEnd,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     HastyPain {
@@ -71,10 +71,10 @@ pub enum BigUnion {
         data: HastyPain,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     MistySnow {
@@ -82,10 +82,10 @@ pub enum BigUnion {
         data: MistySnow,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     DistinctFailure {
@@ -93,10 +93,10 @@ pub enum BigUnion {
         data: DistinctFailure,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     PracticalPrinciple {
@@ -104,10 +104,10 @@ pub enum BigUnion {
         data: PracticalPrinciple,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     LimpingStep {
@@ -115,10 +115,10 @@ pub enum BigUnion {
         data: LimpingStep,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     VibrantExcitement {
@@ -126,10 +126,10 @@ pub enum BigUnion {
         data: VibrantExcitement,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     ActiveDiamond {
@@ -137,10 +137,10 @@ pub enum BigUnion {
         data: ActiveDiamond,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     PopularLimit {
@@ -148,10 +148,10 @@ pub enum BigUnion {
         data: PopularLimit,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     FalseMirror {
@@ -159,10 +159,10 @@ pub enum BigUnion {
         data: FalseMirror,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     PrimaryBlock {
@@ -170,10 +170,10 @@ pub enum BigUnion {
         data: PrimaryBlock,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     RotatingRatio {
@@ -181,10 +181,10 @@ pub enum BigUnion {
         data: RotatingRatio,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     ColorfulCover {
@@ -192,10 +192,10 @@ pub enum BigUnion {
         data: ColorfulCover,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     DisloyalValue {
@@ -203,10 +203,10 @@ pub enum BigUnion {
         data: DisloyalValue,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     GruesomeCoach {
@@ -214,10 +214,10 @@ pub enum BigUnion {
         data: GruesomeCoach,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     TotalWork {
@@ -225,10 +225,10 @@ pub enum BigUnion {
         data: TotalWork,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     HarmoniousPlay {
@@ -236,10 +236,10 @@ pub enum BigUnion {
         data: HarmoniousPlay,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     UniqueStress {
@@ -247,10 +247,10 @@ pub enum BigUnion {
         data: UniqueStress,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     UnwillingSmoke {
@@ -258,10 +258,10 @@ pub enum BigUnion {
         data: UnwillingSmoke,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     FrozenSleep {
@@ -269,10 +269,10 @@ pub enum BigUnion {
         data: FrozenSleep,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     DiligentDeal {
@@ -280,10 +280,10 @@ pub enum BigUnion {
         data: DiligentDeal,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     AttractiveScript {
@@ -291,10 +291,10 @@ pub enum BigUnion {
         data: AttractiveScript,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     HoarseMouse {
@@ -302,10 +302,10 @@ pub enum BigUnion {
         data: HoarseMouse,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     CircularCard {
@@ -313,10 +313,10 @@ pub enum BigUnion {
         data: CircularCard,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     PotableBad {
@@ -324,10 +324,10 @@ pub enum BigUnion {
         data: PotableBad,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     TriangularRepair {
@@ -335,10 +335,10 @@ pub enum BigUnion {
         data: TriangularRepair,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 
     GaseousRoad {
@@ -346,10 +346,10 @@ pub enum BigUnion {
         data: GaseousRoad,
         id: String,
         #[serde(rename = "created-at")]
-        created_at: chrono::DateTime<chrono::Utc>,
+        created_at: DateTime<Utc>,
         #[serde(rename = "archived-at")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        archived_at: Option<chrono::DateTime<chrono::Utc>>,
+        archived_at: Option<DateTime<Utc>>,
     },
 }
 
@@ -388,7 +388,7 @@ impl BigUnion {
         }
     }
 
-    pub fn get_created_at(&self) -> &chrono::DateTime<chrono::Utc> {
+    pub fn get_created_at(&self) -> &DateTime<Utc> {
         match self {
             Self::NormalSweet { created_at, .. } => created_at,
             Self::ThankfulFactor { created_at, .. } => created_at,
@@ -422,7 +422,7 @@ impl BigUnion {
         }
     }
 
-    pub fn get_archived_at(&self) -> &Option<chrono::DateTime<chrono::Utc>> {
+    pub fn get_archived_at(&self) -> &Option<DateTime<Utc>> {
         match self {
             Self::NormalSweet { archived_at, .. } => archived_at,
             Self::ThankfulFactor { archived_at, .. } => archived_at,

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_optional_time.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_optional_time.rs
@@ -3,11 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum UnionWithOptionalTime {
-    Date {
-        value: Option<chrono::NaiveDate>,
-    },
+    Date { value: Option<NaiveDate> },
 
-    Datetime {
-        value: Option<chrono::DateTime<chrono::Utc>>,
-    },
+    Datetime { value: Option<DateTime<Utc>> },
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_time.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_time.rs
@@ -1,18 +1,12 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum UnionWithTime {
-    Value {
-        value: i32,
-    },
+    Value { value: i32 },
 
-    Date {
-        value: chrono::NaiveDate,
-    },
+    Date { value: NaiveDate },
 
-    Datetime {
-        value: chrono::DateTime<chrono::Utc>,
-    },
+    Datetime { value: DateTime<Utc> },
 }

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/unions/src/core/mod.rs
+++ b/seed/rust-sdk/unions/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/unions/src/core/mod.rs
+++ b/seed/rust-sdk/unions/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/unions/src/core/request_options.rs
+++ b/seed/rust-sdk/unions/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/unions/src/core/utils.rs
+++ b/seed/rust-sdk/unions/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/unknown/src/api/mod.rs
+++ b/seed/rust-sdk/unknown/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::UnknownAsAnyClient;
 pub use types::*;

--- a/seed/rust-sdk/unknown/src/api/resources/unknown/unknown.rs
+++ b/seed/rust-sdk/unknown/src/api/resources/unknown/unknown.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UnknownClient {

--- a/seed/rust-sdk/unknown/src/api/types/unknown_my_alias.rs
+++ b/seed/rust-sdk/unknown/src/api/types/unknown_my_alias.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MyAlias(pub serde_json::Value);

--- a/seed/rust-sdk/unknown/src/api/types/unknown_my_object.rs
+++ b/seed/rust-sdk/unknown/src/api/types/unknown_my_object.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MyObject {

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/unknown/src/core/mod.rs
+++ b/seed/rust-sdk/unknown/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/unknown/src/core/mod.rs
+++ b/seed/rust-sdk/unknown/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/unknown/src/core/request_options.rs
+++ b/seed/rust-sdk/unknown/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/unknown/src/core/utils.rs
+++ b/seed/rust-sdk/unknown/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/validation/src/api/mod.rs
+++ b/seed/rust-sdk/validation/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::ValidationClient;
 pub use types::*;

--- a/seed/rust-sdk/validation/src/api/types/type_.rs
+++ b/seed/rust-sdk/validation/src/api/types/type_.rs
@@ -1,6 +1,7 @@
 use crate::shape::Shape;
 use serde::{Deserialize, Serialize};
 
+/// Defines properties with default values and validation rules.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Type {
     pub decimal: f64,

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/validation/src/core/mod.rs
+++ b/seed/rust-sdk/validation/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/validation/src/core/mod.rs
+++ b/seed/rust-sdk/validation/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/validation/src/core/request_options.rs
+++ b/seed/rust-sdk/validation/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/validation/src/core/utils.rs
+++ b/seed/rust-sdk/validation/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/variables/src/api/mod.rs
+++ b/seed/rust-sdk/variables/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::*;
+pub use resources::VariablesClient;

--- a/seed/rust-sdk/variables/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/variables/src/api/resources/service/service.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct ServiceClient {

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/variables/src/core/mod.rs
+++ b/seed/rust-sdk/variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/variables/src/core/mod.rs
+++ b/seed/rust-sdk/variables/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/variables/src/core/request_options.rs
+++ b/seed/rust-sdk/variables/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/variables/src/core/utils.rs
+++ b/seed/rust-sdk/variables/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/version-no-default/src/api/mod.rs
+++ b/seed/rust-sdk/version-no-default/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::VersionClient;
 pub use types::*;

--- a/seed/rust-sdk/version-no-default/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/version-no-default/src/api/resources/user/user.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/version-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/version-no-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/version-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/version-no-default/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/version-no-default/src/core/request_options.rs
+++ b/seed/rust-sdk/version-no-default/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/version-no-default/src/core/utils.rs
+++ b/seed/rust-sdk/version-no-default/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/version/src/api/mod.rs
+++ b/seed/rust-sdk/version/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::VersionClient;
 pub use types::*;

--- a/seed/rust-sdk/version/src/api/resources/user/user.rs
+++ b/seed/rust-sdk/version/src/api/resources/user/user.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct UserClient {

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/version/src/core/mod.rs
+++ b/seed/rust-sdk/version/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/version/src/core/mod.rs
+++ b/seed/rust-sdk/version/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/version/src/core/request_options.rs
+++ b/seed/rust-sdk/version/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/version/src/core/utils.rs
+++ b/seed/rust-sdk/version/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::WebsocketBearerAuthClient;
 pub use types::*;

--- a/seed/rust-sdk/websocket-bearer-auth/src/api/resources/realtime/realtime.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/api/resources/realtime/realtime.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct RealtimeClient {

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/request_options.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/utils.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::WebsocketAuthClient;
 pub use types::*;

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/resources/auth/auth.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/resources/auth/auth.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct AuthClient {

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/resources/realtime/realtime.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/resources/realtime/realtime.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct RealtimeClient {

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/types/auth_token_response.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/types/auth_token_response.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An OAuth token response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenResponse {
     pub access_token: String,

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/request_options.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/utils.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }

--- a/seed/rust-sdk/websocket/src/api/mod.rs
+++ b/seed/rust-sdk/websocket/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::*;
+pub use resources::WebsocketClient;
 pub use types::*;

--- a/seed/rust-sdk/websocket/src/api/resources/realtime/realtime.rs
+++ b/seed/rust-sdk/websocket/src/api/resources/realtime/realtime.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
 use reqwest::Method;
 
 pub struct RealtimeClient {

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -1,4 +1,4 @@
-use crate::{ApiError, ClientConfig, RequestOptions, Utils::join_url};
+use crate::{join_url, ApiError, ClientConfig, RequestOptions};
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Client, Method, Request, Response,

--- a/seed/rust-sdk/websocket/src/core/mod.rs
+++ b/seed/rust-sdk/websocket/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::*;
+pub use utils::join_url;

--- a/seed/rust-sdk/websocket/src/core/mod.rs
+++ b/seed/rust-sdk/websocket/src/core/mod.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use http_client::HttpClient;
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
-pub use utils::Utils;
+pub use utils::*;

--- a/seed/rust-sdk/websocket/src/core/request_options.rs
+++ b/seed/rust-sdk/websocket/src/core/request_options.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
-
 /// Options for customizing individual requests
 #[derive(Debug, Clone, Default)]
 pub struct RequestOptions {

--- a/seed/rust-sdk/websocket/src/core/utils.rs
+++ b/seed/rust-sdk/websocket/src/core/utils.rs
@@ -1,21 +1,19 @@
 /// URL building utilities
-pub mod Utils {
-    /// Safely join a base URL with a path, handling slashes properly
-    ///
-    /// # Examples
-    /// ```
-    /// use example_api::utils::url::join_url;
-    ///
-    /// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
-    /// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
-    /// ```
-    pub fn join_url(base_url: &str, path: &str) -> String {
-        format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            path.trim_start_matches('/')
-        )
-    }
+/// Safely join a base URL with a path, handling slashes properly
+///
+/// # Examples
+/// ```
+/// use example_api::utils::url::join_url;
+///
+/// assert_eq!(join_url("https://api.example.com", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com", "/users"), "https://api.example.com/users");
+/// assert_eq!(join_url("https://api.example.com/", "/users"), "https://api.example.com/users");
+/// ```
+pub fn join_url(base_url: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
 }


### PR DESCRIPTION
## Description

This PR add a Rust code generator with `documentation support` and improves overall code generation quality by fixing imports, `warnings`, and adding proper description handling.

Linear ticket: 
- https://linear.app/buildwithfern/issue/FER-6669/rust-sdk-eliminate-warning-from-the-sdk
- https://linear.app/buildwithfern/issue/FER-6671/rust-sdk-add-description-before-the-the-method-function-if-available

## Changes Made

- Added support for generating Rust documentation comments (`DocComment` AST node) with summaries, descriptions, parameters, and examples
- Implemented description support for `structs`, `enums`, `enum variants`, `fields`, and `client sub-modules`
- Fixed Rust codegen imports to reduce unnecessary dependencies and warnings
- Improved `chrono` type handling to only import `date/datetime` types when actually used
- Removed redundant imports (`serde_json::Value`, unused `QueryBuilder` imports)
- Enhanced `Default` derive logic for request bodies and improved module import patterns

## Extra's

- Updated utility functions and HTTP client implementations for better code quality
- Cleaned up request options and fixed module re-export patterns

## Testing
 
- [x] Units test added/updated 
- [x] Updated Rust seed test snapshots to validate new documentation generation
- [x] Verified improved import handling reduces compilation warnings