### PR TITLE
fix(java): use configured ObjectMapper in wire tests to support Optional<T> serialization

### DIFF
--- a/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestClassBuilder.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/builders/TestClassBuilder.ts
@@ -31,6 +31,7 @@ export class TestClassBuilder {
             writer.addImport("org.junit.jupiter.api.AfterEach");
             writer.addImport("org.junit.jupiter.api.BeforeEach");
             writer.addImport("org.junit.jupiter.api.Test");
+            writer.addImport(`${this.context.getRootPackageName()}.core.ObjectMappers`);
 
             // Add any additional imports collected from snippets and type resolution
             if (additionalImports) {
@@ -44,7 +45,7 @@ export class TestClassBuilder {
 
             writer.writeLine("private MockWebServer server;");
             writer.writeLine(`private ${clientClassName} client;`);
-            writer.writeLine("private ObjectMapper objectMapper = new ObjectMapper();");
+            writer.writeLine("private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;");
 
             writer.writeLine("@BeforeEach");
             writer.writeLine("public void setup() throws Exception {");

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,12 @@
+- version: 3.6.1
+  changelogEntry:
+    - summary: |
+        Fixed wire tests failing with InvalidDefinitionException for Optional<T> serialization by using
+        the configured ObjectMappers.JSON_MAPPER instead of plain ObjectMapper.
+      type: fix
+  createdAt: "2025-09-25"
+  irVersion: 60
+
 - version: 3.6.0
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/examples/default/src/test/java/com/seed/examples/FileNotificationServiceWireTest.java
+++ b/seed/java-sdk/examples/default/src/test/java/com/seed/examples/FileNotificationServiceWireTest.java
@@ -3,6 +3,7 @@ package com.seed.examples;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.examples.SeedExamplesClient;
+import com.seed.examples.core.ObjectMappers;
 import com.seed.examples.resources.types.types.Exception;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class FileNotificationServiceWireTest {
     private MockWebServer server;
     private SeedExamplesClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/examples/default/src/test/java/com/seed/examples/FileServiceWireTest.java
+++ b/seed/java-sdk/examples/default/src/test/java/com/seed/examples/FileServiceWireTest.java
@@ -3,6 +3,7 @@ package com.seed.examples;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.examples.SeedExamplesClient;
+import com.seed.examples.core.ObjectMappers;
 import com.seed.examples.resources.file.service.requests.GetFileRequest;
 import com.seed.examples.resources.types.types.File;
 import okhttp3.mockwebserver.MockResponse;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class FileServiceWireTest {
     private MockWebServer server;
     private SeedExamplesClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/examples/default/src/test/java/com/seed/examples/HealthServiceWireTest.java
+++ b/seed/java-sdk/examples/default/src/test/java/com/seed/examples/HealthServiceWireTest.java
@@ -3,6 +3,7 @@ package com.seed.examples;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.examples.SeedExamplesClient;
+import com.seed.examples.core.ObjectMappers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Test;
 public class HealthServiceWireTest {
     private MockWebServer server;
     private SeedExamplesClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/examples/default/src/test/java/com/seed/examples/ServiceWireTest.java
+++ b/seed/java-sdk/examples/default/src/test/java/com/seed/examples/ServiceWireTest.java
@@ -3,6 +3,7 @@ package com.seed.examples;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.examples.SeedExamplesClient;
+import com.seed.examples.core.ObjectMappers;
 import com.seed.examples.resources.commons.types.types.Data;
 import com.seed.examples.resources.commons.types.types.EventInfo;
 import com.seed.examples.resources.commons.types.types.Metadata;
@@ -44,7 +45,7 @@ import org.junit.jupiter.api.Test;
 public class ServiceWireTest {
     private MockWebServer server;
     private SeedExamplesClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContainerWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContainerWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.types.object.types.ObjectWithRequiredField;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsContainerWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContentTypeWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsContentTypeWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.types.object.types.ObjectWithOptionalField;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsContentTypeWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsEnumWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsEnumWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.types.enum_.types.WeatherReport;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsEnumWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsHttpMethodsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsHttpMethodsWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.types.object.types.ObjectWithOptionalField;
 import com.seed.exhaustive.resources.types.object.types.ObjectWithRequiredField;
 import java.math.BigInteger;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsHttpMethodsWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsObjectWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsObjectWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.types.object.types.NestedObjectWithOptionalField;
 import com.seed.exhaustive.resources.types.object.types.NestedObjectWithRequiredField;
 import com.seed.exhaustive.resources.types.object.types.ObjectWithMapOfMap;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsObjectWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsParamsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsParamsWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.endpoints.params.requests.GetWithPathAndQuery;
 import com.seed.exhaustive.resources.endpoints.params.requests.GetWithQuery;
 import okhttp3.mockwebserver.MockResponse;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsParamsWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPrimitiveWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPrimitiveWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import okhttp3.mockwebserver.MockResponse;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsPrimitiveWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPutWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsPutWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.endpoints.put.requests.PutRequest;
 import com.seed.exhaustive.resources.endpoints.put.types.PutResponse;
 import okhttp3.mockwebserver.MockResponse;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsPutWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUnionWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUnionWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.types.union.types.Animal;
 import com.seed.exhaustive.resources.types.union.types.Dog;
 import okhttp3.mockwebserver.MockResponse;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsUnionWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUrlsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/EndpointsUrlsWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Test;
 public class EndpointsUrlsWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/InlinedRequestsWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/InlinedRequestsWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.inlinedrequests.requests.PostWithObjectBody;
 import com.seed.exhaustive.resources.types.object.types.ObjectWithOptionalField;
 import java.math.BigInteger;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class InlinedRequestsWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoAuthWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoAuthWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import java.util.HashMap;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class NoAuthWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoReqBodyWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/NoReqBodyWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.types.object.types.ObjectWithOptionalField;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class NoReqBodyWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/test/java/com/seed/exhaustive/ReqWithHeadersWireTest.java
@@ -3,6 +3,7 @@ package com.seed.exhaustive;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.exhaustive.SeedExhaustiveClient;
+import com.seed.exhaustive.core.ObjectMappers;
 import com.seed.exhaustive.resources.reqwithheaders.requests.ReqWithHeaders;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class ReqWithHeadersWireTest {
     private MockWebServer server;
     private SeedExhaustiveClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/unions/default/src/test/java/com/seed/unions/BigunionWireTest.java
+++ b/seed/java-sdk/unions/default/src/test/java/com/seed/unions/BigunionWireTest.java
@@ -3,6 +3,7 @@ package com.seed.unions;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.unions.SeedUnionsClient;
+import com.seed.unions.core.ObjectMappers;
 import com.seed.unions.resources.bigunion.types.BigUnion;
 import com.seed.unions.resources.bigunion.types.NormalSweet;
 import java.util.Arrays;
@@ -18,7 +19,7 @@ import org.junit.jupiter.api.Test;
 public class BigunionWireTest {
     private MockWebServer server;
     private SeedUnionsClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();

--- a/seed/java-sdk/unions/default/src/test/java/com/seed/unions/UnionWireTest.java
+++ b/seed/java-sdk/unions/default/src/test/java/com/seed/unions/UnionWireTest.java
@@ -3,6 +3,7 @@ package com.seed.unions;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seed.unions.SeedUnionsClient;
+import com.seed.unions.core.ObjectMappers;
 import com.seed.unions.resources.union.types.Circle;
 import com.seed.unions.resources.union.types.Shape;
 import okhttp3.mockwebserver.MockResponse;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class UnionWireTest {
     private MockWebServer server;
     private SeedUnionsClient client;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = ObjectMappers.JSON_MAPPER;
     @BeforeEach
     public void setup() throws Exception {
         server = new MockWebServer();


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-6786: \[Java\] Wire testing dependecy issue for Optionals](https://linear.app/buildwithfern/issue/FER-6786/java-wire-testing-dependecy-issue-for-optionals) 

Previously, wire tests used a plain ObjectMapper that lacked the `jackson-datatype-jdk8 module`, causing  InvalidDefinitionException 

This fix changes TestClassBuilder to use the generated `ObjectMappers.JSON_MAPPER` which includes `Jdk8Module`, `JavaTimeModule`, and other necessary Jackson configurations. 

## Changes Made
- See file 

## Testing
<!-- Describe how you tested these changes -->
- [X] Unit tests added/updated
- [X] Manual testing completed
