### PR TITLE
fix(internal): path parameters respect URL order

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -71,8 +71,11 @@ export function convertHttpOperation({
 
         // If there's a path parameter listed only in the URL, add it to the list
         const reorderedPathParameters: PathParameterWithExample[] = [];
+        const usedParams = new Set<string>();
+
         for (const paramName of paramNamesInUrlOrder) {
             const urlParam = urlParams.get(paramName);
+            usedParams.add(paramName);
 
             if (urlParam) {
                 reorderedPathParameters.push(urlParam);
@@ -102,6 +105,13 @@ export function convertHttpOperation({
                     }),
                     description: undefined
                 });
+            }
+        }
+
+        // Add any remaining path parameters that don't appear in the URL at the end
+        for (const param of convertedParameters.pathParameters) {
+            if (!usedParams.has(param.name)) {
+                reorderedPathParameters.push(param);
             }
         }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -61,13 +61,11 @@ export function convertHttpOperation({
     const PATH_PARAM_REGEX = /{([^}]+)}/g;
     const paramNamesInUrlOrder = [...path.matchAll(PATH_PARAM_REGEX)]
         .map((match) => match[1])
-    	.filter((paramName): paramName is string => paramName !== undefined)
+        .filter((paramName): paramName is string => paramName !== undefined);
 
     // Reorder path parameters to match URL order
     if (paramNamesInUrlOrder.length > 0) {
-        const urlParams = new Map(
-            convertedParameters.pathParameters.map((param) => [param.name, param])
-        );
+        const urlParams = new Map(convertedParameters.pathParameters.map((param) => [param.name, param]));
 
         // If there's a path parameter listed only in the URL, add it to the list
         const reorderedPathParameters: PathParameterWithExample[] = [];

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/inline-path-parameters.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/inline-path-parameters.json
@@ -261,8 +261,8 @@ service:
       request:
         name: SearchRequest
         path-parameters:
-          id: string
           organization_id: string
+          id: string
         body:
           properties:
             access:
@@ -275,8 +275,8 @@ service:
         status-code: 200
       examples:
         - path-parameters:
-            id: id
             organization_id: organization_id
+            id: id
           request: {}
           response:
             body:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/permit.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-docs/permit.json
@@ -12388,16 +12388,6 @@ service:
       source:
         openapi: ../openapi.json
       path-parameters:
-        resource_id:
-          type: string
-          docs: >-
-            Either the unique id of the resource, or the URL-friendly key of the
-            resource (i.e: the "slug").
-        action_group_id:
-          type: string
-          docs: >-
-            Either the unique id of the action group, or the URL-friendly key of
-            the action group (i.e: the "slug").
         proj_id:
           type: string
           docs: >-
@@ -12408,6 +12398,16 @@ service:
           docs: >-
             Either the unique id of the environment, or the URL-friendly key of
             the environment (i.e: the "slug").
+        resource_id:
+          type: string
+          docs: >-
+            Either the unique id of the resource, or the URL-friendly key of the
+            resource (i.e: the "slug").
+        action_group_id:
+          type: string
+          docs: >-
+            Either the unique id of the action group, or the URL-friendly key of
+            the action group (i.e: the "slug").
       display-name: Update Resource Action Group
       request:
         name: ResourceActionGroupUpdate
@@ -12439,10 +12439,10 @@ service:
         - root.UpdateResourceActionGroupRequestUnprocessableEntityError
       examples:
         - path-parameters:
-            resource_id: resource_id
-            action_group_id: action_group_id
             proj_id: proj_id
             env_id: env_id
+            resource_id: resource_id
+            action_group_id: action_group_id
           request: {}
           response:
             body:
@@ -20384,16 +20384,16 @@ service:
           docs: >-
             Either the unique id of the project, or the URL-friendly key of the
             project (i.e: the "slug").
-        tenant_id:
-          type: string
-          docs: >-
-            Either the unique id of the tenant, or the URL-friendly key of the
-            tenant (i.e: the "slug").
         env_id:
           type: string
           docs: >-
             Either the unique id of the environment, or the URL-friendly key of
             the environment (i.e: the "slug").
+        tenant_id:
+          type: string
+          docs: >-
+            Either the unique id of the tenant, or the URL-friendly key of the
+            tenant (i.e: the "slug").
       display-name: List Tenant Users
       request:
         name: ListTenantUsersRequest
@@ -20426,8 +20426,8 @@ service:
       examples:
         - path-parameters:
             proj_id: proj_id
-            tenant_id: tenant_id
             env_id: env_id
+            tenant_id: tenant_id
           query-parameters:
             search: search
             role: role

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/deepgram.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/deepgram.json
@@ -4460,23 +4460,6 @@
             "file": "../openapi.yml",
             "type": "openapi"
           }
-        },
-        {
-          "description": "The unique identifier of the project",
-          "name": "project_id",
-          "schema": {
-            "schema": {
-              "example": "123456-7890-1234-5678-901234",
-              "type": "string"
-            },
-            "generatedName": "DeleteProjectRequestProjectId",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.yml",
-            "type": "openapi"
-          }
         }
       ],
       "queryParameters": [],
@@ -5015,16 +4998,6 @@
                 },
                 "type": "primitive"
               }
-            },
-            {
-              "name": "project_id",
-              "value": {
-                "value": {
-                  "value": "123456-7890-1234-5678-901234",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
             }
           ],
           "queryParameters": [],
@@ -5061,23 +5034,6 @@
         "Management API"
       ],
       "pathParameters": [
-        {
-          "description": "The unique identifier of the project",
-          "name": "project_id",
-          "schema": {
-            "schema": {
-              "example": "123456-7890-1234-5678-901234",
-              "type": "string"
-            },
-            "generatedName": "UpdateProjectRequestProjectId",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.yml",
-            "type": "openapi"
-          }
-        },
         {
           "description": "The unique identifier of the project",
           "name": "project_id",
@@ -5642,16 +5598,6 @@
       "examples": [
         {
           "pathParameters": [
-            {
-              "name": "project_id",
-              "value": {
-                "value": {
-                  "value": "123456-7890-1234-5678-901234",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            },
             {
               "name": "project_id",
               "value": {
@@ -7956,23 +7902,6 @@
             "file": "../openapi.yml",
             "type": "openapi"
           }
-        },
-        {
-          "description": "The unique identifier of the project",
-          "name": "project_id",
-          "schema": {
-            "schema": {
-              "example": "123456-7890-1234-5678-901234",
-              "type": "string"
-            },
-            "generatedName": "ListProjectKeysRequestProjectId",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.yml",
-            "type": "openapi"
-          }
         }
       ],
       "queryParameters": [],
@@ -8377,16 +8306,6 @@
                 },
                 "type": "primitive"
               }
-            },
-            {
-              "name": "project_id",
-              "value": {
-                "value": {
-                  "value": "123456-7890-1234-5678-901234",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
             }
           ],
           "queryParameters": [],
@@ -8430,23 +8349,6 @@
         "Management API"
       ],
       "pathParameters": [
-        {
-          "description": "The unique identifier of the project",
-          "name": "project_id",
-          "schema": {
-            "schema": {
-              "example": "123456-7890-1234-5678-901234",
-              "type": "string"
-            },
-            "generatedName": "CreateProjectKeyRequestProjectId",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.yml",
-            "type": "openapi"
-          }
-        },
         {
           "description": "The unique identifier of the project",
           "name": "project_id",
@@ -8847,16 +8749,6 @@
       "examples": [
         {
           "pathParameters": [
-            {
-              "name": "project_id",
-              "value": {
-                "value": {
-                  "value": "123456-7890-1234-5678-901234",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            },
             {
               "name": "project_id",
               "value": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/inline-path-parameters.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/inline-path-parameters.json
@@ -248,14 +248,12 @@
       ],
       "pathParameters": [
         {
-          "name": "id",
+          "name": "organization_id",
           "schema": {
-            "description": "Bookmark ID",
             "schema": {
               "type": "string"
             },
-            "generatedName": "SearchRequestId",
-            "groupName": [],
+            "generatedName": "",
             "type": "primitive"
           },
           "source": {
@@ -264,12 +262,14 @@
           }
         },
         {
-          "name": "organization_id",
+          "name": "id",
           "schema": {
+            "description": "Bookmark ID",
             "schema": {
               "type": "string"
             },
-            "generatedName": "",
+            "generatedName": "SearchRequestId",
+            "groupName": [],
             "type": "primitive"
           },
           "source": {
@@ -397,20 +397,20 @@
         {
           "pathParameters": [
             {
-              "name": "id",
+              "name": "organization_id",
               "value": {
                 "value": {
-                  "value": "id",
+                  "value": "organization_id",
                   "type": "string"
                 },
                 "type": "primitive"
               }
             },
             {
-              "name": "organization_id",
+              "name": "id",
               "value": {
                 "value": {
-                  "value": "organization_id",
+                  "value": "id",
                   "type": "string"
                 },
                 "type": "primitive"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/permit.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/permit.json
@@ -10124,42 +10124,6 @@
       ],
       "pathParameters": [
         {
-          "description": "Either the unique id of the resource, or the URL-friendly key of the resource (i.e: the \"slug\").",
-          "name": "resource_id",
-          "schema": {
-            "description": "Either the unique id of the resource, or the URL-friendly key of the resource (i.e: the \"slug\").",
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "UpdateResourceActionGroupRequestResourceId",
-            "title": "Resource Id",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        },
-        {
-          "description": "Either the unique id of the action group, or the URL-friendly key of the action group (i.e: the \"slug\").",
-          "name": "action_group_id",
-          "schema": {
-            "description": "Either the unique id of the action group, or the URL-friendly key of the action group (i.e: the \"slug\").",
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "UpdateResourceActionGroupRequestActionGroupId",
-            "title": "Action Group Id",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        },
-        {
           "description": "Either the unique id of the project, or the URL-friendly key of the project (i.e: the \"slug\").",
           "name": "proj_id",
           "schema": {
@@ -10187,6 +10151,42 @@
             },
             "generatedName": "UpdateResourceActionGroupRequestEnvId",
             "title": "Env Id",
+            "groupName": [],
+            "type": "primitive"
+          },
+          "source": {
+            "file": "../openapi.json",
+            "type": "openapi"
+          }
+        },
+        {
+          "description": "Either the unique id of the resource, or the URL-friendly key of the resource (i.e: the \"slug\").",
+          "name": "resource_id",
+          "schema": {
+            "description": "Either the unique id of the resource, or the URL-friendly key of the resource (i.e: the \"slug\").",
+            "schema": {
+              "type": "string"
+            },
+            "generatedName": "UpdateResourceActionGroupRequestResourceId",
+            "title": "Resource Id",
+            "groupName": [],
+            "type": "primitive"
+          },
+          "source": {
+            "file": "../openapi.json",
+            "type": "openapi"
+          }
+        },
+        {
+          "description": "Either the unique id of the action group, or the URL-friendly key of the action group (i.e: the \"slug\").",
+          "name": "action_group_id",
+          "schema": {
+            "description": "Either the unique id of the action group, or the URL-friendly key of the action group (i.e: the \"slug\").",
+            "schema": {
+              "type": "string"
+            },
+            "generatedName": "UpdateResourceActionGroupRequestActionGroupId",
+            "title": "Action Group Id",
             "groupName": [],
             "type": "primitive"
           },
@@ -10278,26 +10278,6 @@
         {
           "pathParameters": [
             {
-              "name": "resource_id",
-              "value": {
-                "value": {
-                  "value": "resource_id",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            },
-            {
-              "name": "action_group_id",
-              "value": {
-                "value": {
-                  "value": "action_group_id",
-                  "type": "string"
-                },
-                "type": "primitive"
-              }
-            },
-            {
               "name": "proj_id",
               "value": {
                 "value": {
@@ -10312,6 +10292,26 @@
               "value": {
                 "value": {
                   "value": "env_id",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            {
+              "name": "resource_id",
+              "value": {
+                "value": {
+                  "value": "resource_id",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            {
+              "name": "action_group_id",
+              "value": {
+                "value": {
+                  "value": "action_group_id",
                   "type": "string"
                 },
                 "type": "primitive"
@@ -26254,24 +26254,6 @@
           }
         },
         {
-          "description": "Either the unique id of the tenant, or the URL-friendly key of the tenant (i.e: the \"slug\").",
-          "name": "tenant_id",
-          "schema": {
-            "description": "Either the unique id of the tenant, or the URL-friendly key of the tenant (i.e: the \"slug\").",
-            "schema": {
-              "type": "string"
-            },
-            "generatedName": "ListTenantUsersRequestTenantId",
-            "title": "Tenant Id",
-            "groupName": [],
-            "type": "primitive"
-          },
-          "source": {
-            "file": "../openapi.json",
-            "type": "openapi"
-          }
-        },
-        {
           "description": "Either the unique id of the environment, or the URL-friendly key of the environment (i.e: the \"slug\").",
           "name": "env_id",
           "schema": {
@@ -26281,6 +26263,24 @@
             },
             "generatedName": "ListTenantUsersRequestEnvId",
             "title": "Env Id",
+            "groupName": [],
+            "type": "primitive"
+          },
+          "source": {
+            "file": "../openapi.json",
+            "type": "openapi"
+          }
+        },
+        {
+          "description": "Either the unique id of the tenant, or the URL-friendly key of the tenant (i.e: the \"slug\").",
+          "name": "tenant_id",
+          "schema": {
+            "description": "Either the unique id of the tenant, or the URL-friendly key of the tenant (i.e: the \"slug\").",
+            "schema": {
+              "type": "string"
+            },
+            "generatedName": "ListTenantUsersRequestTenantId",
+            "title": "Tenant Id",
             "groupName": [],
             "type": "primitive"
           },
@@ -26474,20 +26474,20 @@
               }
             },
             {
-              "name": "tenant_id",
+              "name": "env_id",
               "value": {
                 "value": {
-                  "value": "tenant_id",
+                  "value": "env_id",
                   "type": "string"
                 },
                 "type": "primitive"
               }
             },
             {
-              "name": "env_id",
+              "name": "tenant_id",
               "value": {
                 "value": {
-                  "value": "env_id",
+                  "value": "tenant_id",
                   "type": "string"
                 },
                 "type": "primitive"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/inline-path-parameters.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/inline-path-parameters.json
@@ -261,8 +261,8 @@ service:
       request:
         name: SearchRequest
         path-parameters:
-          id: string
           organization_id: string
+          id: string
         body:
           properties:
             access:
@@ -275,8 +275,8 @@ service:
         status-code: 200
       examples:
         - path-parameters:
-            id: id
             organization_id: organization_id
+            id: id
           request: {}
           response:
             body:

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/permit.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/permit.json
@@ -10570,16 +10570,6 @@ service:
       source:
         openapi: ../openapi.json
       path-parameters:
-        resource_id:
-          type: string
-          docs: >-
-            Either the unique id of the resource, or the URL-friendly key of the
-            resource (i.e: the "slug").
-        action_group_id:
-          type: string
-          docs: >-
-            Either the unique id of the action group, or the URL-friendly key of
-            the action group (i.e: the "slug").
         proj_id:
           type: string
           docs: >-
@@ -10590,6 +10580,16 @@ service:
           docs: >-
             Either the unique id of the environment, or the URL-friendly key of
             the environment (i.e: the "slug").
+        resource_id:
+          type: string
+          docs: >-
+            Either the unique id of the resource, or the URL-friendly key of the
+            resource (i.e: the "slug").
+        action_group_id:
+          type: string
+          docs: >-
+            Either the unique id of the action group, or the URL-friendly key of
+            the action group (i.e: the "slug").
       display-name: Update Resource Action Group
       request:
         name: ResourceActionGroupUpdate
@@ -10621,10 +10621,10 @@ service:
         - root.UnprocessableEntityError
       examples:
         - path-parameters:
-            resource_id: resource_id
-            action_group_id: action_group_id
             proj_id: proj_id
             env_id: env_id
+            resource_id: resource_id
+            action_group_id: action_group_id
           request: {}
           response:
             body:
@@ -18566,16 +18566,16 @@ service:
           docs: >-
             Either the unique id of the project, or the URL-friendly key of the
             project (i.e: the "slug").
-        tenant_id:
-          type: string
-          docs: >-
-            Either the unique id of the tenant, or the URL-friendly key of the
-            tenant (i.e: the "slug").
         env_id:
           type: string
           docs: >-
             Either the unique id of the environment, or the URL-friendly key of
             the environment (i.e: the "slug").
+        tenant_id:
+          type: string
+          docs: >-
+            Either the unique id of the tenant, or the URL-friendly key of the
+            tenant (i.e: the "slug").
       display-name: List Tenant Users
       request:
         name: ListTenantUsersRequest
@@ -18608,8 +18608,8 @@ service:
       examples:
         - path-parameters:
             proj_id: proj_id
-            tenant_id: tenant_id
             env_id: env_id
+            tenant_id: tenant_id
           query-parameters:
             search: search
             role: role

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Ensure path parameters are parsed in the same order as they appear in the endpoint's URL.
+      type: fix
+  irVersion: 60
+  createdAt: "2025-09-25"
+  version: 0.82.1
+
+- changelogEntry:
+    - summary: |
         Update migration versions for ir-v60 for python and java generators
       type: feat
   irVersion: 60
@@ -21,7 +29,7 @@
         The default is `true`.
       type: feat
     - summary: |
-        Add type for nullable schema examples. 
+        Add type for nullable schema examples.
         If a schema is nullable, examples for its inner type will be parsed or generated, or `null` will be used as an example if no inner examples are available.
       type: feat
   irVersion: 60


### PR DESCRIPTION
## Description
Linear ticket: Fixes FER-6801
If a user specifies path parameters in a different order than they appear in the URL, as in:
```json
"here/{param1}/there/{param2}":
  "parameters": [
    {
      "name": "param2",
      "in": "path"
    },
    {
      "name": "param1",
      "in": "path"
    }
  ],
```
we now adhere to the URL order (param1, then param2) instead of the listed `parameters` order in all cases.

## Changes Made
Changes to the `openapi-ir-parser`.

## Testing
Tested against `openapi-ir-to-fern-tests` and Auth0.
- [X] Unit tests added/updated
- [X] Manual testing completed
