### PR TITLE
fix(ci): Python seeds target higher version

### DIFF
--- a/seed/fastapi/seed.yml
+++ b/seed/fastapi/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v58
+irVersion: v60
 displayName: FastAPI
 image: fernapi/fern-fastapi-server
 changelogLocation: ../../generators/python/fastapi/versions.yml

--- a/seed/pydantic-v2/seed.yml
+++ b/seed/pydantic-v2/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v57
+irVersion: v60
 displayName: Pydantic Model
 image: fernapi/fern-pydantic-model-v2
 changelogLocation: ../../generators/python/pydantic/versions.yml

--- a/seed/pydantic/seed.yml
+++ b/seed/pydantic/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v58
+irVersion: v60
 displayName: Pydantic Model
 image: fernapi/fern-pydantic-model
 changelogLocation: ../../generators/python/pydantic/versions.yml

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v59
+irVersion: v60
 displayName: Python SDK
 image: fernapi/fern-python-sdk
 changelogLocation: ../../generators/python/sdk/versions.yml


### PR DESCRIPTION
Was causing issues with python generator running on IR60 but being handed V59 or V58