### PR TITLE
feat(cli): Allow output folders per fixture when multiple are passed in to test

### DIFF
--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -140,14 +140,21 @@ function addTestCommand(cli: Argv) {
 
                 for (const fixture of argv.fixture) {
                     if (!availableFixtures.includes(fixture) && !availableFixturesWithOutputFolders.includes(fixture)) {
-                        throw new Error(`Fixture ${fixture} not found. Please make sure that it is a valid fixture for the generator ${generator.workspaceName}.`);
+                        throw new Error(
+                            `Fixture ${fixture} not found. Please make sure that it is a valid fixture for the generator ${generator.workspaceName}.`
+                        );
                     }
                 }
-                
+
                 // Verify if there are multiple fixtures passed in or a fixture has a colon separated output folder, that
                 // the flag for the output folder is not also used
-                if ((argv.fixture.length > 1 || argv.fixture.some((fixture) => fixture.includes(':'))) && argv.outputFolder != null) {
-                    throw new Error(`Output folder cannot be specified if multiple fixtures are passed in or if the fixture is passed in with colon separated output folders.`);
+                if (
+                    (argv.fixture.length > 1 || argv.fixture.some((fixture) => fixture.includes(":"))) &&
+                    argv.outputFolder != null
+                ) {
+                    throw new Error(
+                        `Output folder cannot be specified if multiple fixtures are passed in or if the fixture is passed in with colon separated output folders.`
+                    );
                 }
 
                 if (argv.local) {
@@ -336,7 +343,7 @@ function addGetAvailableFixturesCommand(cli: Argv) {
                 );
             }
 
-            const availableFixtures = await getAvailableFixtures(generator, argv["include-subfolders"])
+            const availableFixtures = await getAvailableFixtures(generator, argv["include-subfolders"]);
 
             // Note: HAVE to log the output for CI to pick it up
             console.log(JSON.stringify({ fixtures: availableFixtures }, null, 2));
@@ -347,9 +354,7 @@ function addGetAvailableFixturesCommand(cli: Argv) {
 async function getAvailableFixtures(generator: GeneratorWorkspace, withOutputFolders: boolean) {
     // Get all available fixtures
     const availableFixtures = FIXTURES.filter((fixture) => {
-        const matchingPrefix = LANGUAGE_SPECIFIC_FIXTURE_PREFIXES.filter((prefix) =>
-            fixture.startsWith(prefix)
-        )[0];
+        const matchingPrefix = LANGUAGE_SPECIFIC_FIXTURE_PREFIXES.filter((prefix) => fixture.startsWith(prefix))[0];
         return matchingPrefix == null || generator.workspaceName.startsWith(matchingPrefix);
     });
 
@@ -371,8 +376,8 @@ async function getAvailableFixtures(generator: GeneratorWorkspace, withOutputFol
         }
         // Return map with output folders
         return allOptions;
-    } 
-    
+    }
+
     // Don't include subfolders, return the original fixtures
     return availableFixtures;
 }

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -70,7 +70,7 @@ function addTestCommand(cli: Argv) {
                 .option("fixture", {
                     type: "array",
                     string: true,
-                    default: FIXTURES,
+                    // default: FIXTURES,
                     demandOption: false,
                     description: "Runs on all fixtures if not provided"
                 })
@@ -129,11 +129,15 @@ function addTestCommand(cli: Argv) {
                 let testRunner: TestRunner;
                 let scriptRunner: ScriptRunner;
 
+                // If no fixtures passed in, use all available fixtures (without output folders)
+                if (argv.fixture == null) {
+                    argv.fixture = await getAvailableFixtures(generator, false);
+                }
+
                 // Get both formats of fixtures and check if the fixtures passed in are of one of the two formats allowed
                 const availableFixtures = await getAvailableFixtures(generator, false);
                 const availableFixturesWithOutputFolders = await getAvailableFixtures(generator, true);
 
-                // Make sure all passed in fixtures are valid if multiple
                 for (const fixture of argv.fixture) {
                     if (!availableFixtures.includes(fixture) && !availableFixturesWithOutputFolders.includes(fixture)) {
                         throw new Error(`Fixture ${fixture} not found. Please make sure that it is a valid fixture for the generator ${generator.workspaceName}.`);

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -71,7 +71,6 @@ function addTestCommand(cli: Argv) {
                     type: "array",
                     string: true,
                     default: FIXTURES,
-                    choices: FIXTURES,
                     demandOption: false,
                     description: "Runs on all fixtures if not provided"
                 })
@@ -129,6 +128,23 @@ function addTestCommand(cli: Argv) {
                 }
                 let testRunner: TestRunner;
                 let scriptRunner: ScriptRunner;
+
+                // Get both formats of fixtures and check if the fixtures passed in are of one of the two formats allowed
+                const availableFixtures = await getAvailableFixtures(generator, false);
+                const availableFixturesWithOutputFolders = await getAvailableFixtures(generator, true);
+
+                // Make sure all passed in fixtures are valid if multiple
+                for (const fixture of argv.fixture) {
+                    if (!availableFixtures.includes(fixture) && !availableFixturesWithOutputFolders.includes(fixture)) {
+                        throw new Error(`Fixture ${fixture} not found. Please make sure that it is a valid fixture for the generator ${generator.workspaceName}.`);
+                    }
+                }
+                
+                // Verify if there are multiple fixtures passed in or a fixture has a colon separated output folder, that
+                // the flag for the output folder is not also used
+                if ((argv.fixture.length > 1 || argv.fixture.some((fixture) => fixture.includes(':'))) && argv.outputFolder != null) {
+                    throw new Error(`Output folder cannot be specified if multiple fixtures are passed in or if the fixture is passed in with colon separated output folders.`);
+                }
 
                 if (argv.local) {
                     if (generator.workspaceConfig.test.local == null) {
@@ -316,35 +332,45 @@ function addGetAvailableFixturesCommand(cli: Argv) {
                 );
             }
 
-            // Get all available fixtures
-            const availableFixtures = FIXTURES.filter((fixture) => {
-                const matchingPrefix = LANGUAGE_SPECIFIC_FIXTURE_PREFIXES.filter((prefix) =>
-                    fixture.startsWith(prefix)
-                )[0];
-                return matchingPrefix == null || generator.workspaceName.startsWith(matchingPrefix);
-            });
+            const availableFixtures = await getAvailableFixtures(generator, argv["include-subfolders"])
 
-            if (argv["include-subfolders"]) {
-                // Add fixtures that have subfolders with their subfolder'ed version
-                const allOptions: string[] = [];
-                for (const fixture of availableFixtures) {
-                    const config = generator.workspaceConfig.fixtures?.[fixture];
-                    if (config != null && config.length > 0) {
-                        // This fixture has subfolders, add to map as fixture:outputFolder
-                        for (const outputFolder of config.map((c) => c.outputFolder)) {
-                            allOptions.push(`${fixture}:${outputFolder}`);
-                        }
-                    } else {
-                        // This fixture has no subfolders, keep as is
-                        allOptions.push(fixture);
-                    }
-                }
-                console.log(JSON.stringify({ fixtures: allOptions }, null, 2));
-            } else {
-                console.log(JSON.stringify({ fixtures: availableFixtures }, null, 2));
-            }
+            // Note: HAVE to log the output for CI to pick it up
+            console.log(JSON.stringify({ fixtures: availableFixtures }, null, 2));
         }
     );
+}
+
+async function getAvailableFixtures(generator: GeneratorWorkspace, withOutputFolders: boolean) {
+    // Get all available fixtures
+    const availableFixtures = FIXTURES.filter((fixture) => {
+        const matchingPrefix = LANGUAGE_SPECIFIC_FIXTURE_PREFIXES.filter((prefix) =>
+            fixture.startsWith(prefix)
+        )[0];
+        return matchingPrefix == null || generator.workspaceName.startsWith(matchingPrefix);
+    });
+
+    // Optionally, include output folders in format fixture:outputFolder (note: this will replace the fixture name without the output folder)
+    if (withOutputFolders) {
+        // Add fixtures that have subfolders with their subfoldered version
+        const allOptions: string[] = [];
+        for (const fixture of availableFixtures) {
+            const config = generator.workspaceConfig.fixtures?.[fixture];
+            if (config != null && config.length > 0) {
+                // This fixture has subfolders, add to map as fixture:outputFolder
+                for (const outputFolder of config.map((c) => c.outputFolder)) {
+                    allOptions.push(`${fixture}:${outputFolder}`);
+                }
+            } else {
+                // This fixture has no subfolders, keep as is
+                allOptions.push(fixture);
+            }
+        }
+        // Return map with output folders
+        return allOptions;
+    } 
+    
+    // Don't include subfolders, return the original fixtures
+    return availableFixtures;
 }
 
 function addPublishCommands(cli: Argv) {

--- a/packages/seed/src/commands/test/testWorkspaceFixtures.ts
+++ b/packages/seed/src/commands/test/testWorkspaceFixtures.ts
@@ -29,21 +29,20 @@ export async function testGenerator({
 }): Promise<boolean> {
     const testCases: Promise<TestRunner.TestResult>[] = [];
     for (const fixture of fixtures) {
-        
         let fixtureName = fixture;
         let fixtureOutputFolder = outputFolder;
-        
+
         // Parse fixture name and outputFolder if format is "name:outputFolder"
         // Format name:outputFolder will override the passed in outputFolder
-        if (fixture.includes(':')) {
-            const [name, folder] = fixture.split(':', 2);
+        if (fixture.includes(":")) {
+            const [name, folder] = fixture.split(":", 2);
             fixtureName = name ?? fixture;
             fixtureOutputFolder = folder;
         }
 
         const config = generator.workspaceConfig.fixtures?.[fixtureName];
         const matchingPrefix = LANGUAGE_SPECIFIC_FIXTURE_PREFIXES.filter((prefix) => fixtureName.startsWith(prefix))[0];
-        
+
         if (matchingPrefix != null && !generator.workspaceName.startsWith(matchingPrefix)) {
             CONSOLE_LOGGER.debug(
                 `Skipping fixture ${fixtureName} for generator ${generator.workspaceName} because it was deemed specific to another language`

--- a/packages/seed/src/commands/test/testWorkspaceFixtures.ts
+++ b/packages/seed/src/commands/test/testWorkspaceFixtures.ts
@@ -29,22 +29,35 @@ export async function testGenerator({
 }): Promise<boolean> {
     const testCases: Promise<TestRunner.TestResult>[] = [];
     for (const fixture of fixtures) {
-        const config = generator.workspaceConfig.fixtures?.[fixture];
-        const matchingPrefix = LANGUAGE_SPECIFIC_FIXTURE_PREFIXES.filter((prefix) => fixture.startsWith(prefix))[0];
+        
+        let fixtureName = fixture;
+        let fixtureOutputFolder = outputFolder;
+        
+        // Parse fixture name and outputFolder if format is "name:outputFolder"
+        // Format name:outputFolder will override the passed in outputFolder
+        if (fixture.includes(':')) {
+            const [name, folder] = fixture.split(':', 2);
+            fixtureName = name ?? fixture;
+            fixtureOutputFolder = folder;
+        }
+
+        const config = generator.workspaceConfig.fixtures?.[fixtureName];
+        const matchingPrefix = LANGUAGE_SPECIFIC_FIXTURE_PREFIXES.filter((prefix) => fixtureName.startsWith(prefix))[0];
+        
         if (matchingPrefix != null && !generator.workspaceName.startsWith(matchingPrefix)) {
             CONSOLE_LOGGER.debug(
-                `Skipping fixture ${fixture} for generator ${generator.workspaceName} because it was deemed specific to another language`
+                `Skipping fixture ${fixtureName} for generator ${generator.workspaceName} because it was deemed specific to another language`
             );
             continue;
         }
         if (config != null) {
             for (const instance of config) {
-                if (outputFolder != null && instance.outputFolder !== outputFolder) {
+                if (fixtureOutputFolder != null && instance.outputFolder !== fixtureOutputFolder) {
                     continue;
                 }
                 testCases.push(
                     runner.run({
-                        fixture,
+                        fixture: fixtureName,
                         configuration: instance,
                         inspect
                     })
@@ -53,7 +66,7 @@ export async function testGenerator({
         } else {
             testCases.push(
                 runner.run({
-                    fixture,
+                    fixture: fixtureName,
                     configuration: undefined,
                     inspect
                 })


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6805/cli-allow-each-fixture-to-have-its-own-output-folder-for-seed-test
Closes FER-6805
Allow output folders per fixture when passing multiple fixtures in at once to seed test

## Changes Made
- Remove `choices` for input fixtures. Parsing happens manually a bit later now so we can extract all available fixtures with output folders
- Move code for `getAvailableFixtures` to reusable function so that `seed get-available-fixtures` and `seed test` can both use it
- Update `testWorkspaceFixtures.ts` to handle new parsing

## Testing
- Verified on command line that you cannot have --outputFolder flag and output folder with `:` simultaneously
- Verified on command line that you cannot pass invalid fixtures (test inclusive of output folders)
- Verified on command line that the `get-available-fixtures` command still works
