### PR TITLE
fix(cli): suppress stdout piping of entire generator-cli output

### DIFF
--- a/generators/base/src/GeneratorAgentClient.ts
+++ b/generators/base/src/GeneratorAgentClient.ts
@@ -55,7 +55,7 @@ export class GeneratorAgentClient {
             config: referenceConfig
         });
         const args = ["generate-reference", "--config", referenceConfigFilepath];
-        const cli = await this.getOrInstall();
+        const cli = await this.getOrInstall({ doNotPipeOutput: true });
         const content = await cli(args);
         return content.stdout;
     }
@@ -66,24 +66,26 @@ export class GeneratorAgentClient {
         return AbsoluteFilePath.of(file.path);
     }
 
-    private async getOrInstall(): Promise<LoggingExecutable> {
+    private async getOrInstall(options: createLoggingExecutable.Options = {}): Promise<LoggingExecutable> {
         if (this.cli) {
             return this.cli;
         }
         if (this.skipInstall) {
             this.cli = createLoggingExecutable("generator-cli", {
                 cwd: process.cwd(),
-                logger: this.logger
+                logger: this.logger,
+                ...options
             });
             return this.cli;
         }
-        return this.install();
+        return this.install(options);
     }
 
-    private async install(): Promise<LoggingExecutable> {
+    private async install(options: createLoggingExecutable.Options = {}): Promise<LoggingExecutable> {
         const npm = createLoggingExecutable("npm", {
             cwd: process.cwd(),
-            logger: this.logger
+            logger: this.logger,
+            ...options
         });
         this.logger.debug(`Installing ${GENERATOR_AGENT_NPM_PACKAGE} ...`);
         try {
@@ -97,7 +99,8 @@ export class GeneratorAgentClient {
 
         const cli = createLoggingExecutable("generator-cli", {
             cwd: process.cwd(),
-            logger: this.logger
+            logger: this.logger,
+            ...options
         });
         const version = await cli(["--version"]);
         this.logger.debug(`Successfully installed ${GENERATOR_AGENT_NPM_PACKAGE} version ${version.stdout}`);

--- a/generators/base/src/GeneratorAgentClient.ts
+++ b/generators/base/src/GeneratorAgentClient.ts
@@ -23,7 +23,7 @@ export class GeneratorAgentClient {
             config: readmeConfig
         });
         const args = ["generate", "readme", "--config", readmeConfigFilepath];
-        const cli = await this.getOrInstall();
+        const cli = await this.getOrInstall({ doNotPipeOutput: true });
         const content = await cli(args);
         return content.stdout;
     }
@@ -40,7 +40,7 @@ export class GeneratorAgentClient {
         });
         const cmd = withPullRequest ? "pr" : "push";
         const args = ["github", cmd, "--config", githubConfigFilepath];
-        const cli = await this.getOrInstall();
+        const cli = await this.getOrInstall({ doNotPipeOutput: true });
 
         const content = await cli(args);
         return content.stdout;


### PR DESCRIPTION
## Description
When generators fail they logging is polluted with the entire contents of the `readme.md` and `reference.md`. This behavior is a byproduct  of these files being created by the generator-cli being run as a subprocess with its stdout being piped to the parent process stdout (when all we really need to do is capture the stdout as a string) which bubbles up to the top-level generator during failure.

The simple solution is to pass `doNotPipeOutput: true` to all of the methods since the cli is memoized with the options of the first method invocation. **Could refactor it to not reuse the options if y'all think it matters**
