### PR TITLE
fix(ci): Fix the fixtures command in the all case

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -84,15 +84,15 @@ runs:
       env:
         FORCE_COLOR: "2"
       run: |
-        FORMATTED_FIXTURES=""
+        FORMATTED_FIXTURES_COMMAND=""
         if [[ "${{ inputs.fixtures-to-run }}" != "all" ]]; then
-          FORMATTED_FIXTURES="${{ inputs.fixtures-to-run }}"
+          FORMATTED_FIXTURES_COMMAND="--fixture ${{ inputs.fixtures-to-run }}"
         fi
 
         pnpm seed:local test \
           --generator ${{ inputs.generator-name }} \
           --parallel 16 \
-          --fixture ${FORMATTED_FIXTURES} \
+          ${FORMATTED_FIXTURES_COMMAND} \
           ${{ inputs.skip-scripts == 'true' && '--skip-scripts' || '' }} \
           ${{ inputs.allow-unexpected-failures == 'true' && '--allow-unexpected-failures' || '' }}
 


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6823/ci-fix-the-fixtures-all-case-for-seed-test-and-seed-update
Closes FER-6823
When trying to run all tests, the command in CI was running `--fixture` with no inputs. This was instead trying to run a fixture that didn't exist and calling everything a pass

## Changes Made
- Fix command for all case in seed test

## Testing
Verified in CI in the jobs here: https://github.com/fern-api/fern/actions/runs/18061648530
