### PR TITLE
chore(internal): add validation for unescaped angle brackets in versions.yml changelogs

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -16,7 +16,7 @@
 
 - changelogEntry:
     - summary: |
-        Update display names for undiscriminated unions without titles. 
+        Update display names for undiscriminated unions without titles.
 
         Now, if no title or description is provided, and one cannot be generated from the object properties, the display name will be undefined.
       type: fix
@@ -601,9 +601,9 @@
               request:
                 body:
                   properties:
-                    author: optional<string>
-                    tags: optional<list<string>>
-                    title: optional<string>
+                    author: `optional<string>`
+                    tags: `optional<list<string>>`
+                    title: `optional<string>`
                 content-type: application/json
                 name: UploadDocumentRequest
                 ...
@@ -3930,7 +3930,7 @@
         ```yml docs.yml
         navigation:
           - api: API Reference
-            openrpc: <path to openrpc file>
+            openrpc: `<path to openrpc file>`
         ```
       type: fix
   irVersion: 55
@@ -3993,7 +3993,7 @@
           User:
             properties:
               name: string
-              email: nullable<string>
+              email: `nullable<string>`
         ```
       type: feat
   irVersion: 55
@@ -5657,13 +5657,13 @@
 
         ```yml
         types:
-          GenericTest<T>:
+          `GenericTest<T>`:
             properties:
               value: T
               other-value: string
 
           GenericApplication:
-            type: GenericTest<string>
+            type: `GenericTest<string>`
         ```
 
         More information can be found here: https://buildwithfern.com/learn/api-definition/fern/types#generics.
@@ -9274,8 +9274,8 @@
 - changelogEntry:
     - summary: "## What's Changed\r\n* feature: allow specifying OpenAPI overrides in\
         \ generators.yml by @dsinghvi in https://github.com/fern-api/fern/pull/2613\r\
-        \n  ```yaml\r\n  # generators.yml \r\n  openapi: <path to openapi> \r\n  openapi-overrides:\
-        \ <path to openapi overrides> \r\n  ```\r\n\r\n\r\n**Full Changelog**: https://github.com/fern-api/fern/compare/0.16.29...0.16.30"
+        \n  ```yaml\r\n  # generators.yml \r\n  openapi: `<path to openapi>` \r\n  openapi-overrides:\
+        \ `<path to openapi overrides>` \r\n  ```\r\n\r\n\r\n**Full Changelog**: https://github.com/fern-api/fern/compare/0.16.29...0.16.30"
       type: chore
   createdAt: "2024-01-12"
   irVersion: 32
@@ -10228,7 +10228,7 @@
   version: 0.15.0-rc15
 - changelogEntry:
     - summary: "- Support specifying instance when running docs generation `fern generate
-        --docs --instance <url>`"
+        --docs --instance` `<url>`"
       type: chore
   createdAt: "2023-09-06"
   irVersion: 25
@@ -10419,9 +10419,9 @@
         \ what types are referenced from exactly one service (@amckinney).\r\n```yaml\r\
         \n  ServiceTypeReferenceInfo:\r\n    properties:\r\n      typesReferencedOnlyByService:\r\
         \n        docs: \"Types referenced by exactly one service.\"\r\n        type:\
-        \ map<commons.ServiceId, list<commons.TypeId>>\r\n      sharedTypes:\r\n   \
+        \ `map<commons.ServiceId, list<commons.TypeId>>`\r\n      sharedTypes:\r\n   \
         \     docs: \"Types referenced by either zero or multiple services.\"\r\n  \
-        \      type: list<commons.TypeId>\r\n```"
+        \      type: `list<commons.TypeId>`\r\n```"
       type: chore
   createdAt: "2023-08-01"
   irVersion: 22

--- a/packages/seed/src/commands/validate/angleBracketValidator.ts
+++ b/packages/seed/src/commands/validate/angleBracketValidator.ts
@@ -1,0 +1,57 @@
+export interface ChangelogEntry {
+    version?: string;
+    changelogEntry?: Array<{
+        summary?: string;
+        type?: string;
+    }>;
+    [key: string]: unknown;
+}
+
+/**
+ * Validates that angle brackets in changelog entries are properly escaped with backticks.
+ * This prevents breaking the docs publishing workflow.
+ *
+ * Returns an array of error messages for any violations found.
+ */
+export function validateAngleBracketEscaping(entry: ChangelogEntry): string[] {
+    const errors: string[] = [];
+
+    if (entry.changelogEntry && Array.isArray(entry.changelogEntry)) {
+        for (const changelogItem of entry.changelogEntry) {
+            if (changelogItem.summary && typeof changelogItem.summary === "string") {
+                const unescapedBrackets = findUnescapedAngleBrackets(changelogItem.summary);
+
+                if (unescapedBrackets.length > 0) {
+                    const version = entry.version || "unknown";
+                    errors.push(
+                        `Version ${version}: Found unescaped angle brackets in changelog summary. ` +
+                            `Patterns like ${unescapedBrackets.map((p) => `"${p}"`).join(", ")} should be wrapped in backticks. ` +
+                            `Example: \`${unescapedBrackets[0]}\``
+                    );
+                }
+            }
+        }
+    }
+
+    return errors;
+}
+
+export function findUnescapedAngleBrackets(text: string): string[] {
+    const patterns: string[] = [];
+
+    let textWithoutCodeBlocks = text.replace(/```[\s\S]*?```/g, "");
+
+    const textWithoutBackticks = textWithoutCodeBlocks.replace(/`[^`]*`/g, "");
+
+    // Find angle bracket patterns like <T>, <User>, <string, object>, <br>, etc.
+    const anglePattern = /<[^>]+>/g;
+    const matches = textWithoutBackticks.match(anglePattern);
+
+    if (matches) {
+        // Deduplicate patterns while preserving order
+        const uniquePatterns = [...new Set(matches)];
+        patterns.push(...uniquePatterns);
+    }
+
+    return patterns;
+}

--- a/packages/seed/src/commands/validate/angleBracketValidator.ts
+++ b/packages/seed/src/commands/validate/angleBracketValidator.ts
@@ -43,12 +43,10 @@ export function findUnescapedAngleBrackets(text: string): string[] {
 
     const textWithoutBackticks = textWithoutCodeBlocks.replace(/`[^`]*`/g, "");
 
-    // Find angle bracket patterns like <T>, <User>, <string, object>, <br>, etc.
     const anglePattern = /<[^>]+>/g;
     const matches = textWithoutBackticks.match(anglePattern);
 
     if (matches) {
-        // Deduplicate patterns while preserving order
         const uniquePatterns = [...new Set(matches)];
         patterns.push(...uniquePatterns);
     }

--- a/packages/seed/src/commands/validate/validateCliChangelog.ts
+++ b/packages/seed/src/commands/validate/validateCliChangelog.ts
@@ -6,8 +6,8 @@ import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 
 import { loadCliWorkspace } from "../../loadGeneratorWorkspaces";
-import { assertValidSemVerChangeOrThrow, assertValidSemVerOrThrow } from "./semVerUtils";
 import { validateAngleBracketEscaping } from "./angleBracketValidator";
+import { assertValidSemVerChangeOrThrow, assertValidSemVerOrThrow } from "./semVerUtils";
 
 export async function validateCliRelease({ context }: { context: TaskContext }): Promise<void> {
     const cliWorkspace = await loadCliWorkspace();
@@ -46,7 +46,9 @@ async function validateCliChangelog({
     if (Array.isArray(changelogs)) {
         for (const entry of changelogs) {
             const angleBracketErrors = validateAngleBracketEscaping(entry);
-            context.logger.debug(`Checking version ${entry.version}: Found ${angleBracketErrors.length} angle bracket errors`);
+            context.logger.debug(
+                `Checking version ${entry.version}: Found ${angleBracketErrors.length} angle bracket errors`
+            );
             if (angleBracketErrors.length > 0) {
                 hasErrors = true;
                 for (const error of angleBracketErrors) {

--- a/packages/seed/src/commands/validate/validateGeneratorChangelog.ts
+++ b/packages/seed/src/commands/validate/validateGeneratorChangelog.ts
@@ -5,8 +5,8 @@ import chalk from "chalk";
 import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces";
-import { assertValidSemVerChangeOrThrow, assertValidSemVerOrThrow } from "./semVerUtils";
 import { validateAngleBracketEscaping } from "./angleBracketValidator";
+import { assertValidSemVerChangeOrThrow, assertValidSemVerOrThrow } from "./semVerUtils";
 
 const parseReleaseOrThrow = serializers.generators.GeneratorReleaseRequest.parseOrThrow;
 
@@ -52,7 +52,9 @@ async function validateGeneratorChangelog({
     if (Array.isArray(changelogs)) {
         for (const entry of changelogs) {
             const angleBracketErrors = validateAngleBracketEscaping(entry);
-            context.logger.debug(`Checking version ${entry.version}: Found ${angleBracketErrors.length} angle bracket errors`);
+            context.logger.debug(
+                `Checking version ${entry.version}: Found ${angleBracketErrors.length} angle bracket errors`
+            );
             if (angleBracketErrors.length > 0) {
                 hasErrors = true;
                 for (const error of angleBracketErrors) {


### PR DESCRIPTION
## Description
Linear ticket: Fixes [FER-6891: \[Chore\] Backticks breaking docs in changelogs](https://linear.app/buildwithfern/issue/FER-6891/chore-backticks-breaking-docs-in-changelogs)

Unescaped angle brackets in changelog entries (`<T>, Dictionary<string, object>,<br>`) break our docs publishing workflow. Added validation to detect and report unescaped angle brackets in all versions.yml files across the codebase.

## Changes Made
- See file changes 
- Fixed remaining unescaped angle bracket in CLI versions.yml (I'm guessing this hasn't been breaking in the CLI but just added there)
- CI Integration: Validation runs automatically via validate-changelog.yml workflow and blocks PR merging on failure


## Testing
  - Manual testing completed - all changelogs pass validation
  - CI script (validate-all-changelogs.sh) runs successfully
  - Tested with intentionally broken entries to confirm validation catches errors
  - Verified code blocks don't trigger false positives
