### PR TITLE
fix(java): pass variables to OAuth auth client for token endpoints

### DIFF
--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,11 @@
+- version: 3.6.3
+  changelogEntry:
+    - summary: |
+        Fixed OAuth auth clients not receiving variables needed for token endpoints with path parameters.
+      type: fix
+  createdAt: "2025-09-28"
+  irVersion: 60
+
 - version: 3.6.2
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/AsyncSeedOauthClientCredentialsWithVariablesClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/AsyncSeedOauthClientCredentialsWithVariablesClientBuilder.java
@@ -134,8 +134,12 @@ public class AsyncSeedOauthClientCredentialsWithVariablesClientBuilder {
      */
     protected void setAuthentication(ClientOptions.Builder builder) {
         if (this.clientId != null && this.clientSecret != null) {
-            AuthClient authClient = new AuthClient(
-                    ClientOptions.builder().environment(this.environment).build());
+            ClientOptions.Builder authClientOptionsBuilder =
+                    ClientOptions.builder().environment(this.environment);
+            if (this.rootVariable != null) {
+                authClientOptionsBuilder.rootVariable(this.rootVariable);
+            }
+            AuthClient authClient = new AuthClient(authClientOptionsBuilder.build());
             OAuthTokenSupplier oAuthTokenSupplier =
                     new OAuthTokenSupplier(this.clientId, this.clientSecret, authClient);
             builder.addHeader("Authorization", oAuthTokenSupplier);

--- a/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariablesClientBuilder.java
+++ b/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariablesClientBuilder.java
@@ -134,8 +134,12 @@ public class SeedOauthClientCredentialsWithVariablesClientBuilder {
      */
     protected void setAuthentication(ClientOptions.Builder builder) {
         if (this.clientId != null && this.clientSecret != null) {
-            AuthClient authClient = new AuthClient(
-                    ClientOptions.builder().environment(this.environment).build());
+            ClientOptions.Builder authClientOptionsBuilder =
+                    ClientOptions.builder().environment(this.environment);
+            if (this.rootVariable != null) {
+                authClientOptionsBuilder.rootVariable(this.rootVariable);
+            }
+            AuthClient authClient = new AuthClient(authClientOptionsBuilder.build());
             OAuthTokenSupplier oAuthTokenSupplier =
                     new OAuthTokenSupplier(this.clientId, this.clientSecret, authClient);
             builder.addHeader("Authorization", oAuthTokenSupplier);


### PR DESCRIPTION
## Description
Linear ticket: Resolves [FER-6706: When using `oauth` we don't set variables when instantiating the client for the Oauth token provider.](https://linear.app/buildwithfern/issue/FER-6706/when-using-oauth-we-dont-set-variables-when-instantiating-the-client)

Java SDK was not passing API variables to the OAuth auth client, causing `NullPointerException` when OAuth token endpoints required path variables. This affected customers like PhaseTwo whose OAuth endpoint is `/realms/{realm}/protocol/openid-connect/token`

## Changes Made
- Modified AbstractRootClientGenerator.java to dynamically pass all configured variables to the OAuth auth client during instantiation, not just the environment.

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed - verified I saw changes with manually testing against PhaseTwo config
