### PR TITLE
fix(swift): disable global install during readme/reference gen

### DIFF
--- a/generators/base/src/AbstractGeneratorAgent.ts
+++ b/generators/base/src/AbstractGeneratorAgent.ts
@@ -43,17 +43,20 @@ export abstract class AbstractGeneratorAgent<GeneratorContext extends AbstractGe
     public constructor({
         logger,
         config,
-        selfHosted = false
+        selfHosted = false,
+        skipInstall = false
     }: {
         logger: Logger;
         config: FernGeneratorExec.GeneratorConfig;
         selfHosted?: boolean;
+        skipInstall?: boolean;
     }) {
         this.logger = logger;
         this.config = config;
         this.cli = new GeneratorAgentClient({
             logger,
-            selfHosted
+            selfHosted,
+            skipInstall
         });
     }
 

--- a/generators/swift/sdk/src/SdkGeneratorCli.ts
+++ b/generators/swift/sdk/src/SdkGeneratorCli.ts
@@ -90,9 +90,14 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
 
     private async generateReadme(context: SdkGeneratorContext): Promise<void> {
         try {
+            const endpointSnippets = this.generateSnippets(context);
+            if (endpointSnippets.length === 0) {
+                context.logger.debug("No snippets were produced; skipping README.md generation.");
+                return;
+            }
             const content = await context.generatorAgent.generateReadme({
                 context,
-                endpointSnippets: this.generateSnippets(context)
+                endpointSnippets
             });
             context.project.addRootFiles(new File("README.md", RelativeFilePath.of(""), content));
         } catch (e) {

--- a/generators/swift/sdk/src/SwiftGeneratorAgent.ts
+++ b/generators/swift/sdk/src/SwiftGeneratorAgent.ts
@@ -22,7 +22,7 @@ export class SwiftGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorCont
         readmeConfigBuilder: ReadmeConfigBuilder;
         ir: IntermediateRepresentation;
     }) {
-        super({ logger, config, selfHosted: ir.selfHosted, skipInstall: true });
+        super({ logger, config, selfHosted: ir.selfHosted, skipInstall: false });
         this.readmeConfigBuilder = readmeConfigBuilder;
         this.publishConfig = ir.publishConfig;
     }

--- a/generators/swift/sdk/src/SwiftGeneratorAgent.ts
+++ b/generators/swift/sdk/src/SwiftGeneratorAgent.ts
@@ -22,7 +22,7 @@ export class SwiftGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorCont
         readmeConfigBuilder: ReadmeConfigBuilder;
         ir: IntermediateRepresentation;
     }) {
-        super({ logger, config, selfHosted: ir.selfHosted });
+        super({ logger, config, selfHosted: ir.selfHosted, skipInstall: true });
         this.readmeConfigBuilder = readmeConfigBuilder;
         this.publishConfig = ir.publishConfig;
     }

--- a/generators/swift/sdk/src/SwiftGeneratorAgent.ts
+++ b/generators/swift/sdk/src/SwiftGeneratorAgent.ts
@@ -22,7 +22,7 @@ export class SwiftGeneratorAgent extends AbstractGeneratorAgent<SdkGeneratorCont
         readmeConfigBuilder: ReadmeConfigBuilder;
         ir: IntermediateRepresentation;
     }) {
-        super({ logger, config, selfHosted: ir.selfHosted, skipInstall: false });
+        super({ logger, config, selfHosted: ir.selfHosted, skipInstall: true });
         this.readmeConfigBuilder = readmeConfigBuilder;
         this.publishConfig = ir.publishConfig;
     }

--- a/seed/swift-sdk/bytes-download/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/bytes-download/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/bytes-download/reference.md
+++ b/seed/swift-sdk/bytes-download/reference.md
@@ -1,0 +1,2 @@
+# Reference
+## Service

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references-advanced/reference.md
+++ b/seed/swift-sdk/circular-references-advanced/reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/seed/swift-sdk/circular-references/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/circular-references/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/circular-references/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/circular-references/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/circular-references/reference.md
+++ b/seed/swift-sdk/circular-references/reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/seed/swift-sdk/empty-clients/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/empty-clients/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/empty-clients/reference.md
+++ b/seed/swift-sdk/empty-clients/reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/seed/swift-sdk/literals-unions/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/literals-unions/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/literals-unions/reference.md
+++ b/seed/swift-sdk/literals-unions/reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/seed/swift-sdk/object/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/object/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/object/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/object/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/object/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/object/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/object/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/object/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/object/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/object/Sources/Schemas/Type.swift
+++ b/seed/swift-sdk/object/Sources/Schemas/Type.swift
@@ -8,7 +8,7 @@ public struct Type: Codable, Hashable, Sendable {
     public let four: Bool
     public let five: Int64
     public let six: Date
-    public let seven: Date
+    public let seven: CalendarDate
     public let eight: UUID
     public let nine: String
     public let ten: [Int]
@@ -26,7 +26,7 @@ public struct Type: Codable, Hashable, Sendable {
     public let twentytwo: Float
     public let twentythree: String
     public let twentyfour: Date?
-    public let twentyfive: Date?
+    public let twentyfive: CalendarDate?
     /// Additional properties that are not explicitly defined in the schema
     public let additionalProperties: [String: JSONValue]
 
@@ -37,7 +37,7 @@ public struct Type: Codable, Hashable, Sendable {
         four: Bool,
         five: Int64,
         six: Date,
-        seven: Date,
+        seven: CalendarDate,
         eight: UUID,
         nine: String,
         ten: [Int],
@@ -55,7 +55,7 @@ public struct Type: Codable, Hashable, Sendable {
         twentytwo: Float,
         twentythree: String,
         twentyfour: Date? = nil,
-        twentyfive: Date? = nil,
+        twentyfive: CalendarDate? = nil,
         additionalProperties: [String: JSONValue] = .init()
     ) {
         self.one = one
@@ -94,7 +94,7 @@ public struct Type: Codable, Hashable, Sendable {
         self.four = try container.decode(Bool.self, forKey: .four)
         self.five = try container.decode(Int64.self, forKey: .five)
         self.six = try container.decode(Date.self, forKey: .six)
-        self.seven = try container.decode(Date.self, forKey: .seven)
+        self.seven = try container.decode(CalendarDate.self, forKey: .seven)
         self.eight = try container.decode(UUID.self, forKey: .eight)
         self.nine = try container.decode(String.self, forKey: .nine)
         self.ten = try container.decode([Int].self, forKey: .ten)
@@ -112,7 +112,7 @@ public struct Type: Codable, Hashable, Sendable {
         self.twentytwo = try container.decode(Float.self, forKey: .twentytwo)
         self.twentythree = try container.decode(String.self, forKey: .twentythree)
         self.twentyfour = try container.decodeIfPresent(Date.self, forKey: .twentyfour)
-        self.twentyfive = try container.decodeIfPresent(Date.self, forKey: .twentyfive)
+        self.twentyfive = try container.decodeIfPresent(CalendarDate.self, forKey: .twentyfive)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
 

--- a/seed/swift-sdk/object/reference.md
+++ b/seed/swift-sdk/object/reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/objects-with-imports/reference.md
+++ b/seed/swift-sdk/objects-with-imports/reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/seed/swift-sdk/public-object/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/public-object/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/public-object/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/public-object/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/public-object/reference.md
+++ b/seed/swift-sdk/public-object/reference.md
@@ -1,0 +1,2 @@
+# Reference
+## Service

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -112,6 +112,7 @@ allowedFailures:
   - multi-url-environment-no-default
   - nullable
   - nullable-optional
+  - oauth-client-credentials-with-variables
   - pagination:no-custom-config
   - pagination:custom-pager
   - pagination:custom-pager-with-exception-handler
@@ -129,6 +130,7 @@ allowedFailures:
   - undiscriminated-unions
   - unions
   - validation
+  - variables
   - websocket-bearer-auth
   - websocket-inferred-auth
   - property-access

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/WebsocketBearerAuthClient.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/WebsocketBearerAuthClient.swift
@@ -24,7 +24,7 @@ public final class WebsocketBearerAuthClient: Sendable {
         self.init(
             baseURL: baseURL,
             headerAuth: nil,
-            bearerAuth: .init(token: apiKey),
+            bearerAuth: .init(token: .staticToken(apiKey)),
             basicAuth: nil,
             headers: headers,
             timeout: timeout,
@@ -43,7 +43,7 @@ public final class WebsocketBearerAuthClient: Sendable {
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public convenience init(
         baseURL: String,
-        apiKey: ClientConfig.CredentialProvider,
+        apiKey: @escaping ClientConfig.CredentialProvider,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
         maxRetries: Int? = nil,
@@ -52,7 +52,7 @@ public final class WebsocketBearerAuthClient: Sendable {
         self.init(
             baseURL: baseURL,
             headerAuth: nil,
-            bearerAuth: .init(token: apiKey),
+            bearerAuth: .init(token: .provider(apiKey)),
             basicAuth: nil,
             headers: headers,
             timeout: timeout,

--- a/seed/swift-sdk/websocket-bearer-auth/reference.md
+++ b/seed/swift-sdk/websocket-bearer-auth/reference.md
@@ -1,0 +1,1 @@
+# Reference

--- a/seed/swift-sdk/websocket/Sources/Core/CalendarDate.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/CalendarDate.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Represents a calendar date without time information, following RFC 3339 section 5.6 (`YYYY-MM-DD` format)
+public struct CalendarDate: Codable, Hashable, Sendable, CustomStringConvertible, Comparable {
+    /// The year component (expected range: 1-9999)
+    public let year: Int
+
+    /// The month component (valid range: 1-12)
+    public let month: Int
+
+    /// The day component (valid range: 1-31, depending on month)
+    public let day: Int
+
+    /// Failable initializer for creating a CalendarDate with validation
+    public init?(year: Int, month: Int, day: Int) {
+        guard Self.isValidDate(year: year, month: month, day: day) else {
+            return nil
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Failable initializer for creating a CalendarDate from a `YYYY-MM-DD` string
+    public init?(_ dateString: String) {
+        let components = dateString.split(separator: "-")
+        guard components.count == 3,
+            let year = Int(components[0]),
+            let month = Int(components[1]),
+            let day = Int(components[2])
+        else {
+            return nil
+        }
+        self.init(year: year, month: month, day: day)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        guard let calendarDate = CalendarDate(dateString) else {
+            throw Error.invalidFormat(dateString)
+        }
+        self = calendarDate
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        // Format as YYYY-MM-DD with zero-padding
+        // %04d = 4-digit year with leading zeros (e.g., 2025)
+        // %02d = 2-digit month/day with leading zeros (e.g., 01, 05)
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    // MARK: - Comparable
+
+    public static func < (lhs: CalendarDate, rhs: CalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    // MARK: - Private Helpers
+
+    /// Validates that the given year, month, and day form a valid calendar date using Foundation's Calendar APIs.
+    private static func isValidDate(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = DateComponents(year: year, month: month, day: day)
+
+        guard let date = calendar.date(from: components) else {
+            return false
+        }
+
+        // Ensure the date components match what we created (handles invalid dates like Feb 30)
+        let reconstructedComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        return
+            (reconstructedComponents.year == year
+            && reconstructedComponents.month == month
+            && reconstructedComponents.day == day)
+    }
+
+    // MARK: - Error Types
+
+    /// Errors that can occur when working with CalendarDate
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidFormat(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidFormat(let string):
+                return "Invalid date format: '\(string)'. Expected YYYY-MM-DD"
+            }
+        }
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Data+String.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Data+String.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Data + String Extensions
+extension Data {
+    /// Safely appends a UTF-8 encoded string to the data
+    ///
+    /// - Parameter string: The string to append
+    mutating func appendUTF8String(_ string: String) {
+        guard let data = string.data(using: .utf8) else {
+            assertionFailure("Failed to encode string to UTF-8: \(string)")
+            return
+        }
+        self.append(data)
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/HTTP.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/HTTP.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct HTTP {
+enum HTTP {
     enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
@@ -13,10 +13,12 @@ struct HTTP {
     enum ContentType: String, CaseIterable {
         case applicationJson = "application/json"
         case applicationOctetStream = "application/octet-stream"
+        case multipartFormData = "multipart/form-data"
     }
 
     enum RequestBody {
         case jsonEncodable(any Encodable)
         case data(Data)
+        case multipartFormData(MultipartFormData)
     }
 }

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormData.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormData.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Helper class for building multipart form data requests
+class MultipartFormData {
+    let boundary: String
+    private var bodyData: Data
+
+    init() {
+        self.boundary = "Boundary-\(UUID().uuidString)"
+        self.bodyData = Data()
+    }
+
+    /// Append a file field to the form data
+    func appendFile(
+        _ data: Data, withName name: String, fileName: String? = nil
+    ) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        var contentDisposition = "Content-Disposition: form-data; name=\"\(name)\""
+        if let fileName {
+            contentDisposition += "; filename=\"\(fileName)\""
+        }
+        contentDisposition += "\r\n"
+        bodyData.appendUTF8String(contentDisposition)
+        bodyData.appendUTF8String(
+            "Content-Type: \(HTTP.ContentType.applicationOctetStream.rawValue)\r\n\r\n")
+        bodyData.append(data)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Append a text field to the form data
+    func appendField(_ value: String, withName name: String) {
+        bodyData.appendUTF8String("--\(boundary)\r\n")
+        bodyData.appendUTF8String(
+            "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        bodyData.appendUTF8String(value)
+        bodyData.appendUTF8String("\r\n")
+    }
+
+    /// Returns the complete multipart form data with closing boundary
+    func data() -> Data {
+        var finalData = bodyData
+        finalData.appendUTF8String("--\(boundary)--\r\n")
+        return finalData
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormDataConvertible.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormDataConvertible.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Protocol for types that can be converted to multipart form data
+protocol MultipartFormDataConvertible {
+    /// The multipart fields that represent this request
+    var multipartFormFields: [MultipartFormField] { get }
+}
+
+extension MultipartFormDataConvertible {
+    /// Converts this request to multipart form data
+    func asMultipartFormData() -> MultipartFormData {
+        let multipartData = MultipartFormData()
+        let jsonEncoder = Serde.jsonEncoder
+
+        for field in multipartFormFields {
+            switch field {
+            case .file(let file, let fieldName):
+                multipartData.appendFile(file.data, withName: fieldName, fileName: file.filename)
+            case .fileArray(let files, let fieldName):
+                for file in files {
+                    multipartData.appendFile(
+                        file.data,
+                        withName: fieldName,
+                        fileName: file.filename
+                    )
+                }
+            case .field(let encodableValue, let fieldName):
+                do {
+                    let encodedData = try jsonEncoder.encode(value: encodableValue)
+                    if let encodedString = String(data: encodedData, encoding: .utf8) {
+                        multipartData.appendField(encodedString, withName: fieldName)
+                    }
+                } catch {
+                    // Fallback - this should rarely happen with well-formed Encodable types
+                    multipartData.appendField("", withName: fieldName)
+                }
+            }
+        }
+
+        return multipartData
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormField.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/MultipartFormField.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a field in multipart form data
+enum MultipartFormField {
+    /// A single file field
+    case file(_ file: FormFile, fieldName: String)
+    /// An array of files with the same field name
+    case fileArray(_ files: [FormFile], fieldName: String)
+    /// A text field with JSON-encoded value (for strings, numbers, booleans, dates, etc.)
+    case field(_ value: EncodableValue, fieldName: String)
+
+    /// Create a text field from any Encodable value
+    static func field<T: Encodable>(_ value: T, fieldName: String) -> MultipartFormField {
+        return .field(.init(value), fieldName: fieldName)
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Networking/QueryParameter.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Networking/QueryParameter.swift
@@ -10,6 +10,7 @@ enum QueryParameter {
     case float(Float)
     case double(Double)
     case date(Date)
+    case calendarDate(CalendarDate)
     case stringArray([String])
     case uuid(UUID)
     case unknown(Any)
@@ -34,6 +35,8 @@ enum QueryParameter {
             return String(value)
         case .date(let value):
             return value.ISO8601Format()
+        case .calendarDate(let value):
+            return value.description
         case .stringArray(let values):
             return values.joined(separator: ",")
         case .uuid(let value):

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/EncodableValue.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/EncodableValue.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Type-erased wrapper for encodable values
+struct EncodableValue {
+    let value: any Encodable
+
+    init<T: Encodable>(_ value: T) {
+        self.value = value
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/JSONEncoder+EncodableValue.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension JSONEncoder {
+    /// Helper for type-erasing Encodable values
+    private struct AnyEncodable: Encodable {
+        private let value: any Encodable
+
+        init(_ value: any Encodable) {
+            self.value = value
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try value.encode(to: encoder)
+        }
+    }
+
+    func encode(value: EncodableValue) throws -> Data {
+        return try self.encode(AnyEncodable(value.value))
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedDecodingContainer+Nullable.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension KeyedDecodingContainer {
+    /// Decodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public func decodeNullableIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> Nullable<T>? where T: Decodable {
+        if contains(key) {
+            if try decodeNil(forKey: key) {
+                return .null
+            } else {
+                let value = try decode(type, forKey: key)
+                return .value(value)
+            }
+        } else {
+            return nil
+        }
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
+++ b/seed/swift-sdk/websocket/Sources/Core/Serde/KeyedEncodingContainer+Nullable.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes a Nullable<T>? value, properly handling missing vs null vs value
+    /// Use this for `Optional<Nullable<T>>` fields
+    public mutating func encodeNullableIfPresent<T>(_ value: Nullable<T>?, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable {
+        switch value {
+        case nil:
+            // Don't encode the key at all - field is missing
+            break
+        case .some(.null):
+            try encodeNil(forKey: key)
+        case .some(.value(let wrapped)):
+            try encode(wrapped, forKey: key)
+        }
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Public/FormFile.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/FormFile.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents a file with its data and optional metadata for multipart uploads
+public struct FormFile {
+    /// The file data
+    public let data: Data
+    /// Optional filename
+    public let filename: String?
+
+    public init(data: Data, filename: String? = nil) {
+        self.data = data
+        self.filename = filename
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension FormFile {
+    /// Create a FormFile from raw Data with no metadata
+    /// - Parameter data: The file data
+    public static func data(_ data: Data) -> FormFile {
+        return FormFile(data: data)
+    }
+
+    /// Create a FormFile from Data with a filename
+    /// - Parameters:
+    ///   - data: The file data
+    ///   - filename: The filename
+    public static func named(_ data: Data, filename: String) -> FormFile {
+        return FormFile(data: data, filename: filename)
+    }
+}

--- a/seed/swift-sdk/websocket/Sources/Public/Nullable.swift
+++ b/seed/swift-sdk/websocket/Sources/Public/Nullable.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents a value that can be either a concrete value or explicit `null`, distinguishing between null and missing fields in JSON.
+public enum Nullable<Wrapped>: Codable, Hashable, Sendable
+where Wrapped: Codable & Hashable & Sendable {
+    case value(Wrapped)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let wrappedValue = try container.decode(Wrapped.self)
+            self = .value(wrappedValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .value(let wrapped):
+            try container.encode(wrapped)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    /// Returns the wrapped value if present, otherwise nil
+    public var wrappedValue: Wrapped? {
+        switch self {
+        case .value(let wrapped):
+            return wrapped
+        case .null:
+            return nil
+        }
+    }
+
+    /// Returns true if this contains an explicit null value
+    public var isNull: Bool {
+        switch self {
+        case .value(_):
+            return false
+        case .null:
+            return true
+        }
+    }
+
+    /// Convenience initializer from optional value
+    public init(_ value: Wrapped?) {
+        if let value = value {
+            self = .value(value)
+        } else {
+            self = .null
+        }
+    }
+}

--- a/seed/swift-sdk/websocket/reference.md
+++ b/seed/swift-sdk/websocket/reference.md
@@ -1,0 +1,1 @@
+# Reference


### PR DESCRIPTION
## Description
Linear ticket: n/a
<!-- Provide a clear and concise description of the changes made in this PR -->
Disables global installation of `@fern-api/generator-cli` during readme and reference generation. Also skips readme gen if no endpoint snippets are available.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Updated `AbstractGeneratorAgent` constructor to allow passing `skipInstall` to the underlying `GeneratorAgentClient`
- Updated `SwiftGeneratorAgent` to pass `skipInstall: true` to `AbstractGeneratorAgent`
- Updated `SdkGeneratorCli.generateReadme()` to exit with no failure if there no endpoint snippets available.
- Added `oauth-client-credentials-with-variables` and `variables` fixtures to `allowedFailures` (snippet gen errors that I'll address later)
- Updated Seed snapshots


## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed