### PR TITLE
chore(internal): fail loud when no configuration files found

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -56,7 +56,7 @@ export async function generateWorkspace({
     }
 
     if (workspace.generatorsConfiguration.groups.length === 0) {
-        context.logger.warn(`This workspaces has no groups specified in ${GENERATORS_CONFIGURATION_FILENAME}`);
+        context.logger.warn(`This workspace has no groups specified in ${GENERATORS_CONFIGURATION_FILENAME}`);
         return;
     }
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fail loud when no configuration files are found for either SDKs or docs.
+      type: chore
+  irVersion: 60
+  createdAt: "2025-09-30"
+  version: 0.84.1
+
+- changelogEntry:
+    - summary: |
         Add a `resolve-aliases` config flag to the OpenAPI parser which will inline aliases if possible.
       type: feat
   irVersion: 60
@@ -25,10 +33,10 @@
 
 - changelogEntry:
     - summary: |
-        Introduce `page-actions` configuration in the `docs.yml` so that users can choose which 
-        actions are visible. 
+        Introduce `page-actions` configuration in the `docs.yml` so that users can choose which
+        actions are visible.
 
-        ```docs.yml 
+        ```docs.yml
         page-actions:
           chatgpt: false
           claude: true

--- a/packages/cli/configuration-loader/src/generators-yml/loadGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/loadGeneratorsConfiguration.ts
@@ -1,4 +1,8 @@
-import { generatorsYml } from "@fern-api/configuration";
+import {
+    GENERATORS_CONFIGURATION_FILENAME,
+    GENERATORS_CONFIGURATION_FILENAME_ALTERNATIVE,
+    generatorsYml
+} from "@fern-api/configuration";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import { readFile } from "fs/promises";
@@ -72,8 +76,8 @@ export async function getPathToGeneratorsConfiguration({
 }: {
     absolutePathToWorkspace: AbsoluteFilePath;
 }): Promise<AbsoluteFilePath | undefined> {
-    const ymlPath = join(absolutePathToWorkspace, RelativeFilePath.of("generators.yml"));
-    const yamlPath = join(absolutePathToWorkspace, RelativeFilePath.of("generators.yaml"));
+    const ymlPath = join(absolutePathToWorkspace, RelativeFilePath.of(GENERATORS_CONFIGURATION_FILENAME));
+    const yamlPath = join(absolutePathToWorkspace, RelativeFilePath.of(GENERATORS_CONFIGURATION_FILENAME_ALTERNATIVE));
 
     if (await doesPathExist(ymlPath)) {
         return ymlPath;

--- a/packages/cli/configuration/src/constants.ts
+++ b/packages/cli/configuration/src/constants.ts
@@ -8,6 +8,7 @@ export const FERN_PACKAGE_MARKER_FILENAME_NO_EXTENSION = "__package__";
 export const FERN_PACKAGE_MARKER_FILENAME = `${FERN_PACKAGE_MARKER_FILENAME_NO_EXTENSION}.yml`;
 export const DEPENDENCIES_FILENAME = "dependencies.yml";
 export const GENERATORS_CONFIGURATION_FILENAME = "generators.yml";
+export const GENERATORS_CONFIGURATION_FILENAME_ALTERNATIVE = "generators.yaml";
 export const DEPENDENCIES_CONFIGURATION_FILENAME = "dependencies.yml";
 export const DOCS_CONFIGURATION_FILENAME = "docs.yml";
 export const PROJECT_CONFIG_FILENAME = "fern.config.json";

--- a/packages/cli/project-loader/src/loadProject.ts
+++ b/packages/cli/project-loader/src/loadProject.ts
@@ -98,7 +98,7 @@ export async function loadProjectFromDirectory({
                 ` › ${APIS_DIRECTORY}/\n` +
                 ` › ${DEFINITION_DIRECTORY}/\n` +
                 ` › ${OPENAPI_DIRECTORY}/\n` +
-                ` › ${ASYNCAPI_DIRECTORY}/\n\n` +
+                ` › ${ASYNCAPI_DIRECTORY}/\n` +
                 `For more information:\n` +
                 ` › SDK project structure: https://buildwithfern.com/learn/api-definitions/overview/project-structure\n` +
                 ` › Docs project structure: https://buildwithfern.com/learn/docs/getting-started/project-structure`


### PR DESCRIPTION
## Description
Linear ticket: Fixes FER-6351
Adds a verbose error when no workspaces are generated from any configuration file:
```
No SDK specifications or docs specifications found. Please ensure one of the following files is present:
 › generators.yml
 › docs.yml
Or one of the following directories:
 › apis/
 › definition/
 › openapi/
 › asyncapi/

For more information:
 › SDK project structure: https://buildwithfern.com/learn/api-definitions/overview/project-structure
 › Docs project structure: https://buildwithfern.com/learn/docs/getting-started/project-structure
 ```
Before, most `fern` commands would silently exit by looping over 0 workspaces and then returning, which was unhelpful.

## Changes Made
Changes to `loadProject.ts` in `packages/cli/project-loader`. Also a grammatical nitpick elsewhere; also makes it so https://github.com/fern-api/fern/pull/5483 works across the board, but advises for `.yml` everywhere to be safe (since this `.yaml` logic for `generators.yaml` isn't applied elsewhere currently).
