### PR TITLE
fix(python): Added support for poetry_v1, poetry_v2, uv. Added feature Flags to Indicate which tool (uv, poetry_v1, poetry_v2...)

### DIFF
--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -290,7 +290,7 @@ httpx = "^0.24.0"
                     deps.append(f'{name} = ">={dep.version}"')
                 else:  # EXACT
                     # Check if version already contains a specifier
-                    if dep.version.startswith(("==", ">=", "<=", "~=", "!=")):
+                    if dep.version.startswith(("==", ">=", "<=", "~=", "!=", "^")):
                         deps.append(f'{name} = "{dep.version}"')
                     else:
                         deps.append(f'{name} = "=={dep.version}"')
@@ -315,7 +315,7 @@ httpx = "^0.24.0"
                     version = f">={dep.version}"
                 else:  # EXACT
                     # Check if version already contains a specifier
-                    if dep.version.startswith(('==', '>=', '<=', '~=', '!=')):
+                    if dep.version.startswith(('==', '>=', '<=', '~=', '!=', '^')):
                         version = dep.version
                     else:
                         version = f"=={dep.version}"

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -392,3 +392,4 @@ section-order = ["future", "standard-library", "third-party", "first-party"]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 """
+# Clean encoding fix

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -91,25 +91,10 @@ class PyProjectToml:
             f.write(content)
 
     def _generate_optional_dependencies(self) -> str:
-        """Generate [project.optional-dependencies] section combining dev dependencies and extras"""
+        """Generate [project.optional-dependencies] section for extras only"""
         optional_deps = {}
 
-        # Add dev dependencies as 'dev' group
-        dev_deps = []
-        for dep in self._dependency_manager.get_dev_dependencies():
-            if dep.compatibility == DependencyCompatibility.GREATER_THAN_OR_EQUAL:
-                dev_deps.append(f'{dep.name}>={dep.version}')
-            else:  # EXACT
-                # Check if version already contains a specifier
-                if dep.version.startswith(('==', '>=', '<=', '~=', '!=')):
-                    dev_deps.append(f'{dep.name}{dep.version}')
-                else:
-                    dev_deps.append(f'{dep.name}=={dep.version}')
-
-        if dev_deps:
-            optional_deps['dev'] = dev_deps
-
-        # Add extras
+        # Add extras only (dev dependencies are handled in Poetry section)
         for key, vals in self._extras.items():
             optional_deps[key] = vals
 
@@ -139,9 +124,9 @@ class PyProjectToml:
 
         def to_string(self) -> str:
             description = ""
-            authors = []
-            keywords = []
-            project_urls = []
+            authors: List[dict] = []
+            keywords: List[str] = []
+            project_urls: List[str] = []
             classifiers = [
                 "Intended Audience :: Developers",
                 "Programming Language :: Python",
@@ -236,7 +221,7 @@ include = ["{self.package.include}*"]
         def to_string(self) -> str:
             description = ""
             if self.pypi_metadata is not None:
-                description = self.pypi_metadata.description
+                description = self.pypi_metadata.description or ""
 
             authors = []
             if self.pypi_metadata is not None and self.pypi_metadata.authors is not None:

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -5,7 +5,7 @@ import os
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional, Set, cast
+from typing import Dict, List, Optional, Set, cast
 
 from fern_python.codegen.ast.dependency.dependency import (
     Dependency,
@@ -124,7 +124,7 @@ class PyProjectToml:
 
         def to_string(self) -> str:
             description = ""
-            authors: List[dict] = []
+            authors: List[Dict[str, str]] = []
             keywords: List[str] = []
             project_urls: List[str] = []
             classifiers = [

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -45,7 +45,7 @@ class PyProjectToml:
         user_defined_toml: Optional[str] = None,
     ):
         self._name = name
-        self._poetry_block = PyProjectToml.PoetryBlock(
+        self._modern_block = PyProjectToml.ModernBlock(
             name=name,
             version=version,
             package=package,
@@ -61,30 +61,27 @@ class PyProjectToml:
 
     def write(self) -> None:
         blocks: List[PyProjectToml.Block] = [
-            self._poetry_block,
-            PyProjectToml.DependenciesBlock(
+            self._modern_block,
+            PyProjectToml.LegacyBlock(
+                name=self._name,
+                version=self._modern_block.version,
+                package=self._modern_block.package,
+                pypi_metadata=self._modern_block.pypi_metadata,
+                github_output_mode=self._modern_block.github_output_mode,
+                license_=self._modern_block.license_,
+                python_version=self._python_version,
                 dependencies=self._dependency_manager.get_dependencies(),
                 dev_dependencies=self._dependency_manager.get_dev_dependencies(),
-                python_version=self._python_version,
             ),
             PyProjectToml.PluginConfigurationBlock(),
             PyProjectToml.BuildSystemBlock(),
         ]
-        content = f"""[project]
-name = "{self._name}"
-
-"""
-
+        content = ""
         for block in blocks:
             content += block.to_string()
 
-        if len(self._extras) > 0:
-            content += """
-[tool.poetry.extras]
-"""
-            for key, vals in self._extras.items():
-                stringified_vals = ", ".join([f'"{val}"' for val in vals])
-                content += f"{key}=[{stringified_vals}]\n"
+        # Handle optional dependencies (dev dependencies + extras)
+        content += self._generate_optional_dependencies()
 
         if self._user_defined_toml is not None:
             content += "\n"
@@ -93,13 +90,46 @@ name = "{self._name}"
         with open(os.path.join(self._path, "pyproject.toml"), "w") as f:
             f.write(content)
 
+    def _generate_optional_dependencies(self) -> str:
+        """Generate [project.optional-dependencies] section combining dev dependencies and extras"""
+        optional_deps = {}
+
+        # Add dev dependencies as 'dev' group
+        dev_deps = []
+        for dep in self._dependency_manager.get_dev_dependencies():
+            if dep.compatibility == DependencyCompatibility.GREATER_THAN_OR_EQUAL:
+                dev_deps.append(f'{dep.name}>={dep.version}')
+            else:  # EXACT
+                # Check if version already contains a specifier
+                if dep.version.startswith(('==', '>=', '<=', '~=', '!=')):
+                    dev_deps.append(f'{dep.name}{dep.version}')
+                else:
+                    dev_deps.append(f'{dep.name}=={dep.version}')
+
+        if dev_deps:
+            optional_deps['dev'] = dev_deps
+
+        # Add extras
+        for key, vals in self._extras.items():
+            optional_deps[key] = vals
+
+        if not optional_deps:
+            return ""
+
+        result = "\n[project.optional-dependencies]\n"
+        for key, deps in optional_deps.items():
+            deps_str = ", ".join([f'"{dep}"' for dep in deps])
+            result += f"{key} = [{deps_str}]\n"
+
+        return result
+
     class Block(ABC):
         @abstractmethod
         def to_string(self) -> str:
             pass
 
     @dataclass(frozen=True)
-    class PoetryBlock(Block):
+    class ModernBlock(Block):
         name: str
         version: Optional[str]
         package: PyProjectTomlPackageConfig
@@ -108,15 +138,10 @@ name = "{self._name}"
         license_: Optional[LicenseConfig]
 
         def to_string(self) -> str:
-            s = f'''[tool.poetry]
-name = "{self.name}"'''
-            if self.version is not None:
-                s += "\n" + f'version = "{self.version}"'
-
             description = ""
-            authors: List[str] = []
-            keywords: List[str] = []
-            project_urls: List[str] = []
+            authors = []
+            keywords = []
+            project_urls = []
             classifiers = [
                 "Intended Audience :: Developers",
                 "Programming Language :: Python",
@@ -134,16 +159,14 @@ name = "{self.name}"'''
                 "Topic :: Software Development :: Libraries :: Python Modules",
                 "Typing :: Typed",
             ]
-            license_evaluated = ""
+
             if self.pypi_metadata is not None:
                 description = (
                     self.pypi_metadata.description if self.pypi_metadata.description is not None else description
                 )
-                authors = (
-                    [f"{author.name} <{author.email}>" for author in self.pypi_metadata.authors]
-                    if self.pypi_metadata.authors is not None
-                    else authors
-                )
+                if self.pypi_metadata.authors is not None:
+                    for author in self.pypi_metadata.authors:
+                        authors.append({"name": author.name, "email": author.email})
                 keywords = self.pypi_metadata.keywords if self.pypi_metadata.keywords is not None else keywords
                 if self.pypi_metadata.documentation_link is not None:
                     project_urls.append(f"Documentation = '{self.pypi_metadata.documentation_link}'")
@@ -151,14 +174,11 @@ name = "{self.name}"'''
                     project_urls.append(f"Homepage = '{self.pypi_metadata.homepage_link}'")
 
             if self.license_ is not None:
-                # TODO(armandobelardo): verify poetry handles custom licenses on it's side
                 if self.license_.get_as_union().type == "basic":
                     license_id = cast(BasicLicense, self.license_.get_as_union()).id
                     if license_id == LicenseId.MIT:
-                        license_evaluated = 'license = "MIT"'
                         classifiers.append("License :: OSI Approved :: MIT License")
                     elif license_id == LicenseId.APACHE_2:
-                        license_evaluated = 'license = "Apache-2.0"'
                         classifiers.append("License :: OSI Approved :: Apache Software License")
 
             if self.github_output_mode is not None:
@@ -168,27 +188,128 @@ name = "{self.name}"'''
             if len(project_urls) > 0:
                 stringified_project_urls = "\n[project.urls]\n" + "\n".join(project_urls) + "\n"
 
+            s = f"""[project]
+name = "{self.name}" """
+            if self.version is not None:
+                s += f'\nversion = "{self.version}"'
+
             s += f"""
 description = "{description}"
 readme = "README.md"
-authors = {json.dumps(authors, indent=4)}
-keywords = {json.dumps(keywords, indent=4)}
-{license_evaluated}
-classifiers = {json.dumps(classifiers, indent=4)}"""
+requires-python = ">=3.8"
+dependencies = []"""
+
             if self.package._from is not None:
                 s += f"""
-packages = [
-    {{ include = "{self.package.include}", from = "{self.package._from}"}}
-]
+[tool.setuptools.packages.find]
+where = ["{self.package._from}"]
+include = ["{self.package.include}*"]
 """
             else:
                 s += f"""
-packages = [
-    {{ include = "{self.package.include}"}}
-]
+[tool.setuptools.packages.find]
+include = ["{self.package.include}*"]
 """
+
+            if authors:
+                s += f"\nauthors = {json.dumps(authors)}"
+            if keywords:
+                s += f"\nkeywords = {json.dumps(keywords)}"
+            if classifiers:
+                s += f"\nclassifiers = {json.dumps(classifiers)}"
+
             s += stringified_project_urls
             return s
+
+    @dataclass(frozen=True)
+    class LegacyBlock(Block):
+        name: str
+        version: Optional[str]
+        package: PyProjectTomlPackageConfig
+        pypi_metadata: Optional[PypiMetadata]
+        github_output_mode: Optional[GithubOutputMode]
+        license_: Optional[LicenseConfig]
+        python_version: str
+        dependencies: Set[Dependency]
+        dev_dependencies: Set[Dependency]
+
+        def to_string(self) -> str:
+            description = ""
+            if self.pypi_metadata is not None:
+                description = self.pypi_metadata.description
+
+            authors = []
+            if self.pypi_metadata is not None and self.pypi_metadata.authors is not None:
+                for author in self.pypi_metadata.authors:
+                    authors.append({"name": author.name, "email": author.email})
+
+            keywords = []
+            if self.pypi_metadata is not None and self.pypi_metadata.keywords is not None:
+                keywords = self.pypi_metadata.keywords
+
+            classifiers = []
+            license_evaluated = ""
+            if self.license_ is not None:
+                if self.license_.get_as_union().type == "basic":
+                    license_id = cast(BasicLicense, self.license_.get_as_union()).id
+                    if license_id == LicenseId.MIT:
+                        license_evaluated = 'license = "MIT"'
+                        classifiers.append("License :: OSI Approved :: MIT License")
+                    elif license_id == LicenseId.APACHE_2:
+                        license_evaluated = 'license = "Apache-2.0"'
+                        classifiers.append("License :: OSI Approved :: Apache Software License")
+
+            # LegacyBlock doesn't generate project.urls - that's PEP 621 format
+
+            s = f"""[tool.poetry]
+name = "{self.name}" """
+            if self.version is not None:
+                s += f'\nversion = "{self.version}"'
+
+            if self.package._from is not None:
+                s += f"""
+packages = [{{include = "{self.package.include}", from = "{self.package._from}"}}]"""
+            else:
+                s += f"""
+packages = [{{include = "{self.package.include}"}}]"""
+
+            s += f"""
+description = "{description}"
+readme = "README.md"
+authors = {json.dumps(authors)}
+keywords = {json.dumps(keywords)}
+{license_evaluated}
+classifiers = {json.dumps(classifiers)}"""
+
+            # Add dependencies
+            deps = self.deps_to_string(self.dependencies)
+            dev_deps = self.deps_to_string(self.dev_dependencies)
+
+            s += f"""
+[tool.poetry.dependencies]
+python = "{self.python_version}"
+{deps}
+[tool.poetry.group.dev.dependencies]
+mypy = "==1.13.0"
+pytest = "^7.4.0"
+pytest-asyncio = "^0.21.0"
+httpx = "^0.24.0"
+{dev_deps}"""
+            return s
+
+        def deps_to_string(self, dependencies: Set[Dependency]) -> str:
+            deps = []
+            for dep in sorted(dependencies, key=lambda dep: dep.name):
+                name = dep.name.replace(".", "-")
+                if dep.compatibility == DependencyCompatibility.GREATER_THAN_OR_EQUAL:
+                    deps.append(f'{name} = ">={dep.version}"')
+                else:  # EXACT
+                    # Check if version already contains a specifier
+                    if dep.version.startswith(('==', '>=', '<=', '~=', '!=')):
+                        deps.append(f'{name} = "{dep.version}"')
+                    else:
+                        deps.append(f'{name} = "=={dep.version}"')
+            return "\n".join(deps)
 
     @dataclass(frozen=True)
     class DependenciesBlock(Block):

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -290,7 +290,7 @@ httpx = "^0.24.0"
                     deps.append(f'{name} = ">={dep.version}"')
                 else:  # EXACT
                     # Check if version already contains a specifier
-                    if dep.version.startswith(('==', '>=', '<=', '~=', '!=')):
+                    if dep.version.startswith(("==", ">=", "<=", "~=", "!=")):
                         deps.append(f'{name} = "{dep.version}"')
                     else:
                         deps.append(f'{name} = "=={dep.version}"')
@@ -313,6 +313,12 @@ httpx = "^0.24.0"
                 name = dep.name.replace(".", "-")
                 if compatibility == DependencyCompatibility.GREATER_THAN_OR_EQUAL:
                     version = f">={dep.version}"
+                else:  # EXACT
+                    # Check if version already contains a specifier
+                    if dep.version.startswith(('==', '>=', '<=', '~=', '!=')):
+                        version = dep.version
+                    else:
+                        version = f"=={dep.version}"
 
                 if is_optional or has_python_version or dep.extras is not None:
                     deps += f'{name} = {{ version = "{version}"'

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -315,7 +315,7 @@ httpx = "^0.24.0"
                     version = f">={dep.version}"
                 else:  # EXACT
                     # Check if version already contains a specifier
-                    if dep.version.startswith(('==', '>=', '<=', '~=', '!=', '^')):
+                    if dep.version.startswith(("==", ">=", "<=", "~=", "!=", "^")):
                         version = dep.version
                     else:
                         version = f"=={dep.version}"

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -392,4 +392,3 @@ section-order = ["future", "standard-library", "third-party", "first-party"]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 """
-# Clean encoding fix

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -7,12 +7,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Set, cast
 
-from fern_python.codegen.ast.dependency.dependency import (
-    Dependency,
-    DependencyCompatibility,
-)
-from fern_python.codegen.dependency_manager import DependencyManager
-
 from fern.generator_exec import (
     BasicLicense,
     GithubOutputMode,
@@ -20,6 +14,12 @@ from fern.generator_exec import (
     LicenseId,
     PypiMetadata,
 )
+
+from fern_python.codegen.ast.dependency.dependency import (
+    Dependency,
+    DependencyCompatibility,
+)
+from fern_python.codegen.dependency_manager import DependencyManager
 
 
 @dataclass(frozen=True)
@@ -80,7 +80,7 @@ class PyProjectToml:
         for block in blocks:
             content += block.to_string()
 
-        # Handle optional dependencies (dev dependencies + extras)
+        # Handle optional dependencies (extras only - dev dependencies are in Poetry section)
         content += self._generate_optional_dependencies()
 
         if self._user_defined_toml is not None:
@@ -182,18 +182,18 @@ name = "{self.name}" """
 description = "{description}"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = []"""
+"""
 
             if self.package._from is not None:
                 s += f"""
 [tool.setuptools.packages.find]
 where = ["{self.package._from}"]
-include = ["{self.package.include}*"]
+include = ["{self.package.include}"]
 """
             else:
                 s += f"""
 [tool.setuptools.packages.find]
-include = ["{self.package.include}*"]
+include = ["{self.package.include}"]
 """
 
             if authors:


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6797/generated-pyprojecttoml-files-are-technically-invalid
In this issue, we had compability issues with UV and the pyproject.toml fern generates.

The main issue is that uv does not understand poetry_v1 (which we currently support) syntax.

With these changes, we generate a giant concatenated toml file that supports all of poetry v1, poetry v2, and uv.

**Note: Poetry v2.x+ may complain and give warnings as it supports both syntaxes of poetry v1 and uv, but should not matter.**

## Changes Made
1. pyproject_toml now has different blocks that generates two toml file, legacy (generates toml file for poetry v1) and modern (generates toml file that is up to PEP621 standards, for uv and poetry v2).
2. It will now concat both of them, supporting all of our current python package managing dependency support
