### PR TITLE
fix(typescript): Log error when `testFramework: vitest` is used alongside incompatible settings

### DIFF
--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -102,6 +102,24 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
                 "Incompatible configuration: noSerdeLayer cannot be false while experimentalGenerateReadWriteOnlyTypes is true."
             );
         }
+        const isUsingVitest = parsed?.testFramework ?? "vitest" === "vitest";
+        if (isUsingVitest) {
+            if (parsed?.useBigInt) {
+                logger.error(
+                    "`testFramework` `vitest` does not currently support BigInt. Please set `useBigInt` to `false` or set `testFramework` to `jest`."
+                );
+            }
+            if (parsed?.streamType === "wrapper") {
+                logger.error(
+                    "`testFramework` `vitest` does not currently support `streamType` `wrapper`. Please set `streamType` to `web` or `node` or set `testFramework` to `jest`."
+                );
+            }
+            if (parsed?.packagePath != null) {
+                logger.error(
+                    "`testFramework` `vitest` does not currently support `packagePath`. Please remove `packagePath` or set `testFramework` to `jest`."
+                );
+            }
+        }
 
         return config;
     }

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -102,7 +102,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
                 "Incompatible configuration: noSerdeLayer cannot be false while experimentalGenerateReadWriteOnlyTypes is true."
             );
         }
-        const isUsingVitest = parsed?.testFramework ?? "vitest" === "vitest";
+        const isUsingVitest = (parsed?.testFramework ?? "vitest") === "vitest";
         if (isUsingVitest) {
             if (parsed?.useBigInt) {
                 logger.error(

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 3.3.5
+  changelogEntry:
+    - summary: |
+        Log error when `testFramework: vitest` is used alongside `useBigInt: true`, `streamType: wrapper`, or `packagePath: path/to/package`.
+      type: feat
+  createdAt: "2025-10-01"
+  irVersion: 60
+
 - version: 3.3.4
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/asIs/AsIsManager.ts
+++ b/generators/typescript/utils/commons/src/asIs/AsIsManager.ts
@@ -27,7 +27,6 @@ export class AsIsManager {
         this.generateWireTests = generateWireTests;
         this.relativePackagePath = relativePackagePath;
         this.relativeTestPath = relativeTestPath;
-        console.log("relativeTestPath", this.relativeTestPath);
     }
 
     /**


### PR DESCRIPTION
Log error when `testFramework: vitest` is used alongside incompatible settings
