### PR TITLE
feat(ci): Setup nightly job to re-balance seed test groups

### DIFF
--- a/.github/workflow-resource-files/seed-groups/csharp-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/csharp-model-seed-groups.json
@@ -1,0 +1,149 @@
+{
+  "totalTestTimeSeconds": 14190,
+  "groups": [
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "optional",
+        "literals-unions",
+        "simple-api",
+        "imdb",
+        "single-url-environment-no-default",
+        "empty-clients",
+        "oauth-client-credentials-custom",
+        "objects-with-imports",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 1460
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "query-parameters",
+        "nullable-optional",
+        "extends",
+        "license",
+        "validation",
+        "error-property",
+        "basic-auth",
+        "mixed-file-directory",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 1461
+    },
+    {
+      "fixtures": [
+        "version",
+        "nullable",
+        "simple-fhir",
+        "no-environment",
+        "file-upload",
+        "websocket-bearer-auth",
+        "path-parameters",
+        "any-auth",
+        "oauth-client-credentials-nested-root",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 1461
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto",
+        "property-access",
+        "public-object",
+        "object",
+        "http-head",
+        "multi-line-docs",
+        "websocket",
+        "oauth-client-credentials-default",
+        "cross-package-type-names",
+        "pagination"
+      ],
+      "groupTotalTimeSeconds": 1460
+    },
+    {
+      "fixtures": [
+        "csharp-system-collision",
+        "api-wide-base-path",
+        "idempotency-headers",
+        "streaming",
+        "pagination-custom",
+        "response-property",
+        "oauth-client-credentials-environment-variables",
+        "enum:forward-compatible-enums",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 1391
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "bytes-download",
+        "plain-text",
+        "request-parameters",
+        "unknown",
+        "websocket-inferred-auth",
+        "oauth-client-credentials",
+        "enum:plain-enums",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 1391
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "version-no-default",
+        "reserved-keywords",
+        "streaming-parameter",
+        "undiscriminated-unions",
+        "variables",
+        "inferred-auth-explicit",
+        "csharp-namespace-conflict",
+        "circular-references"
+      ],
+      "groupTotalTimeSeconds": 1391
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "auth-environment-variables",
+        "server-sent-event-examples",
+        "server-sent-events",
+        "single-url-environment-default",
+        "csharp-namespace-collision",
+        "client-side-params",
+        "custom-auth",
+        "circular-references-advanced"
+      ],
+      "groupTotalTimeSeconds": 1391
+    },
+    {
+      "fixtures": [
+        "alias",
+        "content-type",
+        "multiple-request-bodies",
+        "file-download",
+        "basic-auth-environment-variables",
+        "multi-url-environment",
+        "errors",
+        "package-yml",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 1391
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "csharp-grpc-proto-exhaustive",
+        "mixed-case",
+        "extra-properties",
+        "unions",
+        "inferred-auth-implicit-no-expiry",
+        "inferred-auth-implicit",
+        "multi-url-environment-no-default",
+        "oauth-client-credentials-with-variables"
+      ],
+      "groupTotalTimeSeconds": 1393
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/csharp-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/csharp-sdk-seed-groups.json
@@ -1,0 +1,170 @@
+{
+  "totalTestTimeSeconds": 37097,
+  "groups": [
+    {
+      "fixtures": [
+        "csharp-grpc-proto-exhaustive:include-exception-handler",
+        "path-parameters:no-custom-config",
+        "nullable",
+        "content-type",
+        "auth-environment-variables",
+        "inferred-auth-implicit-no-expiry",
+        "websocket-inferred-auth",
+        "public-object",
+        "multi-url-environment:no-pascal-case-environments",
+        "basic-auth",
+        "exhaustive:include-exception-handler"
+      ],
+      "groupTotalTimeSeconds": 3680
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto-exhaustive:read-only-memory",
+        "bytes-upload",
+        "simple-fhir",
+        "imdb:no-custom-config",
+        "license:mit-license",
+        "csharp-system-collision:system-client",
+        "client-side-params",
+        "undiscriminated-unions",
+        "websocket-bearer-auth",
+        "folders",
+        "audiences",
+        "imdb:exported-client-class-name"
+      ],
+      "groupTotalTimeSeconds": 3685
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto",
+        "unions:no-custom-config",
+        "imdb:include-exception-handler",
+        "package-yml",
+        "multi-line-docs",
+        "multiple-request-bodies",
+        "optional:simplify-object-dictionaries",
+        "nullable-optional",
+        "single-url-environment-default",
+        "basic-auth-environment-variables",
+        "exhaustive:no-root-namespace-for-core-classes"
+      ],
+      "groupTotalTimeSeconds": 3678
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto-exhaustive:no-custom-config",
+        "imdb:extra-dependencies",
+        "file-upload",
+        "license:custom-license",
+        "extra-properties:no-additional-properties",
+        "multi-url-environment-no-default",
+        "query-parameters",
+        "simple-api",
+        "custom-auth",
+        "websocket:no-custom-config",
+        "exhaustive:no-generate-error-types"
+      ],
+      "groupTotalTimeSeconds": 3678
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "csharp-namespace-collision:fully-qualified-namespaces",
+        "oauth-client-credentials:include-exception-handler",
+        "response-property",
+        "optional:no-custom-config",
+        "pagination-custom",
+        "errors",
+        "server-sent-event-examples",
+        "error-property",
+        "examples:readme-config",
+        "exhaustive:explicit-namespaces"
+      ],
+      "groupTotalTimeSeconds": 3672
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "version",
+        "extends",
+        "extra-properties:no-custom-config",
+        "path-parameters:no-inline-path-parameters",
+        "empty-clients",
+        "object",
+        "single-url-environment-no-default",
+        "mixed-file-directory",
+        "cross-package-type-names",
+        "pagination:custom-pager-with-exception-handler",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 3737
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "bytes-download",
+        "no-environment",
+        "oauth-client-credentials-default",
+        "http-head",
+        "reserved-keywords",
+        "file-download",
+        "request-parameters",
+        "any-auth",
+        "enum:forward-compatible-enums",
+        "oauth-client-credentials-with-variables"
+      ],
+      "groupTotalTimeSeconds": 3682
+    },
+    {
+      "fixtures": [
+        "alias",
+        "accept-header",
+        "unions:no-discriminated-unions",
+        "oauth-client-credentials-environment-variables",
+        "multi-url-environment:environment-class-name",
+        "csharp-namespace-conflict",
+        "mixed-case",
+        "inferred-auth-implicit",
+        "streaming-parameter",
+        "literal",
+        "circular-references",
+        "pagination:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 3750
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "query-parameters-openapi",
+        "idempotency-headers",
+        "oauth-client-credentials-nested-root",
+        "plain-text",
+        "streaming",
+        "unknown",
+        "oauth-client-credentials:no-custom-config",
+        "validation",
+        "examples:no-custom-config",
+        "variables",
+        "pagination:custom-pager"
+      ],
+      "groupTotalTimeSeconds": 3782
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto-exhaustive:package-id",
+        "api-wide-base-path",
+        "imdb:exception-class-names",
+        "inferred-auth-explicit",
+        "literals-unions",
+        "objects-with-imports",
+        "property-access",
+        "websocket:with-websockets",
+        "server-sent-events",
+        "enum:plain-enums",
+        "circular-references-advanced",
+        "oauth-client-credentials-custom"
+      ],
+      "groupTotalTimeSeconds": 3753
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/fastapi-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/fastapi-seed-groups.json
@@ -1,0 +1,159 @@
+{
+  "totalTestTimeSeconds": 3209,
+  "groups": [
+    {
+      "fixtures": [
+        "trace",
+        "query-parameters-openapi-as-objects",
+        "bearer-token-environment-variable",
+        "mixed-case",
+        "websocket-bearer-auth",
+        "imdb:includes-extra-fields",
+        "multi-line-docs",
+        "request-parameters",
+        "imdb:async-handlers",
+        "streaming"
+      ],
+      "groupTotalTimeSeconds": 315
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "exhaustive:pydantic-v1",
+        "basic-auth",
+        "circular-references:no-inheritance-for-extended-models",
+        "simple-fhir:no-inheritance-for-extended-models",
+        "public-object",
+        "simple-fhir:no-custom-config",
+        "response-property",
+        "inferred-auth-explicit",
+        "audiences",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 329
+    },
+    {
+      "fixtures": [
+        "alias-extends:no-custom-config",
+        "circular-references-advanced:no-custom-config",
+        "validation",
+        "custom-auth",
+        "undiscriminated-unions",
+        "variables",
+        "client-side-params",
+        "single-url-environment-no-default",
+        "idempotency-headers",
+        "literal",
+        "exhaustive:include-validators"
+      ],
+      "groupTotalTimeSeconds": 329
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "circular-references-advanced:no-inheritance-for-extended-models",
+        "websocket",
+        "empty-clients",
+        "license",
+        "package-yml",
+        "path-parameters",
+        "single-url-environment-default",
+        "any-auth",
+        "enum"
+      ],
+      "groupTotalTimeSeconds": 316
+    },
+    {
+      "fixtures": [
+        "version",
+        "unions:no-inheritance-for-extended-models",
+        "auth-environment-variables",
+        "nullable-optional",
+        "oauth-client-credentials-custom",
+        "pagination:no-custom-config",
+        "property-access",
+        "mixed-file-directory",
+        "query-parameters",
+        "server-sent-event-examples",
+        "exhaustive:frozen_utils"
+      ],
+      "groupTotalTimeSeconds": 326
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "query-parameters-openapi",
+        "unions:no-custom-config",
+        "unknown",
+        "oauth-client-credentials-default",
+        "pagination-custom",
+        "error-property",
+        "objects-with-imports",
+        "http-head",
+        "file-download:no-inheritance-for-extended-models"
+      ],
+      "groupTotalTimeSeconds": 316
+    },
+    {
+      "fixtures": [
+        "alias",
+        "exhaustive:no-custom-config",
+        "bytes-download",
+        "multi-url-environment-no-default",
+        "no-environment",
+        "oauth-client-credentials-nested-root",
+        "extra-properties",
+        "inferred-auth-implicit",
+        "reserved-keywords",
+        "server-sent-events",
+        "cross-package-type-names"
+      ],
+      "groupTotalTimeSeconds": 328
+    },
+    {
+      "fixtures": [
+        "alias-extends:no-inheritance-for-extended-models",
+        "exhaustive:pydantic-v2",
+        "bytes-upload",
+        "nullable",
+        "oauth-client-credentials-environment-variables",
+        "optional",
+        "literals-unions",
+        "inferred-auth-implicit-no-expiry",
+        "file-upload",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 316
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "exhaustive:ignore-extra-fields",
+        "basic-auth-environment-variables",
+        "exhaustive:skip-formatting",
+        "plain-text",
+        "errors",
+        "imdb:v1_on_v2",
+        "oauth-client-credentials-with-variables",
+        "imdb:no-custom-config",
+        "websocket-inferred-auth"
+      ],
+      "groupTotalTimeSeconds": 316
+    },
+    {
+      "fixtures": [
+        "extends",
+        "file-download:no-custom-config",
+        "circular-references:no-custom-config",
+        "oauth-client-credentials",
+        "object",
+        "pagination:no-inheritance-for-extended-models",
+        "multi-url-environment",
+        "multiple-request-bodies",
+        "simple-api",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 318
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/go-fiber-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-fiber-seed-groups.json
@@ -1,0 +1,135 @@
+{
+  "totalTestTimeSeconds": 4107,
+  "groups": [
+    {
+      "fixtures": [
+        "accept-header",
+        "go-bytes-request",
+        "error-property",
+        "oauth-client-credentials-default",
+        "variables",
+        "exhaustive",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 414
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "alias-extends",
+        "public-object",
+        "simple-fhir",
+        "server-sent-event-examples",
+        "errors",
+        "multiple-request-bodies",
+        "pagination-custom",
+        "circular-references",
+        "circular-references-advanced",
+        "package-yml",
+        "streaming:.",
+        "pagination",
+        "custom-auth",
+        "extra-properties",
+        "streaming-parameter",
+        "any-auth",
+        "folders",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 413
+    },
+    {
+      "fixtures": [
+        "version",
+        "nullable",
+        "query-parameters",
+        "path-parameters",
+        "plain-text",
+        "trace",
+        "multi-line-docs",
+        "no-environment",
+        "server-sent-events",
+        "inferred-auth-implicit-no-expiry",
+        "response-property",
+        "basic-auth",
+        "multi-url-environment",
+        "simple-api",
+        "inferred-auth-explicit",
+        "enum",
+        "websocket",
+        "go-content-type",
+        "request-parameters"
+      ],
+      "groupTotalTimeSeconds": 411
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "client-side-params",
+        "nullable-optional",
+        "optional",
+        "property-access",
+        "websocket-inferred-auth",
+        "multi-url-environment-no-default",
+        "object",
+        "unions",
+        "mixed-case",
+        "single-url-environment-default",
+        "inferred-auth-implicit",
+        "oauth-client-credentials",
+        "unknown",
+        "mixed-file-directory",
+        "literals-unions",
+        "websocket-bearer-auth",
+        "idempotency-headers:."
+      ],
+      "groupTotalTimeSeconds": 409
+    },
+    {
+      "fixtures": ["alias", "content-type", "oauth-client-credentials-nested-root", "basic-auth-environment-variables"],
+      "groupTotalTimeSeconds": 409
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "extends",
+        "oauth-client-credentials-with-variables",
+        "cross-package-type-names"
+      ],
+      "groupTotalTimeSeconds": 409
+    },
+    {
+      "fixtures": ["auth-environment-variables", "file-download", "single-url-environment-no-default", "http-head"],
+      "groupTotalTimeSeconds": 409
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "query-parameters-openapi-as-objects",
+        "undiscriminated-unions",
+        "imdb"
+      ],
+      "groupTotalTimeSeconds": 409
+    },
+    {
+      "fixtures": [
+        "bytes-download",
+        "file-upload",
+        "oauth-client-credentials-environment-variables",
+        "audiences",
+        "objects-with-imports"
+      ],
+      "groupTotalTimeSeconds": 415
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "examples",
+        "empty-clients",
+        "oauth-client-credentials-custom",
+        "validation",
+        "license"
+      ],
+      "groupTotalTimeSeconds": 409
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/go-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-model-seed-groups.json
@@ -1,0 +1,115 @@
+{
+  "totalTestTimeSeconds": 4225,
+  "groups": [
+    {
+      "fixtures": [
+        "version",
+        "nullable",
+        "errors",
+        "multiple-request-bodies",
+        "path-parameters",
+        "multi-line-docs",
+        "server-sent-event-examples",
+        "optional",
+        "idempotency-headers:.",
+        "pagination",
+        "error-property",
+        "public-object",
+        "custom-auth",
+        "objects-with-imports",
+        "imdb",
+        "inferred-auth-implicit"
+      ],
+      "groupTotalTimeSeconds": 422
+    },
+    {
+      "fixtures": ["accept-header", "extends", "mixed-file-directory", "literal"],
+      "groupTotalTimeSeconds": 422
+    },
+    {
+      "fixtures": ["alias", "file-download", "oauth-client-credentials-default", "variables"],
+      "groupTotalTimeSeconds": 422
+    },
+    {
+      "fixtures": ["alias-extends", "go-bytes-request", "oauth-client-credentials-with-variables", "websocket"],
+      "groupTotalTimeSeconds": 422
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "object",
+        "circular-references",
+        "response-property",
+        "bytes-download",
+        "multi-url-environment",
+        "server-sent-events",
+        "simple-fhir",
+        "oauth-client-credentials-custom",
+        "simple-api",
+        "folders",
+        "single-url-environment-default",
+        "examples",
+        "query-parameters",
+        "undiscriminated-unions",
+        "reserved-keywords",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 426
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "plain-text",
+        "client-side-params",
+        "websocket-inferred-auth",
+        "request-parameters",
+        "multi-url-environment-no-default",
+        "literals-unions",
+        "mixed-case",
+        "streaming:.",
+        "single-url-environment-no-default",
+        "inferred-auth-implicit-no-expiry",
+        "streaming-parameter",
+        "extra-properties",
+        "unions",
+        "unknown",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 421
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "property-access",
+        "pagination-custom",
+        "circular-references-advanced",
+        "nullable-optional",
+        "license",
+        "package-yml",
+        "no-environment",
+        "http-head",
+        "oauth-client-credentials-environment-variables",
+        "audiences",
+        "oauth-client-credentials",
+        "cross-package-type-names",
+        "oauth-client-credentials-nested-root",
+        "validation",
+        "enum",
+        "basic-auth"
+      ],
+      "groupTotalTimeSeconds": 426
+    },
+    {
+      "fixtures": ["api-wide-base-path", "bytes-upload", "any-auth", "websocket-bearer-auth"],
+      "groupTotalTimeSeconds": 422
+    },
+    {
+      "fixtures": ["auth-environment-variables", "content-type", "basic-auth-environment-variables", "go-content-type"],
+      "groupTotalTimeSeconds": 421
+    },
+    {
+      "fixtures": ["bearer-token-environment-variable", "file-upload", "empty-clients", "inferred-auth-explicit"],
+      "groupTotalTimeSeconds": 421
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/go-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-sdk-seed-groups.json
@@ -1,0 +1,166 @@
+{
+  "totalTestTimeSeconds": 9459,
+  "groups": [
+    {
+      "fixtures": [
+        "accept-header",
+        "imdb:with-wiremock-tests",
+        "package-yml:no-custom-config",
+        "path-parameters:v0",
+        "multi-url-environment",
+        "nullable",
+        "single-url-environment-no-default",
+        "objects-with-imports",
+        "client-side-params",
+        "idempotency-headers:.",
+        "examples:package-path",
+        "unions:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 944
+    },
+    {
+      "fixtures": [
+        "version",
+        "path-parameters:with-wire-tests",
+        "extra-properties",
+        "path-parameters:no-custom-config",
+        "path-parameters:package-name",
+        "imdb:deep-package-path",
+        "undiscriminated-unions:v0",
+        "inferred-auth-implicit-no-expiry",
+        "server-sent-events",
+        "query-parameters",
+        "basic-auth",
+        "alias-extends",
+        "unions:package-name"
+      ],
+      "groupTotalTimeSeconds": 946
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "file-upload:package-name",
+        "error-property",
+        "multiple-request-bodies",
+        "oauth-client-credentials-nested-root",
+        "oauth-client-credentials-custom",
+        "websocket",
+        "server-sent-event-examples",
+        "examples:client-name-with-custom-constructor-name",
+        "circular-references-advanced",
+        "unions:v0"
+      ],
+      "groupTotalTimeSeconds": 950
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "examples:always-send-required-properties",
+        "response-property",
+        "mixed-case:no-custom-config",
+        "mixed-case:default-values",
+        "mixed-file-directory",
+        "unknown",
+        "public-object",
+        "any-auth",
+        "circular-references",
+        "empty-clients"
+      ],
+      "groupTotalTimeSeconds": 954
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "examples:no-custom-config",
+        "errors",
+        "license",
+        "inferred-auth-explicit",
+        "literals-unions:no-custom-config",
+        "undiscriminated-unions:no-custom-config",
+        "enum",
+        "basic-auth-environment-variables",
+        "examples:exported-client-name",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 952
+    },
+    {
+      "fixtures": [
+        "alias",
+        "version-no-default",
+        "imdb:no-custom-config",
+        "oauth-client-credentials",
+        "streaming:.",
+        "oauth-client-credentials-environment-variables",
+        "go-bytes-request:no-custom-config",
+        "examples:v0",
+        "examples:export-all-requests-at-root",
+        "examples:client-name"
+      ],
+      "groupTotalTimeSeconds": 943
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "bearer-token-environment-variable",
+        "nullable-optional",
+        "oauth-client-credentials-default",
+        "go-content-type",
+        "single-url-environment-default",
+        "go-bytes-request:use-reader-for-bytes-request",
+        "plain-text",
+        "bytes-download",
+        "examples:readme-config"
+      ],
+      "groupTotalTimeSeconds": 946
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "content-type",
+        "optional",
+        "oauth-client-credentials-with-variables",
+        "http-head",
+        "validation",
+        "multi-url-environment-no-default",
+        "property-access",
+        "exhaustive",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 942
+    },
+    {
+      "fixtures": [
+        "extends",
+        "file-upload:v0",
+        "pagination",
+        "simple-api",
+        "imdb:package-path",
+        "audiences",
+        "cross-package-type-names",
+        "folders",
+        "examples:getters-pass-by-value",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 943
+    },
+    {
+      "fixtures": [
+        "file-upload:no-custom-config",
+        "file-download",
+        "multi-line-docs",
+        "no-environment",
+        "simple-fhir",
+        "object",
+        "websocket-inferred-auth",
+        "inferred-auth-implicit",
+        "custom-auth",
+        "literal",
+        "streaming-parameter",
+        "pagination-custom",
+        "request-parameters"
+      ],
+      "groupTotalTimeSeconds": 939
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/java-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/java-model-seed-groups.json
@@ -1,0 +1,150 @@
+{
+  "totalTestTimeSeconds": 29186,
+  "groups": [
+    {
+      "fixtures": [
+        "java-inline-types",
+        "simple-api",
+        "api-wide-base-path",
+        "oauth-client-credentials",
+        "oauth-client-credentials-with-variables",
+        "error-property",
+        "errors",
+        "query-parameters",
+        "request-parameters",
+        "simple-fhir"
+      ],
+      "groupTotalTimeSeconds": 2958
+    },
+    {
+      "fixtures": [
+        "nullable-optional",
+        "version",
+        "accept-header",
+        "file-upload",
+        "optional",
+        "path-parameters",
+        "undiscriminated-unions",
+        "http-head",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 2879
+    },
+    {
+      "fixtures": [
+        "websocket-bearer-auth",
+        "java-nullable-named-request-types",
+        "inferred-auth-explicit",
+        "content-type",
+        "response-property",
+        "extra-properties",
+        "websocket",
+        "unknown",
+        "mixed-file-directory"
+      ],
+      "groupTotalTimeSeconds": 2877
+    },
+    {
+      "fixtures": [
+        "any-auth",
+        "version-no-default",
+        "auth-environment-variables",
+        "java-builder-extension",
+        "java-custom-package-prefix",
+        "multi-url-environment-no-default",
+        "basic-auth",
+        "oauth-client-credentials-custom",
+        "empty-clients",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 2943
+    },
+    {
+      "fixtures": [
+        "literals-unions",
+        "file-download",
+        "unions",
+        "bytes-download",
+        "oauth-client-credentials-nested-root",
+        "custom-auth",
+        "imdb:disable-required-property-builder-checks",
+        "pagination",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 2885
+    },
+    {
+      "fixtures": [
+        "object",
+        "websocket-inferred-auth",
+        "single-url-environment-default",
+        "bearer-token-environment-variable",
+        "circular-references-advanced",
+        "package-yml",
+        "variables",
+        "imdb:enable-public-constructors",
+        "streaming"
+      ],
+      "groupTotalTimeSeconds": 2888
+    },
+    {
+      "fixtures": [
+        "multiple-request-bodies",
+        "circular-references",
+        "query-parameters-openapi",
+        "inferred-auth-implicit-no-expiry",
+        "license",
+        "client-side-params",
+        "validation",
+        "literal",
+        "cross-package-type-names",
+        "alias-extends"
+      ],
+      "groupTotalTimeSeconds": 2949
+    },
+    {
+      "fixtures": [
+        "plain-text",
+        "java-single-property-endpoint",
+        "server-sent-event-examples",
+        "extends",
+        "oauth-client-credentials-default",
+        "pagination-custom",
+        "property-access",
+        "oauth-client-credentials-environment-variables",
+        "single-url-environment-no-default",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 2956
+    },
+    {
+      "fixtures": [
+        "mixed-case",
+        "multi-url-environment",
+        "bytes-upload",
+        "public-object",
+        "objects-with-imports",
+        "multi-line-docs",
+        "enum",
+        "streaming-parameter",
+        "audiences",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 2955
+    },
+    {
+      "fixtures": [
+        "java-pagination-deep-cursor-path",
+        "no-environment",
+        "alias",
+        "query-parameters-openapi-as-objects",
+        "nullable",
+        "basic-auth-environment-variables",
+        "inferred-auth-implicit",
+        "trace",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 2896
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/java-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/java-sdk-seed-groups.json
@@ -1,0 +1,175 @@
+{
+  "totalTestTimeSeconds": 51121,
+  "groups": [
+    {
+      "fixtures": [
+        "trace",
+        "public-object",
+        "nullable:no-custom-config",
+        "java-pagination-deep-cursor-path:wire-tests",
+        "error-property",
+        "exhaustive:custom-license",
+        "exhaustive:enable-public-constructors",
+        "validation",
+        "nullable-optional:with-nullable-annotation",
+        "extra-properties",
+        "path-parameters"
+      ],
+      "groupTotalTimeSeconds": 5092
+    },
+    {
+      "fixtures": [
+        "version:no-custom-config",
+        "file-download",
+        "variables",
+        "java-inline-types:no-inline",
+        "alias",
+        "examples:default",
+        "java-pagination-deep-cursor-path",
+        "examples:no-custom-config",
+        "http-head",
+        "enum:no-custom-config",
+        "property-access",
+        "bytes-download"
+      ],
+      "groupTotalTimeSeconds": 5155
+    },
+    {
+      "fixtures": [
+        "java-nullable-named-request-types:custom-config",
+        "java-single-property-endpoint",
+        "nullable:wrapped-aliases",
+        "errors",
+        "literal",
+        "no-environment",
+        "exhaustive:json-include-non-empty",
+        "basic-auth-environment-variables",
+        "client-side-params:default",
+        "enum:forward-compatible-enums",
+        "oauth-client-credentials",
+        "pagination-custom"
+      ],
+      "groupTotalTimeSeconds": 5081
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "multi-url-environment",
+        "circular-references",
+        "query-parameters-openapi",
+        "java-builder-extension:base-client",
+        "java-inline-types:no-wrapped-aliases",
+        "imdb:disable-required-property-builder-checks",
+        "java-builder-extension:extensible-builders",
+        "basic-auth",
+        "oauth-client-credentials-nested-root",
+        "reserved-keywords",
+        "exhaustive:local-files"
+      ],
+      "groupTotalTimeSeconds": 5134
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "single-url-environment-default",
+        "multiple-request-bodies",
+        "java-custom-package-prefix",
+        "multi-line-docs",
+        "folders",
+        "file-upload:no-custom-config",
+        "streaming",
+        "websocket",
+        "objects-with-imports",
+        "exhaustive:custom-client-class-name",
+        "alias-extends"
+      ],
+      "groupTotalTimeSeconds": 5154
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "circular-references-advanced",
+        "package-yml",
+        "query-parameters-openapi-as-objects",
+        "version-no-default",
+        "exhaustive:custom-error-names",
+        "pagination:default",
+        "idempotency-headers",
+        "server-sent-event-examples",
+        "unions:default",
+        "request-parameters",
+        "websocket-inferred-auth"
+      ],
+      "groupTotalTimeSeconds": 5081
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "query-parameters",
+        "custom-auth",
+        "mixed-file-directory",
+        "multi-url-environment-no-default",
+        "file-upload:wrapped-aliases",
+        "mixed-case",
+        "unknown",
+        "cross-package-type-names",
+        "server-sent-events",
+        "empty-clients",
+        "streaming-parameter",
+        "inferred-auth-implicit"
+      ],
+      "groupTotalTimeSeconds": 5082
+    },
+    {
+      "fixtures": [
+        "oauth-client-credentials-environment-variables",
+        "nullable-optional:legacy",
+        "license",
+        "accept-header",
+        "java-inline-types:enable-forward-compatible-enums",
+        "exhaustive:forward-compatible-enums",
+        "undiscriminated-unions",
+        "examples:inline-file-properties",
+        "exhaustive:custom-dependency",
+        "file-upload:inline-file-properties",
+        "exhaustive:signed_publish"
+      ],
+      "groupTotalTimeSeconds": 5091
+    },
+    {
+      "fixtures": [
+        "simple-fhir",
+        "oauth-client-credentials-default",
+        "any-auth",
+        "literals-unions",
+        "object",
+        "audiences",
+        "examples:readme-config",
+        "imdb:flat-package-layout",
+        "websocket-bearer-auth",
+        "oauth-client-credentials-custom",
+        "plain-text",
+        "inferred-auth-explicit",
+        "inferred-auth-implicit-no-expiry"
+      ],
+      "groupTotalTimeSeconds": 5082
+    },
+    {
+      "fixtures": [
+        "single-url-environment-no-default",
+        "extends",
+        "response-property",
+        "oauth-client-credentials-with-variables",
+        "version:forward-compatible-enums",
+        "content-type",
+        "java-inline-types:inline",
+        "simple-api",
+        "exhaustive:no-custom-config",
+        "exhaustive:flat-package-layout",
+        "optional",
+        "exhaustive:publish-to"
+      ],
+      "groupTotalTimeSeconds": 5169
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/java-spring-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/java-spring-seed-groups.json
@@ -1,0 +1,151 @@
+{
+  "totalTestTimeSeconds": 2184,
+  "groups": [
+    {
+      "fixtures": [
+        "trace",
+        "circular-references",
+        "inferred-auth-implicit-no-expiry",
+        "simple-api",
+        "validation",
+        "error-property",
+        "oauth-client-credentials-nested-root",
+        "license"
+      ],
+      "groupTotalTimeSeconds": 212
+    },
+    {
+      "fixtures": [
+        "nullable-optional:with-nullable-annotation",
+        "bytes-download",
+        "file-upload",
+        "oauth-client-credentials",
+        "custom-auth",
+        "pagination-custom",
+        "java-pagination-deep-cursor-path",
+        "oauth-client-credentials-with-variables",
+        "audiences",
+        "literals-unions"
+      ],
+      "groupTotalTimeSeconds": 224
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "alias",
+        "java-inline-types",
+        "undiscriminated-unions",
+        "empty-clients",
+        "path-parameters",
+        "multiple-request-bodies",
+        "server-sent-events",
+        "cross-package-type-names",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 223
+    },
+    {
+      "fixtures": [
+        "content-type:package-prefix",
+        "api-wide-base-path",
+        "nullable",
+        "basic-auth",
+        "oauth-client-credentials-custom",
+        "property-access",
+        "objects-with-imports",
+        "single-url-environment-default",
+        "examples",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 223
+    },
+    {
+      "fixtures": [
+        "java-nullable-named-request-types",
+        "auth-environment-variables",
+        "request-parameters",
+        "inferred-auth-explicit",
+        "oauth-client-credentials-default",
+        "query-parameters",
+        "package-yml",
+        "unknown",
+        "imdb:enable-public-constructors",
+        "no-environment"
+      ],
+      "groupTotalTimeSeconds": 223
+    },
+    {
+      "fixtures": [
+        "nullable-optional:legacy",
+        "bearer-token-environment-variable",
+        "pagination",
+        "circular-references-advanced",
+        "reserved-keywords",
+        "response-property",
+        "single-url-environment-no-default",
+        "public-object",
+        "java-builder-extension",
+        "http-head"
+      ],
+      "groupTotalTimeSeconds": 221
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "extends",
+        "errors",
+        "any-auth",
+        "mixed-case",
+        "multi-url-environment",
+        "websocket",
+        "enum",
+        "optional",
+        "imdb:disable-required-property-builder-checks"
+      ],
+      "groupTotalTimeSeconds": 220
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "simple-fhir",
+        "exhaustive",
+        "websocket-inferred-auth",
+        "multi-line-docs",
+        "oauth-client-credentials-environment-variables",
+        "websocket-bearer-auth",
+        "java-custom-package-prefix",
+        "plain-text",
+        "file-download"
+      ],
+      "groupTotalTimeSeconds": 216
+    },
+    {
+      "fixtures": [
+        "version",
+        "client-side-params",
+        "unions",
+        "basic-auth-environment-variables",
+        "multi-url-environment-no-default",
+        "object",
+        "extra-properties",
+        "mixed-file-directory",
+        "java-single-property-endpoint"
+      ],
+      "groupTotalTimeSeconds": 211
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "alias-extends",
+        "bytes-upload",
+        "inferred-auth-implicit",
+        "server-sent-event-examples",
+        "streaming-parameter",
+        "streaming",
+        "literal",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 211
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/openapi-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/openapi-seed-groups.json
@@ -1,0 +1,148 @@
+{
+  "totalTestTimeSeconds": 1069,
+  "groups": [
+    {
+      "fixtures": [
+        "version",
+        "objects-with-imports",
+        "pagination",
+        "nullable-optional",
+        "inferred-auth-implicit",
+        "inferred-auth-implicit-no-expiry",
+        "imdb:json-format",
+        "property-access",
+        "response-property",
+        "multi-url-environment",
+        "error-property"
+      ],
+      "groupTotalTimeSeconds": 107
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "bytes-upload",
+        "websocket-inferred-auth",
+        "path-parameters",
+        "oauth-client-credentials-custom",
+        "basic-auth-environment-variables",
+        "streaming-parameter",
+        "validation"
+      ],
+      "groupTotalTimeSeconds": 107
+    },
+    {
+      "fixtures": [
+        "alias",
+        "file-upload",
+        "trace",
+        "optional",
+        "literals-unions",
+        "simple-api",
+        "undiscriminated-unions",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 107
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "oauth-client-credentials-nested-root",
+        "inferred-auth-explicit",
+        "oauth-client-credentials-with-variables",
+        "literal",
+        "mixed-case",
+        "license",
+        "server-sent-events",
+        "single-url-environment-no-default",
+        "request-parameters",
+        "extra-properties"
+      ],
+      "groupTotalTimeSeconds": 107
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "oauth-client-credentials-default",
+        "enum:custom-overrides",
+        "mixed-file-directory",
+        "audiences",
+        "examples",
+        "imdb:no-custom-config",
+        "pagination-custom",
+        "public-object",
+        "imdb:override",
+        "websocket"
+      ],
+      "groupTotalTimeSeconds": 107
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "oauth-client-credentials-environment-variables",
+        "exhaustive",
+        "nullable",
+        "enum:no-custom-config",
+        "folders",
+        "imdb:custom-filename",
+        "plain-text",
+        "query-parameters",
+        "imdb:custom-overrides",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 107
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "bytes-download",
+        "empty-clients",
+        "idempotency-headers",
+        "object",
+        "multiple-request-bodies",
+        "unions",
+        "custom-auth",
+        "multi-line-docs"
+      ],
+      "groupTotalTimeSeconds": 109
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "content-type",
+        "circular-references-advanced",
+        "simple-fhir",
+        "package-yml",
+        "oauth-client-credentials",
+        "any-auth",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 106
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "extends",
+        "client-side-params",
+        "circular-references",
+        "multi-url-environment-no-default",
+        "single-url-environment-default",
+        "basic-auth",
+        "server-sent-event-examples"
+      ],
+      "groupTotalTimeSeconds": 106
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "file-download",
+        "cross-package-type-names",
+        "http-head",
+        "no-environment",
+        "streaming",
+        "errors",
+        "unknown"
+      ],
+      "groupTotalTimeSeconds": 106
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/php-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/php-model-seed-groups.json
@@ -1,0 +1,143 @@
+{
+  "totalTestTimeSeconds": 4238,
+  "groups": [
+    {
+      "fixtures": [
+        "version-no-default",
+        "nullable",
+        "mixed-case",
+        "basic-auth-environment-variables",
+        "license",
+        "server-sent-events",
+        "any-auth",
+        "custom-auth",
+        "enum"
+      ],
+      "groupTotalTimeSeconds": 426
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "unions",
+        "inferred-auth-explicit",
+        "multi-url-environment",
+        "query-parameters",
+        "multi-url-environment-no-default",
+        "errors",
+        "literals-unions",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 424
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "client-side-params",
+        "basic-auth",
+        "circular-references-advanced",
+        "oauth-client-credentials-environment-variables",
+        "variables",
+        "http-head",
+        "public-object",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 424
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "nullable-optional",
+        "empty-clients",
+        "extra-properties",
+        "oauth-client-credentials-nested-root",
+        "multi-line-docs",
+        "error-property",
+        "imdb",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 426
+    },
+    {
+      "fixtures": [
+        "extends",
+        "file-download",
+        "objects-with-imports",
+        "websocket-bearer-auth",
+        "unknown",
+        "pagination-custom",
+        "plain-text",
+        "optional",
+        "cross-package-type-names"
+      ],
+      "groupTotalTimeSeconds": 432
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "bytes-upload",
+        "inferred-auth-implicit",
+        "oauth-client-credentials-default",
+        "request-parameters",
+        "oauth-client-credentials-with-variables",
+        "idempotency-headers",
+        "server-sent-event-examples",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 430
+    },
+    {
+      "fixtures": [
+        "file-upload",
+        "content-type",
+        "oauth-client-credentials-custom",
+        "single-url-environment-no-default",
+        "reserved-keywords",
+        "object",
+        "oauth-client-credentials",
+        "streaming",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 429
+    },
+    {
+      "fixtures": [
+        "alias",
+        "auth-environment-variables",
+        "property-access",
+        "websocket-inferred-auth",
+        "no-environment",
+        "path-parameters",
+        "response-property",
+        "single-url-environment-default"
+      ],
+      "groupTotalTimeSeconds": 408
+    },
+    {
+      "fixtures": [
+        "version",
+        "bytes-download",
+        "simple-fhir",
+        "circular-references",
+        "websocket",
+        "undiscriminated-unions",
+        "simple-api",
+        "mixed-file-directory",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 431
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "api-wide-base-path",
+        "streaming-parameter",
+        "inferred-auth-implicit-no-expiry",
+        "multiple-request-bodies",
+        "package-yml",
+        "pagination",
+        "validation"
+      ],
+      "groupTotalTimeSeconds": 408
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/php-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/php-sdk-seed-groups.json
@@ -1,0 +1,157 @@
+{
+  "totalTestTimeSeconds": 8100,
+  "groups": [
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "pagination:property-accessors",
+        "path-parameters:inline-path-parameters",
+        "oauth-client-credentials-custom",
+        "path-parameters:inline-path-parameters-private",
+        "imdb:clientName",
+        "property-access",
+        "server-sent-events",
+        "public-object",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 822
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "nullable",
+        "pagination:no-custom-config",
+        "enum",
+        "websocket-inferred-auth",
+        "objects-with-imports",
+        "query-parameters:no-custom-config",
+        "single-url-environment-no-default",
+        "streaming-parameter",
+        "circular-references-advanced"
+      ],
+      "groupTotalTimeSeconds": 821
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "any-auth",
+        "errors",
+        "alias:composer-json",
+        "response-property",
+        "multi-line-docs",
+        "reserved-keywords",
+        "audiences",
+        "cross-package-type-names",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 822
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "inferred-auth-explicit",
+        "custom-auth",
+        "mixed-case",
+        "imdb:no-custom-config",
+        "imdb:packageName",
+        "imdb:private",
+        "package-yml:no-custom-config",
+        "literals-unions",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 784
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "inferred-auth-implicit",
+        "unions:no-custom-config",
+        "oauth-client-credentials-with-variables",
+        "license",
+        "inferred-auth-implicit-no-expiry",
+        "imdb:package-path",
+        "simple-api",
+        "single-url-environment-default",
+        "multi-url-environment",
+        "multi-url-environment-no-default",
+        "pagination-custom"
+      ],
+      "groupTotalTimeSeconds": 768
+    },
+    {
+      "fixtures": [
+        "version",
+        "unions:property-accessors",
+        "oauth-client-credentials-default",
+        "client-side-params",
+        "validation",
+        "file-upload",
+        "nullable-optional",
+        "unknown",
+        "empty-clients",
+        "examples:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 815
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "extends:private",
+        "oauth-client-credentials-environment-variables",
+        "path-parameters:no-custom-config",
+        "request-parameters",
+        "server-sent-event-examples",
+        "basic-auth",
+        "plain-text",
+        "http-head",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 813
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "file-download",
+        "oauth-client-credentials-nested-root",
+        "query-parameters:private",
+        "alias:no-custom-config",
+        "undiscriminated-unions",
+        "multiple-request-bodies",
+        "variables",
+        "object",
+        "examples:readme-config"
+      ],
+      "groupTotalTimeSeconds": 812
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "bytes-download",
+        "error-property",
+        "imdb:namespace",
+        "extra-properties",
+        "oauth-client-credentials",
+        "optional",
+        "websocket",
+        "circular-references",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 822
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "version-no-default",
+        "basic-auth-environment-variables",
+        "no-environment",
+        "mixed-file-directory",
+        "idempotency-headers",
+        "package-yml:private",
+        "simple-fhir",
+        "extends:no-custom-config",
+        "streaming"
+      ],
+      "groupTotalTimeSeconds": 821
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/postman-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/postman-seed-groups.json
@@ -1,0 +1,144 @@
+{
+  "totalTestTimeSeconds": 960,
+  "groups": [
+    {
+      "fixtures": [
+        "accept-header",
+        "file-upload",
+        "inferred-auth-explicit",
+        "property-access",
+        "circular-references-advanced",
+        "oauth-client-credentials-default",
+        "websocket",
+        "simple-api"
+      ],
+      "groupTotalTimeSeconds": 96
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "pagination",
+        "oauth-client-credentials-with-variables",
+        "examples",
+        "multiple-request-bodies",
+        "error-property",
+        "oauth-client-credentials-custom",
+        "package-yml",
+        "websocket-bearer-auth",
+        "validation"
+      ],
+      "groupTotalTimeSeconds": 96
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "oauth-client-credentials-environment-variables",
+        "mixed-file-directory",
+        "trace",
+        "inferred-auth-implicit",
+        "http-head",
+        "objects-with-imports",
+        "pagination-custom",
+        "custom-auth",
+        "request-parameters"
+      ],
+      "groupTotalTimeSeconds": 96
+    },
+    {
+      "fixtures": [
+        "version",
+        "audiences",
+        "enum",
+        "nullable",
+        "folders",
+        "oauth-client-credentials",
+        "optional",
+        "path-parameters",
+        "multi-line-docs",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 96
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "cross-package-type-names",
+        "literal",
+        "nullable-optional",
+        "imdb:no-custom-config",
+        "oauth-client-credentials-nested-root",
+        "public-object",
+        "response-property",
+        "multi-url-environment",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 96
+    },
+    {
+      "fixtures": [
+        "alias",
+        "bytes-download",
+        "license",
+        "imdb:collection-name",
+        "websocket-inferred-auth",
+        "simple-fhir",
+        "query-parameters",
+        "undiscriminated-unions"
+      ],
+      "groupTotalTimeSeconds": 96
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "bytes-upload",
+        "mixed-case",
+        "inferred-auth-implicit-no-expiry",
+        "any-auth",
+        "errors",
+        "single-url-environment-default",
+        "unknown"
+      ],
+      "groupTotalTimeSeconds": 96
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "content-type",
+        "no-environment",
+        "literals-unions",
+        "basic-auth",
+        "extra-properties",
+        "single-url-environment-no-default",
+        "empty-clients",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 98
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "extends",
+        "client-side-params",
+        "object",
+        "basic-auth-environment-variables",
+        "idempotency-headers",
+        "streaming",
+        "server-sent-event-examples"
+      ],
+      "groupTotalTimeSeconds": 95
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "file-download",
+        "exhaustive",
+        "plain-text",
+        "circular-references",
+        "multi-url-environment-no-default",
+        "unions",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 95
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/pydantic-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/pydantic-seed-groups.json
@@ -1,0 +1,151 @@
+{
+  "totalTestTimeSeconds": 4637,
+  "groups": [
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "nullable",
+        "nullable-optional",
+        "circular-references:no-custom-config",
+        "property-access",
+        "circular-references-advanced:no-inheritance-for-extended-models",
+        "single-url-environment-default",
+        "circular-references:no-inheritance-for-extended-models",
+        "mixed-file-directory",
+        "cross-package-type-names"
+      ],
+      "groupTotalTimeSeconds": 480
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "unions:no-custom-config",
+        "oauth-client-credentials",
+        "extra-properties",
+        "mixed-case",
+        "circular-references-advanced:no-custom-config",
+        "simple-api",
+        "websocket-bearer-auth",
+        "license",
+        "pagination-custom"
+      ],
+      "groupTotalTimeSeconds": 480
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "bytes-upload",
+        "errors",
+        "any-auth",
+        "reserved-keywords",
+        "package-yml",
+        "inferred-auth-implicit-no-expiry",
+        "streaming",
+        "folders",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 480
+    },
+    {
+      "fixtures": [
+        "alias",
+        "content-type",
+        "multiple-request-bodies",
+        "basic-auth-environment-variables",
+        "server-sent-events",
+        "pagination:no-custom-config",
+        "multi-url-environment",
+        "oauth-client-credentials-default",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 443
+    },
+    {
+      "fixtures": [
+        "alias-extends:no-custom-config",
+        "extends",
+        "simple-fhir:no-custom-config",
+        "error-property",
+        "unknown",
+        "pagination:no-inheritance-for-extended-models",
+        "no-environment",
+        "oauth-client-credentials-with-variables",
+        "enum",
+        "exhaustive:pydantic-v2"
+      ],
+      "groupTotalTimeSeconds": 475
+    },
+    {
+      "fixtures": [
+        "alias-extends:no-inheritance-for-extended-models",
+        "file-download:no-custom-config",
+        "undiscriminated-unions",
+        "inferred-auth-explicit",
+        "validation",
+        "path-parameters",
+        "response-property",
+        "objects-with-imports",
+        "literals-unions",
+        "exhaustive:pydantic-v1"
+      ],
+      "groupTotalTimeSeconds": 474
+    },
+    {
+      "fixtures": [
+        "version",
+        "oauth-client-credentials-custom",
+        "simple-fhir:no-inheritance-for-extended-models",
+        "inferred-auth-implicit",
+        "optional",
+        "empty-clients",
+        "single-url-environment-no-default",
+        "http-head",
+        "public-object"
+      ],
+      "groupTotalTimeSeconds": 442
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "oauth-client-credentials-environment-variables",
+        "unions:no-inheritance-for-extended-models",
+        "multi-line-docs",
+        "plain-text",
+        "multi-url-environment-no-default",
+        "streaming-parameter",
+        "idempotency-headers",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 442
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "bearer-token-environment-variable",
+        "client-side-params",
+        "object",
+        "websocket",
+        "request-parameters",
+        "server-sent-event-examples",
+        "file-upload",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 442
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "bytes-download",
+        "custom-auth",
+        "websocket-inferred-auth",
+        "basic-auth",
+        "oauth-client-credentials-nested-root",
+        "imdb",
+        "query-parameters",
+        "file-download:no-inheritance-for-extended-models",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 479
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/ruby-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-model-seed-groups.json
@@ -1,0 +1,144 @@
+{
+  "totalTestTimeSeconds": 2177,
+  "groups": [
+    {
+      "fixtures": [
+        "nullable-optional",
+        "bytes-upload",
+        "path-parameters",
+        "multi-line-docs",
+        "audiences",
+        "unknown",
+        "basic-auth-environment-variables",
+        "optional"
+      ],
+      "groupTotalTimeSeconds": 208
+    },
+    {
+      "fixtures": [
+        "unions",
+        "bytes-download",
+        "nullable",
+        "error-property",
+        "enum",
+        "websocket",
+        "server-sent-event-examples",
+        "query-parameters",
+        "public-object"
+      ],
+      "groupTotalTimeSeconds": 220
+    },
+    {
+      "fixtures": [
+        "client-side-params",
+        "bearer-token-environment-variable",
+        "simple-api",
+        "extra-properties",
+        "mixed-file-directory",
+        "cross-package-type-names",
+        "validation",
+        "inferred-auth-implicit-no-expiry",
+        "http-head"
+      ],
+      "groupTotalTimeSeconds": 219
+    },
+    {
+      "fixtures": [
+        "file-upload",
+        "query-parameters-openapi",
+        "file-download",
+        "object",
+        "oauth-client-credentials-with-variables",
+        "multi-url-environment-no-default",
+        "any-auth",
+        "single-url-environment-default",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 219
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "api-wide-base-path",
+        "inferred-auth-implicit",
+        "undiscriminated-unions",
+        "literal",
+        "examples",
+        "folders",
+        "single-url-environment-no-default",
+        "imdb"
+      ],
+      "groupTotalTimeSeconds": 219
+    },
+    {
+      "fixtures": [
+        "version",
+        "auth-environment-variables",
+        "oauth-client-credentials-default",
+        "errors",
+        "objects-with-imports",
+        "package-yml",
+        "websocket-bearer-auth",
+        "basic-auth",
+        "plain-text"
+      ],
+      "groupTotalTimeSeconds": 219
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "version-no-default",
+        "ruby-reserved-word-properties",
+        "streaming-parameter",
+        "streaming",
+        "pagination-custom",
+        "empty-clients",
+        "oauth-client-credentials",
+        "literals-unions"
+      ],
+      "groupTotalTimeSeconds": 219
+    },
+    {
+      "fixtures": [
+        "extends",
+        "accept-header",
+        "oauth-client-credentials-nested-root",
+        "custom-auth",
+        "oauth-client-credentials-environment-variables",
+        "multi-url-environment",
+        "exhaustive",
+        "reserved-keywords",
+        "circular-references"
+      ],
+      "groupTotalTimeSeconds": 218
+    },
+    {
+      "fixtures": [
+        "simple-fhir",
+        "alias",
+        "circular-references-advanced",
+        "response-property",
+        "mixed-case",
+        "property-access",
+        "server-sent-events",
+        "inferred-auth-explicit",
+        "license"
+      ],
+      "groupTotalTimeSeconds": 218
+    },
+    {
+      "fixtures": [
+        "trace",
+        "pagination",
+        "content-type",
+        "websocket-inferred-auth",
+        "oauth-client-credentials-custom",
+        "request-parameters",
+        "variables",
+        "multiple-request-bodies",
+        "no-environment"
+      ],
+      "groupTotalTimeSeconds": 218
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/ruby-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-sdk-seed-groups.json
@@ -1,0 +1,139 @@
+{
+  "totalTestTimeSeconds": 1143,
+  "groups": [
+    {
+      "fixtures": [
+        "accept-header",
+        "file-download",
+        "pagination-custom",
+        "variables",
+        "imdb",
+        "ruby-reserved-word-properties"
+      ],
+      "groupTotalTimeSeconds": 114
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "file-upload",
+        "property-access",
+        "websocket",
+        "mixed-file-directory",
+        "server-sent-event-examples"
+      ],
+      "groupTotalTimeSeconds": 114
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "nullable-optional",
+        "examples",
+        "circular-references",
+        "exhaustive:extra-deps",
+        "inferred-auth-explicit",
+        "literal",
+        "nullable",
+        "oauth-client-credentials-environment-variables",
+        "streaming",
+        "basic-auth-environment-variables",
+        "multi-url-environment-no-default",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 114
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "pagination",
+        "websocket-inferred-auth",
+        "circular-references-advanced",
+        "exhaustive:flattened-module-structure",
+        "inferred-auth-implicit",
+        "mixed-case",
+        "oauth-client-credentials",
+        "oauth-client-credentials-nested-root",
+        "streaming-parameter",
+        "cross-package-type-names",
+        "oauth-client-credentials-with-variables",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 114
+    },
+    {
+      "fixtures": [
+        "version",
+        "client-side-params",
+        "trace",
+        "empty-clients",
+        "undiscriminated-unions",
+        "inferred-auth-implicit-no-expiry",
+        "multi-line-docs",
+        "oauth-client-credentials-custom",
+        "objects-with-imports",
+        "unknown",
+        "custom-auth",
+        "object",
+        "http-head",
+        "multiple-request-bodies"
+      ],
+      "groupTotalTimeSeconds": 116
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "simple-fhir",
+        "unions",
+        "exhaustive:no-custom-config",
+        "enum",
+        "errors",
+        "license",
+        "multi-url-environment",
+        "oauth-client-credentials-default",
+        "query-parameters",
+        "websocket-bearer-auth",
+        "optional",
+        "literals-unions",
+        "no-environment"
+      ],
+      "groupTotalTimeSeconds": 116
+    },
+    {
+      "fixtures": [
+        "alias",
+        "bytes-download",
+        "response-property",
+        "any-auth",
+        "error-property",
+        "path-parameters",
+        "request-parameters"
+      ],
+      "groupTotalTimeSeconds": 116
+    },
+    {
+      "fixtures": ["api-wide-base-path", "bytes-upload", "simple-api", "audiences", "extra-properties", "plain-text"],
+      "groupTotalTimeSeconds": 113
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "content-type",
+        "single-url-environment-default",
+        "basic-auth",
+        "folders",
+        "public-object"
+      ],
+      "groupTotalTimeSeconds": 113
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "extends",
+        "package-yml",
+        "validation",
+        "idempotency-headers",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 113
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/ruby-sdk-v2-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-sdk-v2-seed-groups.json
@@ -1,0 +1,145 @@
+{
+  "totalTestTimeSeconds": 18096,
+  "groups": [
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "oauth-client-credentials-environment-variables",
+        "oauth-client-credentials-with-variables",
+        "response-property",
+        "public-object",
+        "single-url-environment-default",
+        "reserved-keywords",
+        "empty-clients",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 1797
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "pagination",
+        "package-yml",
+        "property-access",
+        "mixed-case",
+        "error-property",
+        "basic-auth",
+        "server-sent-event-examples",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 1791
+    },
+    {
+      "fixtures": [
+        "file-upload",
+        "oauth-client-credentials-nested-root",
+        "objects-with-imports",
+        "path-parameters",
+        "optional",
+        "server-sent-events",
+        "any-auth",
+        "basic-auth-environment-variables",
+        "examples:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 1797
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "version-no-default",
+        "extra-properties",
+        "undiscriminated-unions",
+        "unknown",
+        "idempotency-headers",
+        "streaming-parameter",
+        "circular-references-advanced",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 1830
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "client-side-params",
+        "simple-fhir",
+        "variables",
+        "oauth-client-credentials-custom",
+        "single-url-environment-no-default",
+        "no-environment",
+        "websocket-bearer-auth",
+        "enum"
+      ],
+      "groupTotalTimeSeconds": 1829
+    },
+    {
+      "fixtures": [
+        "file-download",
+        "alias-extends",
+        "nullable-optional",
+        "validation",
+        "websocket",
+        "multiple-request-bodies",
+        "literals-unions",
+        "websocket-inferred-auth",
+        "examples:readme-config"
+      ],
+      "groupTotalTimeSeconds": 1796
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "bytes-download",
+        "multi-url-environment",
+        "custom-auth",
+        "plain-text",
+        "http-head",
+        "license",
+        "ruby-reserved-word-properties",
+        "cross-package-type-names"
+      ],
+      "groupTotalTimeSeconds": 1805
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "version",
+        "errors",
+        "pagination-custom",
+        "inferred-auth-implicit-no-expiry",
+        "streaming",
+        "simple-api",
+        "circular-references",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 1797
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "query-parameters-openapi-as-objects",
+        "multi-url-environment-no-default",
+        "request-parameters",
+        "nullable",
+        "inferred-auth-implicit",
+        "unions",
+        "query-parameters",
+        "mixed-file-directory"
+      ],
+      "groupTotalTimeSeconds": 1838
+    },
+    {
+      "fixtures": [
+        "extends",
+        "alias",
+        "multi-line-docs",
+        "object",
+        "oauth-client-credentials",
+        "oauth-client-credentials-default",
+        "inferred-auth-explicit",
+        "imdb",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 1816
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/rust-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/rust-model-seed-groups.json
@@ -1,0 +1,143 @@
+{
+  "totalTestTimeSeconds": 757,
+  "groups": [
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "unions",
+        "pagination",
+        "basic-auth-environment-variables",
+        "objects-with-imports",
+        "inferred-auth-implicit",
+        "plain-text",
+        "http-head",
+        "reserved-keywords",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 76
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "client-side-params",
+        "oauth-client-credentials-custom",
+        "query-parameters",
+        "path-parameters",
+        "inferred-auth-implicit-no-expiry",
+        "trace",
+        "imdb",
+        "server-sent-event-examples",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 76
+    },
+    {
+      "fixtures": [
+        "version",
+        "circular-references-advanced",
+        "nullable",
+        "property-access",
+        "empty-clients",
+        "undiscriminated-unions",
+        "oauth-client-credentials",
+        "cross-package-type-names",
+        "literals-unions",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 76
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "file-upload",
+        "object",
+        "enum",
+        "oauth-client-credentials-nested-root",
+        "custom-auth",
+        "multi-line-docs",
+        "streaming"
+      ],
+      "groupTotalTimeSeconds": 76
+    },
+    {
+      "fixtures": [
+        "alias",
+        "file-download",
+        "errors",
+        "websocket",
+        "oauth-client-credentials-with-variables",
+        "error-property",
+        "multi-url-environment",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 76
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "nullable-optional",
+        "oauth-client-credentials-environment-variables",
+        "simple-fhir",
+        "public-object",
+        "mixed-file-directory",
+        "unknown",
+        "inferred-auth-explicit",
+        "server-sent-events",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 75
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "bytes-upload",
+        "mixed-case",
+        "websocket-bearer-auth",
+        "optional",
+        "examples",
+        "pagination-custom",
+        "validation"
+      ],
+      "groupTotalTimeSeconds": 76
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "content-type",
+        "multiple-request-bodies",
+        "websocket-inferred-auth",
+        "package-yml",
+        "extra-properties",
+        "request-parameters",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 76
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "extends",
+        "oauth-client-credentials-default",
+        "basic-auth",
+        "multi-url-environment-no-default",
+        "any-auth",
+        "license",
+        "simple-api"
+      ],
+      "groupTotalTimeSeconds": 75
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "bytes-download",
+        "circular-references",
+        "response-property",
+        "no-environment",
+        "audiences",
+        "literal",
+        "single-url-environment-default"
+      ],
+      "groupTotalTimeSeconds": 75
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/rust-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/rust-sdk-seed-groups.json
@@ -1,0 +1,147 @@
+{
+  "totalTestTimeSeconds": 3002,
+  "groups": [
+    {
+      "fixtures": [
+        "client-side-params",
+        "response-property",
+        "inferred-auth-explicit",
+        "plain-text",
+        "error-property",
+        "package-yml",
+        "single-url-environment-default:custom-environment",
+        "exhaustive",
+        "objects-with-imports"
+      ],
+      "groupTotalTimeSeconds": 298
+    },
+    {
+      "fixtures": [
+        "errors",
+        "path-parameters",
+        "custom-auth",
+        "oauth-client-credentials-nested-root",
+        "imdb",
+        "streaming",
+        "single-url-environment-default:full-custom",
+        "simple-api",
+        "public-object"
+      ],
+      "groupTotalTimeSeconds": 298
+    },
+    {
+      "fixtures": [
+        "nullable-optional",
+        "file-upload",
+        "basic-auth",
+        "websocket-inferred-auth",
+        "server-sent-event-examples",
+        "variables",
+        "streaming-parameter",
+        "folders",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 307
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "file-download",
+        "bytes-download",
+        "mixed-case",
+        "basic-auth-environment-variables",
+        "unknown",
+        "trace",
+        "single-url-environment-no-default",
+        "object",
+        "literals-unions"
+      ],
+      "groupTotalTimeSeconds": 301
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "extends",
+        "oauth-client-credentials-environment-variables",
+        "oauth-client-credentials-custom",
+        "multiple-request-bodies",
+        "validation",
+        "idempotency-headers",
+        "enum",
+        "cross-package-type-names"
+      ],
+      "groupTotalTimeSeconds": 309
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "query-parameters-openapi-as-objects",
+        "pagination",
+        "request-parameters",
+        "oauth-client-credentials-with-variables",
+        "extra-properties",
+        "pagination-custom",
+        "literal",
+        "websocket"
+      ],
+      "groupTotalTimeSeconds": 297
+    },
+    {
+      "fixtures": [
+        "alias",
+        "version",
+        "undiscriminated-unions",
+        "inferred-auth-implicit-no-expiry",
+        "property-access",
+        "mixed-file-directory",
+        "examples:no-custom-config",
+        "server-sent-events",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 297
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "api-wide-base-path",
+        "unions",
+        "inferred-auth-implicit",
+        "any-auth",
+        "no-environment",
+        "simple-fhir",
+        "license",
+        "http-head"
+      ],
+      "groupTotalTimeSeconds": 298
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "bearer-token-environment-variable",
+        "nullable",
+        "optional",
+        "reserved-keywords",
+        "multi-line-docs",
+        "multi-url-environment-no-default",
+        "single-url-environment-default:basic",
+        "circular-references",
+        "empty-clients"
+      ],
+      "groupTotalTimeSeconds": 300
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "bytes-upload",
+        "oauth-client-credentials",
+        "imdb:imdb-custom-config",
+        "query-parameters",
+        "multi-url-environment",
+        "oauth-client-credentials-default",
+        "examples:readme-config",
+        "circular-references-advanced"
+      ],
+      "groupTotalTimeSeconds": 297
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/swift-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/swift-sdk-seed-groups.json
@@ -1,0 +1,148 @@
+{
+  "totalTestTimeSeconds": 5171,
+  "groups": [
+    {
+      "fixtures": [
+        "client-side-params:with-custom-config",
+        "response-property",
+        "oauth-client-credentials-nested-root",
+        "basic-auth-environment-variables",
+        "any-auth",
+        "query-parameters-openapi",
+        "single-url-environment-default:with-custom-config",
+        "variables",
+        "cross-package-type-names",
+        "nullable-optional"
+      ],
+      "groupTotalTimeSeconds": 533
+    },
+    {
+      "fixtures": [
+        "client-side-params:no-custom-config",
+        "auth-environment-variables",
+        "oauth-client-credentials",
+        "undiscriminated-unions",
+        "imdb",
+        "query-parameters-openapi-as-objects",
+        "plain-text",
+        "no-environment",
+        "examples:readme-config",
+        "property-access"
+      ],
+      "groupTotalTimeSeconds": 532
+    },
+    {
+      "fixtures": [
+        "file-upload",
+        "api-wide-base-path",
+        "inferred-auth-explicit",
+        "package-yml",
+        "server-sent-events",
+        "server-sent-event-examples",
+        "request-parameters",
+        "literals-unions",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 513
+    },
+    {
+      "fixtures": [
+        "extends",
+        "oauth-client-credentials-custom",
+        "websocket-inferred-auth",
+        "extra-properties",
+        "unknown",
+        "idempotency-headers",
+        "streaming-parameter",
+        "reserved-keywords",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 511
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "file-download",
+        "nullable",
+        "inferred-auth-implicit",
+        "multi-line-docs",
+        "license",
+        "http-head",
+        "circular-references",
+        "query-parameters"
+      ],
+      "groupTotalTimeSeconds": 512
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "accept-header",
+        "bytes-download",
+        "multiple-request-bodies",
+        "empty-clients",
+        "oauth-client-credentials-default",
+        "validation",
+        "public-object",
+        "simple-fhir"
+      ],
+      "groupTotalTimeSeconds": 511
+    },
+    {
+      "fixtures": [
+        "version",
+        "bearer-token-environment-variable",
+        "bytes-upload",
+        "multi-url-environment",
+        "multi-url-environment-no-default",
+        "optional",
+        "websocket",
+        "circular-references-advanced",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 512
+    },
+    {
+      "fixtures": [
+        "pagination:custom-pager-with-exception-handler",
+        "pagination:custom-pager",
+        "custom-auth",
+        "basic-auth",
+        "oauth-client-credentials-with-variables",
+        "simple-api",
+        "websocket-bearer-auth",
+        "folders",
+        "enum"
+      ],
+      "groupTotalTimeSeconds": 509
+    },
+    {
+      "fixtures": [
+        "pagination:no-custom-config",
+        "alias",
+        "inferred-auth-implicit-no-expiry",
+        "mixed-case",
+        "path-parameters",
+        "streaming",
+        "object",
+        "single-url-environment-no-default",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 509
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "errors",
+        "oauth-client-credentials-environment-variables",
+        "pagination-custom",
+        "error-property",
+        "objects-with-imports",
+        "single-url-environment-default:no-custom-config",
+        "unions",
+        "mixed-file-directory",
+        "examples:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 529
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/ts-express-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ts-express-seed-groups.json
@@ -1,0 +1,157 @@
+{
+  "totalTestTimeSeconds": 5767,
+  "groups": [
+    {
+      "fixtures": [
+        "trace:no-custom-config",
+        "bearer-token-environment-variable",
+        "inferred-auth-implicit-no-expiry",
+        "oauth-client-credentials-custom",
+        "path-parameters",
+        "enum",
+        "exhaustive:union-utils",
+        "file-upload",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 573
+    },
+    {
+      "fixtures": [
+        "exhaustive:no-optional-properties",
+        "property-access",
+        "api-wide-base-path",
+        "package-yml",
+        "error-property",
+        "websocket-inferred-auth",
+        "inferred-auth-explicit",
+        "ts-inline-types",
+        "exhaustive:test-package-path",
+        "ts-express-casing:no-serde-layer"
+      ],
+      "groupTotalTimeSeconds": 574
+    },
+    {
+      "fixtures": [
+        "exhaustive:retain-original-casing",
+        "version-no-default",
+        "client-side-params",
+        "request-parameters",
+        "oauth-client-credentials-environment-variables",
+        "basic-auth",
+        "circular-references-advanced",
+        "websocket",
+        "idempotency-headers",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 582
+    },
+    {
+      "fixtures": [
+        "nullable-optional",
+        "no-environment",
+        "accept-header",
+        "query-parameters",
+        "oauth-client-credentials-default",
+        "mixed-file-directory",
+        "cross-package-type-names",
+        "bytes-download",
+        "ts-express-casing:no-custom-config",
+        "plain-text"
+      ],
+      "groupTotalTimeSeconds": 568
+    },
+    {
+      "fixtures": [
+        "nullable",
+        "version",
+        "object",
+        "oauth-client-credentials",
+        "multi-line-docs",
+        "literal",
+        "imdb:validation-status-code",
+        "bytes-upload",
+        "simple-fhir",
+        "multiple-request-bodies",
+        "server-sent-event-examples"
+      ],
+      "groupTotalTimeSeconds": 578
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "auth-environment-variables",
+        "optional",
+        "errors",
+        "custom-auth",
+        "oauth-client-credentials-with-variables",
+        "inferred-auth-implicit",
+        "exhaustive:allow-extra-fields",
+        "simple-api",
+        "public-object",
+        "streaming"
+      ],
+      "groupTotalTimeSeconds": 573
+    },
+    {
+      "fixtures": [
+        "mixed-case:no-custom-config",
+        "query-parameters-openapi",
+        "imdb:output-compiled",
+        "undiscriminated-unions",
+        "literals-unions",
+        "response-property",
+        "validation",
+        "file-download",
+        "unknown",
+        "server-sent-events",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 573
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "extends",
+        "unions",
+        "pagination",
+        "reserved-keywords",
+        "pagination-custom",
+        "circular-references",
+        "folders",
+        "imdb:no-custom-config",
+        "imdb:skip-response-validation"
+      ],
+      "groupTotalTimeSeconds": 582
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "mixed-case:retain-original-casing",
+        "extra-properties",
+        "multi-url-environment",
+        "oauth-client-credentials-nested-root",
+        "any-auth",
+        "audiences",
+        "empty-clients",
+        "single-url-environment-default",
+        "exhaustive:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 581
+    },
+    {
+      "fixtures": [
+        "trace:no-zurg-trace",
+        "alias",
+        "license",
+        "multi-url-environment-no-default",
+        "basic-auth-environment-variables",
+        "objects-with-imports",
+        "examples",
+        "websocket-bearer-auth",
+        "http-head",
+        "imdb:skip-request-validation"
+      ],
+      "groupTotalTimeSeconds": 583
+    }
+  ]
+}

--- a/.github/workflow-resource-files/seed-groups/ts-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ts-sdk-seed-groups.json
@@ -1,0 +1,204 @@
+{
+  "totalTestTimeSeconds": 28810,
+  "groups": [
+    {
+      "fixtures": [
+        "trace:serde-trace",
+        "accept-header",
+        "alias",
+        "query-parameters:serde-layer-query",
+        "file-upload:form-data-node16",
+        "single-url-environment-no-default",
+        "oauth-client-credentials-nested-root:never-throw-errors",
+        "simple-api",
+        "response-property",
+        "mixed-case:no-custom-config",
+        "ts-express-casing",
+        "server-sent-events",
+        "object",
+        "exhaustive:bundle"
+      ],
+      "groupTotalTimeSeconds": 2890
+    },
+    {
+      "fixtures": [
+        "trace:serde-no-throwing",
+        "examples:retain-original-casing",
+        "file-upload:use-jest",
+        "version",
+        "exhaustive:consolidate-type-files",
+        "inferred-auth-explicit",
+        "websocket-inferred-auth:websockets",
+        "basic-auth-environment-variables",
+        "package-yml",
+        "custom-auth",
+        "empty-clients",
+        "unknown:unknown-as-any",
+        "circular-references-advanced",
+        "exhaustive:omit-fern-headers"
+      ],
+      "groupTotalTimeSeconds": 2888
+    },
+    {
+      "fixtures": [
+        "exhaustive:use-yarn",
+        "examples:examples-with-api-reference",
+        "version-no-default",
+        "bytes-upload",
+        "exhaustive:bigint",
+        "exhaustive:with-audiences",
+        "file-download:stream",
+        "basic-auth",
+        "optional",
+        "websocket-bearer-auth:websockets",
+        "request-parameters:flatten-request-parameters",
+        "server-sent-event-examples",
+        "variables",
+        "literals-unions"
+      ],
+      "groupTotalTimeSeconds": 2864
+    },
+    {
+      "fixtures": [
+        "trace:exhaustive",
+        "exhaustive:use-jest",
+        "auth-environment-variables",
+        "query-parameters-openapi-as-objects:no-custom-config",
+        "oauth-client-credentials-with-variables",
+        "oauth-client-credentials-environment-variables",
+        "exhaustive:node-fetch",
+        "path-parameters:inline-path-parameters",
+        "imdb:no-custom-config",
+        "no-environment",
+        "request-parameters:no-custom-config",
+        "license",
+        "property-access:no-custom-config",
+        "file-upload:inline",
+        "bytes-download",
+        "exhaustive:serde-layer"
+      ],
+      "groupTotalTimeSeconds": 2890
+    },
+    {
+      "fixtures": [
+        "file-download:wrapper",
+        "path-parameters:inline-path-parameters-serde",
+        "api-wide-base-path",
+        "extends",
+        "mixed-file-directory",
+        "inferred-auth-implicit",
+        "oauth-client-credentials:no-custom-config",
+        "nullable-optional",
+        "error-property:union-utils",
+        "multi-line-docs",
+        "query-parameters:no-custom-config",
+        "reserved-keywords",
+        "file-download:no-custom-config",
+        "websocket:no-websocket-clients",
+        "exhaustive:local-files-no-source",
+        "exhaustive:local-files"
+      ],
+      "groupTotalTimeSeconds": 2888
+    },
+    {
+      "fixtures": [
+        "file-upload:wrapper",
+        "streaming:wrapper",
+        "query-parameters-openapi:no-custom-config",
+        "exhaustive:web-stream-wrapper",
+        "literal",
+        "file-upload:no-custom-config",
+        "multi-url-environment-no-default",
+        "path-parameters:inline-path-parameters-retain-original-casing",
+        "single-url-environment-default",
+        "idempotency-headers",
+        "streaming:no-custom-config",
+        "any-auth:generate-endpoint-metadata",
+        "ts-inline-types:no-inline",
+        "streaming-parameter",
+        "circular-references"
+      ],
+      "groupTotalTimeSeconds": 2853
+    },
+    {
+      "fixtures": [
+        "exhaustive:no-custom-config",
+        "exhaustive:retain-original-casing",
+        "folders",
+        "cross-package-type-names",
+        "imdb:noScripts",
+        "inferred-auth-implicit-no-expiry",
+        "http-head",
+        "unions",
+        "undiscriminated-unions:skip-response-validation",
+        "property-access:generate-read-write-only-types",
+        "streaming:no-serde-layer",
+        "simple-fhir",
+        "undiscriminated-unions:no-custom-config",
+        "objects-with-imports",
+        "exhaustive:dev-dependencies"
+      ],
+      "groupTotalTimeSeconds": 2896
+    },
+    {
+      "fixtures": [
+        "pagination",
+        "trace:no-custom-config",
+        "file-download:file-download-response-headers",
+        "websocket:serde",
+        "audiences:no-custom-config",
+        "audiences:with-partner-audience",
+        "client-side-params",
+        "multi-url-environment",
+        "imdb:omit-undefined",
+        "errors",
+        "ts-inline-types:inline",
+        "mixed-case:retain-original-casing",
+        "public-object",
+        "plain-text",
+        "oauth-client-credentials-custom"
+      ],
+      "groupTotalTimeSeconds": 2849
+    },
+    {
+      "fixtures": [
+        "file-upload:serde",
+        "exhaustive:bigint-serde-layer",
+        "alias-extends",
+        "content-type",
+        "exhaustive:never-throw-errors",
+        "imdb:branded-string-aliases",
+        "multiple-request-bodies",
+        "path-parameters:default",
+        "pagination-custom",
+        "streaming:allow-custom-fetcher",
+        "request-parameters:use-default-request-parameter-values",
+        "unknown:no-custom-config",
+        "websocket:no-serde",
+        "exhaustive:legacy-exports",
+        "exhaustive:allow-extra-fields"
+      ],
+      "groupTotalTimeSeconds": 2897
+    },
+    {
+      "fixtures": [
+        "oauth-client-credentials:serde",
+        "exhaustive:package-path",
+        "exhaustive:jsr",
+        "bearer-token-environment-variable",
+        "enum",
+        "oauth-client-credentials-default",
+        "request-parameters:use-big-int-and-default-request-parameter-values",
+        "oauth-client-credentials-nested-root:no-custom-config",
+        "path-parameters:retain-original-casing",
+        "extra-properties",
+        "nullable",
+        "validation",
+        "any-auth:no-custom-config",
+        "exhaustive:export-all-requests-at-root",
+        "exhaustive:custom-package-json"
+      ],
+      "groupTotalTimeSeconds": 2895
+    }
+  ]
+}

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -42,7 +42,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Checkout Repo
@@ -122,7 +122,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -1,0 +1,282 @@
+name: Nightly Seed Grouping
+
+on:
+  # Runs every night at 5:00 AM UTC (1:00 AM ET)
+  schedule:
+    - cron: "0 5 * * *"
+  push:
+    # CHRISM -remove
+    branches:
+      - mallinson/nightly-seed-packaging-testing-branch
+  # Runs when triggered manually to do so
+  workflow_dispatch:
+
+# Cancel previous workflows when another is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-seed-test:
+    runs-on: ubuntu-latest
+    #  CHRISM
+    if: false
+    strategy:
+      fail-fast: false # Let all tests run and cascade errors, will only PR generator updates that passed
+      matrix:
+        sdk-name: [
+            ruby-model,
+            ruby-sdk,
+            ruby-sdk-v2,
+            pydantic,
+            # python-sdk, CHRISM - add back
+            fastapi,
+            openapi,
+            postman,
+            java-sdk,
+            java-model,
+            java-spring,
+            ts-sdk,
+            ts-express,
+            go-fiber,
+            go-model,
+            go-sdk,
+            csharp-model,
+            csharp-sdk,
+            php-model,
+            php-sdk,
+            swift-sdk,
+            rust-model,
+            rust-sdk,
+          ]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - uses: bufbuild/buf-setup-action@v1.34.0
+        with:
+          github_token: ${{ github.token }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Install protoc-gen-openapi
+        shell: bash
+        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+
+      - name: Build Seed
+        shell: bash
+        run: |
+          pnpm seed:build
+
+      - name: Save Seed Test Log to File
+        id: save-seed-test-log-to-file
+        run: |
+          pnpm seed:local test --generator ${{ matrix.sdk-name }} --parallel 16 --allow-unexpected-failures > ${{ matrix.sdk-name }}-seed-test-log.txt
+
+      - name: Upload Seed Test Log as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.sdk-name }}-seed-test-log.txt
+          path: ${{ matrix.sdk-name }}-seed-test-log.txt
+          if-no-files-found: error
+          retention-days: 10 # CHRISM - test
+
+      - name: Echo Info for This Run
+        run: |
+          echo "Artifact name: ${{ matrix.sdk-name }}-seed-test-log.txt"
+          echo "GitHub event name: ${{ github.event_name }}"
+          echo "GitHub repository name: ${{ github.repository }}"
+          echo "GitHub workflow name: ${{ github.workflow }}"
+          echo "GitHub workflow run ID: ${{ github.run_id }}"
+
+  # Even trigger this stage when part of previous matrix job is failing. Just don't continue for cancellations or skips.
+  # Failing jobs for a generator will continue to fail and won't PR any changes, but we want the changes for the passing generators.
+  build-seed-groups:
+    runs-on: ubuntu-latest
+    # CHRISM
+    if: always()
+    # if: needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure'
+    needs: [run-seed-test]
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk-name:
+          [
+            ruby-model,
+            ruby-sdk,
+            ruby-sdk-v2,
+            pydantic,
+            python-sdk,
+            fastapi,
+            openapi,
+            postman,
+            java-sdk,
+            java-model,
+            java-spring,
+            ts-sdk,
+            ts-express,
+            go-fiber,
+            go-model,
+            go-sdk,
+            csharp-model,
+            csharp-sdk,
+            php-model,
+            php-sdk,
+            swift-sdk,
+            rust-model,
+            rust-sdk,
+          ]
+    steps:
+      - name: Make artifacts directory
+        shell: bash
+        run: |
+          mkdir -p artifacts
+
+      - name: Download Seed Group File Artifact
+        uses: actions/download-artifact@v5
+        with:
+          path: ./artifacts
+          name: ${{ matrix.sdk-name }}-seed-test-log.txt
+          run-id: 18168948457 # CHRISM - temp
+          github-token: ${{ secrets.FERN_GITHUB_PAT }}
+          repository: ${{ github.repository }}
+          merge-multiple: true
+
+      - name: Group Seed Tests
+        id: group-seed-tests
+        uses: fern-api/package-seed-test@main # CHRISM TODO - set to tag
+        with:
+          number-of-groups: 10
+          seed-test-log-file-path: artifacts/${{ matrix.sdk-name }}-seed-test-log.txt
+
+      - name: Create Seed Group Files
+        id: create-seed-group-files
+        run: |
+          BASH_VAR='${{ steps.group-seed-tests.outputs.json-file-contents }}'
+          echo "$BASH_VAR" > "${{ matrix.sdk-name }}-seed-groups.json"
+
+      - name: Upload Seed Group File as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.sdk-name }}-seed-groups.json
+          path: ${{ matrix.sdk-name }}-seed-groups.json
+          if-no-files-found: error
+          retention-days: 1
+
+  # Even trigger this stage when part of previous matrix job is failing. Just don't continue for cancellations or skips.
+  # Failing jobs for a generator will continue to fail and won't PR any changes, but we want the changes for the passing generators.
+  pr-seed-group-files:
+    runs-on: ubuntu-latest
+    # CHRISM
+    if: always()
+    # if: needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure'
+    needs: [build-seed-groups]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Create Artifacts Downloads Directory
+        shell: bash
+        run: |
+          DIRECTORY=artifacts
+          if [ ! -d "$DIRECTORY" ]; then
+            echo "'$DIRECTORY' does NOT exist, creating it now."
+            mkdir $DIRECTORY
+          else
+            echo "WARNING: Directory '$DIRECTORY' already exists. Not an immediate error but could cause a problem downstream."
+          fi
+
+      - name: Download Seed Group File Artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: ./artifacts
+          pattern: "*-seed-groups.json"
+          merge-multiple: true
+
+      - name: Check for Seed Group Files
+        shell: bash
+        run: |
+          file_count=$(find ./artifacts -type f -name "*-seed-groups.json" | wc -l)
+          echo "Number of seed group files downloaded: $file_count"
+          if [ "$file_count" -eq 0 ]; then
+            echo "Error: No seed group files found"
+            exit 1
+          fi
+
+      - name: Check and Make Directory
+        run: |
+          if [ ! -d ".github/workflow-resource-files/seed-groups" ]; then
+            mkdir -p .github/workflow-resource-files/seed-groups
+          fi
+
+      - name: Overwrite Repo Seed Group Files
+        run: |
+          cp -f artifacts/*-seed-groups.json .github/workflow-resource-files/seed-groups/
+
+      # Setup our linting tools
+      - name: Install and Setup Dev Env
+        uses: ./.github/actions/install
+
+      - name: Lint the Seed Group Files
+        run: |
+          pnpm format:fix .github/workflow-resource-files/seed-groups/
+
+      # Create PR, approve and set to merge per generator
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+          commit-message: "chore(internal): update seed group files"
+          title: "chore(internal): update seed group files"
+          branch: update-seed-group-files
+          body: "Auto-generated PR, triggered by nightly-seed-grouping workflow with: ${{ github.event_name }} from branch: ${{ github.ref_name }}.\nGitHub workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          delete-branch: true
+          add-paths: |
+            .github/workflow-resource-files/seed-groups/**
+          labels: |
+            seed
+
+      - name: Log PR Creation
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        shell: bash
+        run: |
+          echo "PR Created: ${{ steps.cpr.outputs.pull-request-url }}"
+
+      - name: Log PR Update
+        if: steps.cpr.outputs.pull-request-operation == 'updated'
+        shell: bash
+        run: |
+          echo "PR Updated: ${{ steps.cpr.outputs.pull-request-url }}"
+
+      - name: Log PR Failure
+        if: >-
+          ${{
+            steps.cpr.outputs.pull-request-operation != 'updated' && 
+            steps.cpr.outputs.pull-request-operation != 'created'
+          }}
+        shell: bash
+        run: |
+          echo "PR was not created or updated, likely due to no diff for seed group files"
+          echo "PR Operation: ${{ steps.cpr.outputs.pull-request-operation }}. Note: if operation is blank then there were no changes and create-pull-request GitHub Action exited silently and early."
+
+      #  CHRISM - add back
+      # - name: Enable Pull Request Automerge
+      #   if: steps.cpr.outputs.pull-request-operation == 'created'
+      #   uses: peter-evans/enable-pull-request-automerge@v3
+      #   with:
+      #     token: ${{ secrets.FERN_GITHUB_PAT }}
+      #     pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+      #     merge-method: squash
+
+      # - name: Approve PR
+      #   if: steps.cpr.outputs.pull-request-operation == 'created'
+      #   uses: ./.github/actions/auto-approve
+      #   with:
+      #     approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
+      #     pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: "0 5 * * *"
   push:
-    # CHRISM -remove
-    branches:
-      - mallinson/nightly-seed-packaging-testing-branch
   # Runs when triggered manually to do so
   workflow_dispatch:
 
@@ -19,17 +16,16 @@ concurrency:
 jobs:
   run-seed-test:
     runs-on: ubuntu-latest
-    #  CHRISM
-    if: false
     strategy:
       fail-fast: false # Let all tests run and cascade errors, will only PR generator updates that passed
       matrix:
-        sdk-name: [
+        sdk-name:
+          [
             ruby-model,
             ruby-sdk,
             ruby-sdk-v2,
             pydantic,
-            # python-sdk, CHRISM - add back
+            python-sdk,
             fastapi,
             openapi,
             postman,
@@ -84,7 +80,7 @@ jobs:
           name: ${{ matrix.sdk-name }}-seed-test-log.txt
           path: ${{ matrix.sdk-name }}-seed-test-log.txt
           if-no-files-found: error
-          retention-days: 10 # CHRISM - test
+          retention-days: 1
 
       - name: Echo Info for This Run
         run: |
@@ -98,9 +94,7 @@ jobs:
   # Failing jobs for a generator will continue to fail and won't PR any changes, but we want the changes for the passing generators.
   build-seed-groups:
     runs-on: ubuntu-latest
-    # CHRISM
-    if: always()
-    # if: needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure'
+    if: needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure'
     needs: [run-seed-test]
     strategy:
       fail-fast: false
@@ -142,14 +136,13 @@ jobs:
         with:
           path: ./artifacts
           name: ${{ matrix.sdk-name }}-seed-test-log.txt
-          run-id: 18168948457 # CHRISM - temp
           github-token: ${{ secrets.FERN_GITHUB_PAT }}
           repository: ${{ github.repository }}
           merge-multiple: true
 
       - name: Group Seed Tests
         id: group-seed-tests
-        uses: fern-api/package-seed-test@main # CHRISM TODO - set to tag
+        uses: fern-api/group-seed-tests@v1
         with:
           number-of-groups: 10
           seed-test-log-file-path: artifacts/${{ matrix.sdk-name }}-seed-test-log.txt
@@ -172,9 +165,7 @@ jobs:
   # Failing jobs for a generator will continue to fail and won't PR any changes, but we want the changes for the passing generators.
   pr-seed-group-files:
     runs-on: ubuntu-latest
-    # CHRISM
-    if: always()
-    # if: needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure'
+    if: needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure'
     needs: [build-seed-groups]
     steps:
       - name: Checkout Repo
@@ -265,18 +256,17 @@ jobs:
           echo "PR was not created or updated, likely due to no diff for seed group files"
           echo "PR Operation: ${{ steps.cpr.outputs.pull-request-operation }}. Note: if operation is blank then there were no changes and create-pull-request GitHub Action exited silently and early."
 
-      #  CHRISM - add back
-      # - name: Enable Pull Request Automerge
-      #   if: steps.cpr.outputs.pull-request-operation == 'created'
-      #   uses: peter-evans/enable-pull-request-automerge@v3
-      #   with:
-      #     token: ${{ secrets.FERN_GITHUB_PAT }}
-      #     pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-      #     merge-method: squash
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.FERN_GITHUB_PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
 
-      # - name: Approve PR
-      #   if: steps.cpr.outputs.pull-request-operation == 'created'
-      #   uses: ./.github/actions/auto-approve
-      #   with:
-      #     approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
-      #     pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+      - name: Approve PR
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: ./.github/actions/auto-approve
+        with:
+          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -43,7 +43,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Checkout Repo
@@ -123,7 +123,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -4,7 +4,6 @@ on:
   # Runs every night at 5:00 AM UTC (1:00 AM ET)
   schedule:
     - cron: "0 5 * * *"
-  push:
   # Runs when triggered manually to do so
   workflow_dispatch:
 
@@ -43,7 +42,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Checkout Repo
@@ -123,7 +122,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
   # Note: pull request trigger will be removed once repository_dispatch trigger is verified
-  # pull_request:
-  #   types: [opened, synchronize, reopened, ready_for_review]
-  #   branches:
-  #     - main
-  # repository_dispatch:
-  #   types: [seed-tests]
-  # workflow_call:
-  # workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+  repository_dispatch:
+    types: [seed-tests]
+  workflow_call:
+  workflow_dispatch:
 
 # Cancel previous workflows on previous push
 concurrency:
@@ -20,6 +20,106 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
+        include:
+          - files: |
+              generators/ruby/
+              seed/ruby-sdk/seed.yml
+              seed/ruby-model/seed.yml
+            generator-name: ruby
+          - files: |
+              generators/ruby-v2/
+              seed/ruby-sdk-v2/seed.yml
+            generator-name: ruby-v2
+          - files: |
+              generators/openapi/
+              seed/openapi/seed.yml
+            generator-name: openapi
+          - files: |
+              generators/python/
+              seed/pydantic/seed.yml
+              seed/pydantic-v2/seed.yml
+              seed/python-sdk/seed.yml
+              seed/fastapi/seed.yml
+            generator-name: python
+          - files: |
+              generators/postman/
+              seed/postman/seed.yml
+            generator-name: postman
+          - files: |
+              generators/java/
+              seed/java-sdk/seed.yml
+              seed/java-model/seed.yml
+              seed/java-spring/seed.yml
+            generator-name: java
+          - files: |
+              generators/typescript/
+              seed/ts-sdk/seed.yml
+              seed/ts-express/seed.yml
+            generator-name: typescript
+          - files: |
+              generators/go/
+              seed/go-sdk/seed.yml
+              seed/go-model/seed.yml
+              seed/go-fiber/seed.yml
+            generator-name: go
+          - files: |
+              generators/csharp/
+              seed/csharp-sdk/seed.yml
+              seed/csharp-model/seed.yml
+            generator-name: csharp
+          - files: |
+              generators/php/
+              seed/php-sdk/seed.yml
+              seed/php-model/seed.yml
+            generator-name: php
+          - files: |
+              generators/swift/
+              seed/swift-sdk/seed.yml
+            generator-name: swift
+          - files: |
+              generators/rust/
+              seed/rust-model/seed.yml
+              seed/rust-sdk/seed.yml
+            generator-name: rust
+    outputs:
+      # Note: purposely excluding seed. Running every generator at once will lock up all of our runners.
+      ruby: ${{ steps.set-output.outputs.ruby-changes }}
+      ruby-v2: ${{ steps.set-output.outputs.ruby-v2-changes }}
+      openapi: ${{ steps.set-output.outputs.openapi-changes }}
+      python: ${{ steps.set-output.outputs.python-changes }}
+      postman: ${{ steps.set-output.outputs.postman-changes }}
+      java: ${{ steps.set-output.outputs.java-changes }}
+      typescript: ${{ steps.set-output.outputs.typescript-changes }}
+      go: ${{ steps.set-output.outputs.go-changes }}
+      csharp: ${{ steps.set-output.outputs.csharp-changes }}
+      php: ${{ steps.set-output.outputs.php-changes }}
+      swift: ${{ steps.set-output.outputs.swift-changes }}
+      rust: ${{ steps.set-output.outputs.rust-changes }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          # Get sufficient history to check for changes
+          fetch-depth: 200
+          sparse-checkout: |
+            ${{ matrix.files }}
+            .github/
+
+      - name: Get generator changes for ${{ matrix.generator-name }}
+        id: get-generator-changes
+        uses: ./.github/actions/check-for-changed-files
+        with:
+          files: ${{ matrix.files }}
+
+      - name: Set output
+        id: set-output
+        run: |
+          echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
 
   get-all-test-matrices:
     runs-on: ubuntu-latest
@@ -27,34 +127,64 @@ jobs:
       matrix:
         sdk-name:
           [
-            java-sdk
+            ruby-model,
+            ruby-sdk,
+            ruby-sdk-v2,
+            pydantic,
+            python-sdk,
+            fastapi,
+            openapi,
+            postman,
+            java-sdk,
+            java-model,
+            java-spring,
+            ts-sdk,
+            ts-express,
+            go-fiber,
+            go-model,
+            go-sdk,
+            csharp-model,
+            csharp-sdk,
+            php-model,
+            php-sdk,
+            swift-sdk,
+            rust-model,
+            rust-sdk
           ]
     outputs:
+      ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}
+      ruby-sdk: ${{ steps.set-test-matrix.outputs.ruby-sdk-test-matrix }}
+      ruby-sdk-v2: ${{ steps.set-test-matrix.outputs.ruby-sdk-v2-test-matrix }}
+      pydantic: ${{ steps.set-test-matrix.outputs.pydantic-test-matrix }}
+      python-sdk: ${{ steps.set-test-matrix.outputs.python-sdk-test-matrix }}
+      fastapi: ${{ steps.set-test-matrix.outputs.fastapi-test-matrix }}
+      openapi: ${{ steps.set-test-matrix.outputs.openapi-test-matrix }}
+      postman: ${{ steps.set-test-matrix.outputs.postman-test-matrix }}
       java-sdk: ${{ steps.set-test-matrix.outputs.java-sdk-test-matrix }}
+      java-model: ${{ steps.set-test-matrix.outputs.java-model-test-matrix }}
+      java-spring: ${{ steps.set-test-matrix.outputs.java-spring-test-matrix }}
+      ts-sdk: ${{ steps.set-test-matrix.outputs.ts-sdk-test-matrix }}
+      ts-express: ${{ steps.set-test-matrix.outputs.ts-express-test-matrix }}
+      go-fiber: ${{ steps.set-test-matrix.outputs.go-fiber-test-matrix }}
+      go-model: ${{ steps.set-test-matrix.outputs.go-model-test-matrix }}
+      go-sdk: ${{ steps.set-test-matrix.outputs.go-sdk-test-matrix }}
+      csharp-model: ${{ steps.set-test-matrix.outputs.csharp-model-test-matrix }}
+      csharp-sdk: ${{ steps.set-test-matrix.outputs.csharp-sdk-test-matrix }}
+      php-model: ${{ steps.set-test-matrix.outputs.php-model-test-matrix }}
+      php-sdk: ${{ steps.set-test-matrix.outputs.php-sdk-test-matrix }}
+      swift-sdk: ${{ steps.set-test-matrix.outputs.swift-sdk-test-matrix }}
+      rust-model: ${{ steps.set-test-matrix.outputs.rust-model-test-matrix }}
+      rust-sdk: ${{ steps.set-test-matrix.outputs.rust-sdk-test-matrix }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github/workflow-resource-files/balancedGroups.json
-
-      - name: Echo location tehehehe
-        id: echo-location
-        run: |
-          echo "Current directory: $(pwd)"
-
-      - name: Echo level
-        id: echo-level
-        run: |
-          cd .github
-          echo "In GitHub directory, LS: $(ls -l)"
 
       - name: Get test matrix
         id: get-test-matrix
-        run: |
-          BASH_VAR=$(jq -c '.' .github/workflow-resource-files/balancedGroups.json)
-          echo "split-tests=true" >> $GITHUB_OUTPUT
-          echo "test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/get-test-matrix
+        with:
+          sdk-name: ${{ matrix.sdk-name }}
+          package-amount: 10
 
       - name: Set test matrix for ${{ matrix.sdk-name }}
         id: set-test-matrix
@@ -76,20 +206,309 @@ jobs:
             echo "$BASH_VAR" | jq .
           fi
 
+  ruby-model:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.ruby == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: ruby-model
+          generator-path: generators/ruby
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  ruby-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.ruby == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: ruby-sdk
+          generator-path: generators/ruby
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  ruby-sdk-v2:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.ruby-v2 == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: ruby-sdk-v2
+          generator-path: generators/ruby-v2
+          validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  pydantic:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.python == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: pydantic
+          generator-path: generators/python
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  python-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
+    if: >-
+      ${{
+        (needs.changes.outputs.python == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: python-sdk
+          generator-path: generators/python
+          validation-exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  fastapi:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
+    if: >-
+      ${{
+        (needs.changes.outputs.python == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: fastapi
+          generator-path: generators/python
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  openapi:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.openapi == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: openapi
+          generator-path: generators/openapi
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  postman:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
+    if: >-
+      ${{
+        (needs.changes.outputs.postman == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: postman
+          generator-path: generators/postman
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
   java-sdk:
     runs-on: ubuntu-latest
-    needs: [get-all-test-matrices]
+    needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 10 # Limit the number of runners for this job to 10
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
-    # if: >-
-    #   ${{
-    #     (needs.changes.outputs.java == 'true' 
-    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-    #   }}
-    if: true
+    if: >-
+      ${{
+        (needs.changes.outputs.java == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
     steps:
       - name: Echo package
         run: echo '${{toJson(matrix.fixtures)}}' | jq .
@@ -113,1023 +532,510 @@ jobs:
           generator-path: generators/java generators/java-v2
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-
-  # changes:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
-  #       include:
-  #         - files: |
-  #             generators/ruby/
-  #             seed/ruby-sdk/seed.yml
-  #             seed/ruby-model/seed.yml
-  #           generator-name: ruby
-  #         - files: |
-  #             generators/ruby-v2/
-  #             seed/ruby-sdk-v2/seed.yml
-  #           generator-name: ruby-v2
-  #         - files: |
-  #             generators/openapi/
-  #             seed/openapi/seed.yml
-  #           generator-name: openapi
-  #         - files: |
-  #             generators/python/
-  #             seed/pydantic/seed.yml
-  #             seed/pydantic-v2/seed.yml
-  #             seed/python-sdk/seed.yml
-  #             seed/fastapi/seed.yml
-  #           generator-name: python
-  #         - files: |
-  #             generators/postman/
-  #             seed/postman/seed.yml
-  #           generator-name: postman
-  #         - files: |
-  #             generators/java/
-  #             seed/java-sdk/seed.yml
-  #             seed/java-model/seed.yml
-  #             seed/java-spring/seed.yml
-  #           generator-name: java
-  #         - files: |
-  #             generators/typescript/
-  #             seed/ts-sdk/seed.yml
-  #             seed/ts-express/seed.yml
-  #           generator-name: typescript
-  #         - files: |
-  #             generators/go/
-  #             seed/go-sdk/seed.yml
-  #             seed/go-model/seed.yml
-  #             seed/go-fiber/seed.yml
-  #           generator-name: go
-  #         - files: |
-  #             generators/csharp/
-  #             seed/csharp-sdk/seed.yml
-  #             seed/csharp-model/seed.yml
-  #           generator-name: csharp
-  #         - files: |
-  #             generators/php/
-  #             seed/php-sdk/seed.yml
-  #             seed/php-model/seed.yml
-  #           generator-name: php
-  #         - files: |
-  #             generators/swift/
-  #             seed/swift-sdk/seed.yml
-  #           generator-name: swift
-  #         - files: |
-  #             generators/rust/
-  #             seed/rust-model/seed.yml
-  #             seed/rust-sdk/seed.yml
-  #           generator-name: rust
-  #   outputs:
-  #     # Note: purposely excluding seed. Running every generator at once will lock up all of our runners.
-  #     ruby: ${{ steps.set-output.outputs.ruby-changes }}
-  #     ruby-v2: ${{ steps.set-output.outputs.ruby-v2-changes }}
-  #     openapi: ${{ steps.set-output.outputs.openapi-changes }}
-  #     python: ${{ steps.set-output.outputs.python-changes }}
-  #     postman: ${{ steps.set-output.outputs.postman-changes }}
-  #     java: ${{ steps.set-output.outputs.java-changes }}
-  #     typescript: ${{ steps.set-output.outputs.typescript-changes }}
-  #     go: ${{ steps.set-output.outputs.go-changes }}
-  #     csharp: ${{ steps.set-output.outputs.csharp-changes }}
-  #     php: ${{ steps.set-output.outputs.php-changes }}
-  #     swift: ${{ steps.set-output.outputs.swift-changes }}
-  #     rust: ${{ steps.set-output.outputs.rust-changes }}
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-  #       with:
-  #         # Get sufficient history to check for changes
-  #         fetch-depth: 200
-  #         sparse-checkout: |
-  #           ${{ matrix.files }}
-  #           .github/
-
-  #     - name: Get generator changes for ${{ matrix.generator-name }}
-  #       id: get-generator-changes
-  #       uses: ./.github/actions/check-for-changed-files
-  #       with:
-  #         files: ${{ matrix.files }}
-
-  #     - name: Set output
-  #       id: set-output
-  #       run: |
-  #         echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
-
-  # get-all-test-matrices:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       sdk-name:
-  #         [
-  #           ruby-model,
-  #           ruby-sdk,
-  #           ruby-sdk-v2,
-  #           pydantic,
-  #           python-sdk,
-  #           fastapi,
-  #           openapi,
-  #           postman,
-  #           java-sdk,
-  #           java-model,
-  #           java-spring,
-  #           ts-sdk,
-  #           ts-express,
-  #           go-fiber,
-  #           go-model,
-  #           go-sdk,
-  #           csharp-model,
-  #           csharp-sdk,
-  #           php-model,
-  #           php-sdk,
-  #           swift-sdk,
-  #           rust-model,
-  #           rust-sdk
-  #         ]
-  #   outputs:
-  #     ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}
-  #     ruby-sdk: ${{ steps.set-test-matrix.outputs.ruby-sdk-test-matrix }}
-  #     ruby-sdk-v2: ${{ steps.set-test-matrix.outputs.ruby-sdk-v2-test-matrix }}
-  #     pydantic: ${{ steps.set-test-matrix.outputs.pydantic-test-matrix }}
-  #     python-sdk: ${{ steps.set-test-matrix.outputs.python-sdk-test-matrix }}
-  #     fastapi: ${{ steps.set-test-matrix.outputs.fastapi-test-matrix }}
-  #     openapi: ${{ steps.set-test-matrix.outputs.openapi-test-matrix }}
-  #     postman: ${{ steps.set-test-matrix.outputs.postman-test-matrix }}
-  #     java-sdk: ${{ steps.set-test-matrix.outputs.java-sdk-test-matrix }}
-  #     java-model: ${{ steps.set-test-matrix.outputs.java-model-test-matrix }}
-  #     java-spring: ${{ steps.set-test-matrix.outputs.java-spring-test-matrix }}
-  #     ts-sdk: ${{ steps.set-test-matrix.outputs.ts-sdk-test-matrix }}
-  #     ts-express: ${{ steps.set-test-matrix.outputs.ts-express-test-matrix }}
-  #     go-fiber: ${{ steps.set-test-matrix.outputs.go-fiber-test-matrix }}
-  #     go-model: ${{ steps.set-test-matrix.outputs.go-model-test-matrix }}
-  #     go-sdk: ${{ steps.set-test-matrix.outputs.go-sdk-test-matrix }}
-  #     csharp-model: ${{ steps.set-test-matrix.outputs.csharp-model-test-matrix }}
-  #     csharp-sdk: ${{ steps.set-test-matrix.outputs.csharp-sdk-test-matrix }}
-  #     php-model: ${{ steps.set-test-matrix.outputs.php-model-test-matrix }}
-  #     php-sdk: ${{ steps.set-test-matrix.outputs.php-sdk-test-matrix }}
-  #     swift-sdk: ${{ steps.set-test-matrix.outputs.swift-sdk-test-matrix }}
-  #     rust-model: ${{ steps.set-test-matrix.outputs.rust-model-test-matrix }}
-  #     rust-sdk: ${{ steps.set-test-matrix.outputs.rust-sdk-test-matrix }}
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Get test matrix
-  #       id: get-test-matrix
-  #       uses: ./.github/actions/get-test-matrix
-  #       with:
-  #         sdk-name: ${{ matrix.sdk-name }}
-  #         package-amount: 10
-
-  #     - name: Set test matrix for ${{ matrix.sdk-name }}
-  #       id: set-test-matrix
-  #       run: |
-  #         if [[ "${{ steps.get-test-matrix.outputs.split-tests }}" == "true" ]]; then
-  #             BASH_VAR='${{ steps.get-test-matrix.outputs.test-matrix }}'
-  #             echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
-
-  #             # Echo the data to command line for visibility
-  #             echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
-  #             echo "$BASH_VAR" | jq .
-  #         else
-  #           echo "Set empty json matrix, which will run all tests on a single runner"
-  #           BASH_VAR='[{"fixtures":["all"]}]'
-  #           echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
-
-  #           # Echo the data to command line for visibility
-  #           echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
-  #           echo "$BASH_VAR" | jq .
-  #         fi
-
-  # ruby-model:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.ruby == 'true'
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: ruby-model
-  #         generator-path: generators/ruby
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # ruby-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.ruby == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: ruby-sdk
-  #         generator-path: generators/ruby
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # ruby-sdk-v2:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.ruby-v2 == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: ruby-sdk-v2
-  #         generator-path: generators/ruby-v2
-  #         validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # pydantic:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.python == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: pydantic
-  #         generator-path: generators/python
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # python-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.python == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: python-sdk
-  #         generator-path: generators/python
-  #         validation-exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # fastapi:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.python == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: fastapi
-  #         generator-path: generators/python
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # openapi:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.openapi == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: openapi
-  #         generator-path: generators/openapi
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # postman:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.postman == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: postman
-  #         generator-path: generators/postman
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # java-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.java == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: java-sdk
-  #         generator-path: generators/java generators/java-v2
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # java-model:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.java == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: java-model
-  #         generator-path: generators/java
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # java-spring:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.java == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: java-spring
-  #         generator-path: generators/java
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # typescript-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.typescript == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: ts-sdk
-  #         generator-path: generators/typescript
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-  #         validation-exclude-paths: "seed/*/.mock/*,seed/ts-sdk/**/pnpm-lock.yaml"
-
-  # typescript-express:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.typescript == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: ts-express
-  #         generator-path: generators/typescript
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # go-fiber:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.go == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: go-fiber
-  #         generator-path: generators/go generators/go-v2
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # go-model:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.go == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: go-model
-  #         generator-path: generators/go generators/go-v2
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # go-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.go == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: go-sdk
-  #         generator-path: generators/go generators/go-v2
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # csharp-model:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.csharp == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: csharp-model
-  #         generator-path: generators/csharp
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # csharp-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.csharp == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: csharp-sdk
-  #         generator-path: generators/csharp
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # php-model:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.php == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: php-model
-  #         generator-path: generators/php
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # php-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.php == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: php-sdk
-  #         generator-path: generators/php
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # swift-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.swift == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: swift-sdk
-  #         generator-path: generators/swift
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # rust-model:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.rust == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: rust-model
-  #         generator-path: generators/rust
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  # rust-sdk:
-  #   runs-on: ubuntu-latest
-  #   needs: [changes, get-all-test-matrices]
-  #   if: >-
-  #     ${{
-  #       (needs.changes.outputs.rust == 'true' 
-  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #     }}
-  #   strategy:
-  #     fail-fast: false # Let all tests run, even if some fail
-  #     max-parallel: 10 # Limit the number of runners for this job to 10
-  #     matrix:
-  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
-  #   steps:
-  #     - name: Echo package
-  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-  #     # Format for seed tests
-  #     - name: JSON to String
-  #       id: json-to-string
-  #       run: |
-  #         json_data='${{toJson(matrix.fixtures)}}'
-  #         # Convert JSON array to space-separated string
-  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-  #         echo "Generated string: '$string_result'"
-  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
-  #     - name: Checkout repo
-  #       uses: actions/checkout@v4
-
-  #     - name: Run seed
-  #       uses: ./.github/actions/cached-seed
-  #       with:
-  #         generator-name: rust-sdk
-  #         generator-path: generators/rust
-  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  java-model:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
+    if: >-
+      ${{
+        (needs.changes.outputs.java == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: java-model
+          generator-path: generators/java
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  java-spring:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
+    if: >-
+      ${{
+        (needs.changes.outputs.java == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: java-spring
+          generator-path: generators/java
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  typescript-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.typescript == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: ts-sdk
+          generator-path: generators/typescript
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+          validation-exclude-paths: "seed/*/.mock/*,seed/ts-sdk/**/pnpm-lock.yaml"
+
+  typescript-express:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
+    if: >-
+      ${{
+        (needs.changes.outputs.typescript == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: ts-express
+          generator-path: generators/typescript
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  go-fiber:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.go == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: go-fiber
+          generator-path: generators/go generators/go-v2
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  go-model:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.go == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: go-model
+          generator-path: generators/go generators/go-v2
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  go-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.go == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: go-sdk
+          generator-path: generators/go generators/go-v2
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  csharp-model:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.csharp == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: csharp-model
+          generator-path: generators/csharp
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  csharp-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.csharp == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: csharp-sdk
+          generator-path: generators/csharp
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  php-model:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.php == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: php-model
+          generator-path: generators/php
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  php-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.php == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: php-sdk
+          generator-path: generators/php
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  swift-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.swift == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: swift-sdk
+          generator-path: generators/swift
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  rust-model:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.rust == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: rust-model
+          generator-path: generators/rust
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  rust-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes, get-all-test-matrices]
+    if: >-
+      ${{
+        (needs.changes.outputs.rust == 'true'
+        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+      }}
+    strategy:
+      fail-fast: false # Let all tests run, even if some fail
+      max-parallel: 10 # Limit the number of runners for this job to 10
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
+    steps:
+      - name: Echo package
+        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+      # Format for seed tests
+      - name: JSON to String
+        id: json-to-string
+        run: |
+          json_data='${{toJson(matrix.fixtures)}}'
+          # Convert JSON array to space-separated string
+          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+          echo "Generated string: '$string_result'"
+          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run seed
+        uses: ./.github/actions/cached-seed
+        with:
+          generator-name: rust-sdk
+          generator-path: generators/rust
+          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
   # Note: pull request trigger will be removed once repository_dispatch trigger is verified
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
-  repository_dispatch:
-    types: [seed-tests]
-  workflow_call:
-  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
+  #   branches:
+  #     - main
+  # repository_dispatch:
+  #   types: [seed-tests]
+  # workflow_call:
+  # workflow_dispatch:
 
 # Cancel previous workflows on previous push
 concurrency:
@@ -20,106 +20,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
-        include:
-          - files: |
-              generators/ruby/
-              seed/ruby-sdk/seed.yml
-              seed/ruby-model/seed.yml
-            generator-name: ruby
-          - files: |
-              generators/ruby-v2/
-              seed/ruby-sdk-v2/seed.yml
-            generator-name: ruby-v2
-          - files: |
-              generators/openapi/
-              seed/openapi/seed.yml
-            generator-name: openapi
-          - files: |
-              generators/python/
-              seed/pydantic/seed.yml
-              seed/pydantic-v2/seed.yml
-              seed/python-sdk/seed.yml
-              seed/fastapi/seed.yml
-            generator-name: python
-          - files: |
-              generators/postman/
-              seed/postman/seed.yml
-            generator-name: postman
-          - files: |
-              generators/java/
-              seed/java-sdk/seed.yml
-              seed/java-model/seed.yml
-              seed/java-spring/seed.yml
-            generator-name: java
-          - files: |
-              generators/typescript/
-              seed/ts-sdk/seed.yml
-              seed/ts-express/seed.yml
-            generator-name: typescript
-          - files: |
-              generators/go/
-              seed/go-sdk/seed.yml
-              seed/go-model/seed.yml
-              seed/go-fiber/seed.yml
-            generator-name: go
-          - files: |
-              generators/csharp/
-              seed/csharp-sdk/seed.yml
-              seed/csharp-model/seed.yml
-            generator-name: csharp
-          - files: |
-              generators/php/
-              seed/php-sdk/seed.yml
-              seed/php-model/seed.yml
-            generator-name: php
-          - files: |
-              generators/swift/
-              seed/swift-sdk/seed.yml
-            generator-name: swift
-          - files: |
-              generators/rust/
-              seed/rust-model/seed.yml
-              seed/rust-sdk/seed.yml
-            generator-name: rust
-    outputs:
-      # Note: purposely excluding seed. Running every generator at once will lock up all of our runners.
-      ruby: ${{ steps.set-output.outputs.ruby-changes }}
-      ruby-v2: ${{ steps.set-output.outputs.ruby-v2-changes }}
-      openapi: ${{ steps.set-output.outputs.openapi-changes }}
-      python: ${{ steps.set-output.outputs.python-changes }}
-      postman: ${{ steps.set-output.outputs.postman-changes }}
-      java: ${{ steps.set-output.outputs.java-changes }}
-      typescript: ${{ steps.set-output.outputs.typescript-changes }}
-      go: ${{ steps.set-output.outputs.go-changes }}
-      csharp: ${{ steps.set-output.outputs.csharp-changes }}
-      php: ${{ steps.set-output.outputs.php-changes }}
-      swift: ${{ steps.set-output.outputs.swift-changes }}
-      rust: ${{ steps.set-output.outputs.rust-changes }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          # Get sufficient history to check for changes
-          fetch-depth: 200
-          sparse-checkout: |
-            ${{ matrix.files }}
-            .github/
-
-      - name: Get generator changes for ${{ matrix.generator-name }}
-        id: get-generator-changes
-        uses: ./.github/actions/check-for-changed-files
-        with:
-          files: ${{ matrix.files }}
-
-      - name: Set output
-        id: set-output
-        run: |
-          echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
 
   get-all-test-matrices:
     runs-on: ubuntu-latest
@@ -127,64 +27,34 @@ jobs:
       matrix:
         sdk-name:
           [
-            ruby-model,
-            ruby-sdk,
-            ruby-sdk-v2,
-            pydantic,
-            python-sdk,
-            fastapi,
-            openapi,
-            postman,
-            java-sdk,
-            java-model,
-            java-spring,
-            ts-sdk,
-            ts-express,
-            go-fiber,
-            go-model,
-            go-sdk,
-            csharp-model,
-            csharp-sdk,
-            php-model,
-            php-sdk,
-            swift-sdk,
-            rust-model,
-            rust-sdk
+            java-sdk
           ]
     outputs:
-      ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}
-      ruby-sdk: ${{ steps.set-test-matrix.outputs.ruby-sdk-test-matrix }}
-      ruby-sdk-v2: ${{ steps.set-test-matrix.outputs.ruby-sdk-v2-test-matrix }}
-      pydantic: ${{ steps.set-test-matrix.outputs.pydantic-test-matrix }}
-      python-sdk: ${{ steps.set-test-matrix.outputs.python-sdk-test-matrix }}
-      fastapi: ${{ steps.set-test-matrix.outputs.fastapi-test-matrix }}
-      openapi: ${{ steps.set-test-matrix.outputs.openapi-test-matrix }}
-      postman: ${{ steps.set-test-matrix.outputs.postman-test-matrix }}
       java-sdk: ${{ steps.set-test-matrix.outputs.java-sdk-test-matrix }}
-      java-model: ${{ steps.set-test-matrix.outputs.java-model-test-matrix }}
-      java-spring: ${{ steps.set-test-matrix.outputs.java-spring-test-matrix }}
-      ts-sdk: ${{ steps.set-test-matrix.outputs.ts-sdk-test-matrix }}
-      ts-express: ${{ steps.set-test-matrix.outputs.ts-express-test-matrix }}
-      go-fiber: ${{ steps.set-test-matrix.outputs.go-fiber-test-matrix }}
-      go-model: ${{ steps.set-test-matrix.outputs.go-model-test-matrix }}
-      go-sdk: ${{ steps.set-test-matrix.outputs.go-sdk-test-matrix }}
-      csharp-model: ${{ steps.set-test-matrix.outputs.csharp-model-test-matrix }}
-      csharp-sdk: ${{ steps.set-test-matrix.outputs.csharp-sdk-test-matrix }}
-      php-model: ${{ steps.set-test-matrix.outputs.php-model-test-matrix }}
-      php-sdk: ${{ steps.set-test-matrix.outputs.php-sdk-test-matrix }}
-      swift-sdk: ${{ steps.set-test-matrix.outputs.swift-sdk-test-matrix }}
-      rust-model: ${{ steps.set-test-matrix.outputs.rust-model-test-matrix }}
-      rust-sdk: ${{ steps.set-test-matrix.outputs.rust-sdk-test-matrix }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/workflow-resource-files/balancedGroups.json
+
+      - name: Echo location tehehehe
+        id: echo-location
+        run: |
+          echo "Current directory: $(pwd)"
+
+      - name: Echo level
+        id: echo-level
+        run: |
+          cd .github
+          echo "In GitHub directory, LS: $(ls -l)"
 
       - name: Get test matrix
         id: get-test-matrix
-        uses: ./.github/actions/get-test-matrix
-        with:
-          sdk-name: ${{ matrix.sdk-name }}
-          package-amount: 10
+        run: |
+          BASH_VAR=$(jq -c '.' .github/workflow-resource-files/balancedGroups.json)
+          echo "split-tests=true" >> $GITHUB_OUTPUT
+          echo "test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
 
       - name: Set test matrix for ${{ matrix.sdk-name }}
         id: set-test-matrix
@@ -206,309 +76,20 @@ jobs:
             echo "$BASH_VAR" | jq .
           fi
 
-  ruby-model:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.ruby == 'true'
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: ruby-model
-          generator-path: generators/ruby
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  ruby-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.ruby == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: ruby-sdk
-          generator-path: generators/ruby
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  ruby-sdk-v2:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.ruby-v2 == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: ruby-sdk-v2
-          generator-path: generators/ruby-v2
-          validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  pydantic:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.python == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: pydantic
-          generator-path: generators/python
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  python-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
-    if: >-
-      ${{
-        (needs.changes.outputs.python == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: python-sdk
-          generator-path: generators/python
-          validation-exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  fastapi:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
-    if: >-
-      ${{
-        (needs.changes.outputs.python == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: fastapi
-          generator-path: generators/python
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  openapi:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.openapi == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: openapi
-          generator-path: generators/openapi
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
-  postman:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
-    if: >-
-      ${{
-        (needs.changes.outputs.postman == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
-
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: postman
-          generator-path: generators/postman
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-
   java-sdk:
     runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
+    needs: [get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 10 # Limit the number of runners for this job to 10
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
-    if: >-
-      ${{
-        (needs.changes.outputs.java == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
+    # if: >-
+    #   ${{
+    #     (needs.changes.outputs.java == 'true' 
+    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    #   }}
+    if: true
     steps:
       - name: Echo package
         run: echo '${{toJson(matrix.fixtures)}}' | jq .
@@ -532,510 +113,1023 @@ jobs:
           generator-path: generators/java generators/java-v2
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  java-model:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
-    if: >-
-      ${{
-        (needs.changes.outputs.java == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  # changes:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
+  #       include:
+  #         - files: |
+  #             generators/ruby/
+  #             seed/ruby-sdk/seed.yml
+  #             seed/ruby-model/seed.yml
+  #           generator-name: ruby
+  #         - files: |
+  #             generators/ruby-v2/
+  #             seed/ruby-sdk-v2/seed.yml
+  #           generator-name: ruby-v2
+  #         - files: |
+  #             generators/openapi/
+  #             seed/openapi/seed.yml
+  #           generator-name: openapi
+  #         - files: |
+  #             generators/python/
+  #             seed/pydantic/seed.yml
+  #             seed/pydantic-v2/seed.yml
+  #             seed/python-sdk/seed.yml
+  #             seed/fastapi/seed.yml
+  #           generator-name: python
+  #         - files: |
+  #             generators/postman/
+  #             seed/postman/seed.yml
+  #           generator-name: postman
+  #         - files: |
+  #             generators/java/
+  #             seed/java-sdk/seed.yml
+  #             seed/java-model/seed.yml
+  #             seed/java-spring/seed.yml
+  #           generator-name: java
+  #         - files: |
+  #             generators/typescript/
+  #             seed/ts-sdk/seed.yml
+  #             seed/ts-express/seed.yml
+  #           generator-name: typescript
+  #         - files: |
+  #             generators/go/
+  #             seed/go-sdk/seed.yml
+  #             seed/go-model/seed.yml
+  #             seed/go-fiber/seed.yml
+  #           generator-name: go
+  #         - files: |
+  #             generators/csharp/
+  #             seed/csharp-sdk/seed.yml
+  #             seed/csharp-model/seed.yml
+  #           generator-name: csharp
+  #         - files: |
+  #             generators/php/
+  #             seed/php-sdk/seed.yml
+  #             seed/php-model/seed.yml
+  #           generator-name: php
+  #         - files: |
+  #             generators/swift/
+  #             seed/swift-sdk/seed.yml
+  #           generator-name: swift
+  #         - files: |
+  #             generators/rust/
+  #             seed/rust-model/seed.yml
+  #             seed/rust-sdk/seed.yml
+  #           generator-name: rust
+  #   outputs:
+  #     # Note: purposely excluding seed. Running every generator at once will lock up all of our runners.
+  #     ruby: ${{ steps.set-output.outputs.ruby-changes }}
+  #     ruby-v2: ${{ steps.set-output.outputs.ruby-v2-changes }}
+  #     openapi: ${{ steps.set-output.outputs.openapi-changes }}
+  #     python: ${{ steps.set-output.outputs.python-changes }}
+  #     postman: ${{ steps.set-output.outputs.postman-changes }}
+  #     java: ${{ steps.set-output.outputs.java-changes }}
+  #     typescript: ${{ steps.set-output.outputs.typescript-changes }}
+  #     go: ${{ steps.set-output.outputs.go-changes }}
+  #     csharp: ${{ steps.set-output.outputs.csharp-changes }}
+  #     php: ${{ steps.set-output.outputs.php-changes }}
+  #     swift: ${{ steps.set-output.outputs.swift-changes }}
+  #     rust: ${{ steps.set-output.outputs.rust-changes }}
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         # Get sufficient history to check for changes
+  #         fetch-depth: 200
+  #         sparse-checkout: |
+  #           ${{ matrix.files }}
+  #           .github/
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: java-model
-          generator-path: generators/java
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Get generator changes for ${{ matrix.generator-name }}
+  #       id: get-generator-changes
+  #       uses: ./.github/actions/check-for-changed-files
+  #       with:
+  #         files: ${{ matrix.files }}
 
-  java-spring:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
-    if: >-
-      ${{
-        (needs.changes.outputs.java == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  #     - name: Set output
+  #       id: set-output
+  #       run: |
+  #         echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  # get-all-test-matrices:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       sdk-name:
+  #         [
+  #           ruby-model,
+  #           ruby-sdk,
+  #           ruby-sdk-v2,
+  #           pydantic,
+  #           python-sdk,
+  #           fastapi,
+  #           openapi,
+  #           postman,
+  #           java-sdk,
+  #           java-model,
+  #           java-spring,
+  #           ts-sdk,
+  #           ts-express,
+  #           go-fiber,
+  #           go-model,
+  #           go-sdk,
+  #           csharp-model,
+  #           csharp-sdk,
+  #           php-model,
+  #           php-sdk,
+  #           swift-sdk,
+  #           rust-model,
+  #           rust-sdk
+  #         ]
+  #   outputs:
+  #     ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}
+  #     ruby-sdk: ${{ steps.set-test-matrix.outputs.ruby-sdk-test-matrix }}
+  #     ruby-sdk-v2: ${{ steps.set-test-matrix.outputs.ruby-sdk-v2-test-matrix }}
+  #     pydantic: ${{ steps.set-test-matrix.outputs.pydantic-test-matrix }}
+  #     python-sdk: ${{ steps.set-test-matrix.outputs.python-sdk-test-matrix }}
+  #     fastapi: ${{ steps.set-test-matrix.outputs.fastapi-test-matrix }}
+  #     openapi: ${{ steps.set-test-matrix.outputs.openapi-test-matrix }}
+  #     postman: ${{ steps.set-test-matrix.outputs.postman-test-matrix }}
+  #     java-sdk: ${{ steps.set-test-matrix.outputs.java-sdk-test-matrix }}
+  #     java-model: ${{ steps.set-test-matrix.outputs.java-model-test-matrix }}
+  #     java-spring: ${{ steps.set-test-matrix.outputs.java-spring-test-matrix }}
+  #     ts-sdk: ${{ steps.set-test-matrix.outputs.ts-sdk-test-matrix }}
+  #     ts-express: ${{ steps.set-test-matrix.outputs.ts-express-test-matrix }}
+  #     go-fiber: ${{ steps.set-test-matrix.outputs.go-fiber-test-matrix }}
+  #     go-model: ${{ steps.set-test-matrix.outputs.go-model-test-matrix }}
+  #     go-sdk: ${{ steps.set-test-matrix.outputs.go-sdk-test-matrix }}
+  #     csharp-model: ${{ steps.set-test-matrix.outputs.csharp-model-test-matrix }}
+  #     csharp-sdk: ${{ steps.set-test-matrix.outputs.csharp-sdk-test-matrix }}
+  #     php-model: ${{ steps.set-test-matrix.outputs.php-model-test-matrix }}
+  #     php-sdk: ${{ steps.set-test-matrix.outputs.php-sdk-test-matrix }}
+  #     swift-sdk: ${{ steps.set-test-matrix.outputs.swift-sdk-test-matrix }}
+  #     rust-model: ${{ steps.set-test-matrix.outputs.rust-model-test-matrix }}
+  #     rust-sdk: ${{ steps.set-test-matrix.outputs.rust-sdk-test-matrix }}
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: java-spring
-          generator-path: generators/java
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Get test matrix
+  #       id: get-test-matrix
+  #       uses: ./.github/actions/get-test-matrix
+  #       with:
+  #         sdk-name: ${{ matrix.sdk-name }}
+  #         package-amount: 10
 
-  typescript-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.typescript == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  #     - name: Set test matrix for ${{ matrix.sdk-name }}
+  #       id: set-test-matrix
+  #       run: |
+  #         if [[ "${{ steps.get-test-matrix.outputs.split-tests }}" == "true" ]]; then
+  #             BASH_VAR='${{ steps.get-test-matrix.outputs.test-matrix }}'
+  #             echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #             # Echo the data to command line for visibility
+  #             echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
+  #             echo "$BASH_VAR" | jq .
+  #         else
+  #           echo "Set empty json matrix, which will run all tests on a single runner"
+  #           BASH_VAR='[{"fixtures":["all"]}]'
+  #           echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
 
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #           # Echo the data to command line for visibility
+  #           echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
+  #           echo "$BASH_VAR" | jq .
+  #         fi
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: ts-sdk
-          generator-path: generators/typescript
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
-          validation-exclude-paths: "seed/*/.mock/*,seed/ts-sdk/**/pnpm-lock.yaml"
+  # ruby-model:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.ruby == 'true'
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-  typescript-express:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
-    if: >-
-      ${{
-        (needs.changes.outputs.typescript == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: ruby-model
+  #         generator-path: generators/ruby
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: ts-express
-          generator-path: generators/typescript
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  # ruby-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.ruby == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-  go-fiber:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.go == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: ruby-sdk
+  #         generator-path: generators/ruby
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  # ruby-sdk-v2:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.ruby-v2 == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: go-fiber
-          generator-path: generators/go generators/go-v2
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-  go-model:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.go == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: ruby-sdk-v2
+  #         generator-path: generators/ruby-v2
+  #         validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  # pydantic:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.python == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: go-model
-          generator-path: generators/go generators/go-v2
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: pydantic
+  #         generator-path: generators/python
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  go-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.go == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # python-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.python == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: go-sdk
-          generator-path: generators/go generators/go-v2
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: python-sdk
+  #         generator-path: generators/python
+  #         validation-exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  csharp-model:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.csharp == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # fastapi:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.python == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: csharp-model
-          generator-path: generators/csharp
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: fastapi
+  #         generator-path: generators/python
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  csharp-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.csharp == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # openapi:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.openapi == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: csharp-sdk
-          generator-path: generators/csharp
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: openapi
+  #         generator-path: generators/openapi
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  php-model:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.php == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # postman:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.postman == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: php-model
-          generator-path: generators/php
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: postman
+  #         generator-path: generators/postman
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  php-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.php == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # java-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.java == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: php-sdk
-          generator-path: generators/php
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: java-sdk
+  #         generator-path: generators/java generators/java-v2
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  swift-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.swift == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # java-model:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.java == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: swift-sdk
-          generator-path: generators/swift
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: java-model
+  #         generator-path: generators/java
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  rust-model:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.rust == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # java-spring:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.java == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: rust-model
-          generator-path: generators/rust
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: java-spring
+  #         generator-path: generators/java
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
-  rust-sdk:
-    runs-on: ubuntu-latest
-    needs: [changes, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.changes.outputs.rust == 'true' 
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
-    strategy:
-      fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
-      matrix:
-        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
-    steps:
-      - name: Echo package
-        run: echo '${{toJson(matrix.fixtures)}}' | jq .
+  # typescript-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.typescript == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
 
-      # Format for seed tests
-      - name: JSON to String
-        id: json-to-string
-        run: |
-          json_data='${{toJson(matrix.fixtures)}}'
-          # Convert JSON array to space-separated string
-          string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
-          echo "Generated string: '$string_result'"
-          echo "as-string=$string_result" >> $GITHUB_OUTPUT
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
 
-      - name: Run seed
-        uses: ./.github/actions/cached-seed
-        with:
-          generator-name: rust-sdk
-          generator-path: generators/rust
-          fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: ts-sdk
+  #         generator-path: generators/typescript
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+  #         validation-exclude-paths: "seed/*/.mock/*,seed/ts-sdk/**/pnpm-lock.yaml"
+
+  # typescript-express:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.typescript == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: ts-express
+  #         generator-path: generators/typescript
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # go-fiber:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.go == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: go-fiber
+  #         generator-path: generators/go generators/go-v2
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # go-model:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.go == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: go-model
+  #         generator-path: generators/go generators/go-v2
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # go-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.go == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: go-sdk
+  #         generator-path: generators/go generators/go-v2
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # csharp-model:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.csharp == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: csharp-model
+  #         generator-path: generators/csharp
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # csharp-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.csharp == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: csharp-sdk
+  #         generator-path: generators/csharp
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # php-model:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.php == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: php-model
+  #         generator-path: generators/php
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # php-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.php == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: php-sdk
+  #         generator-path: generators/php
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # swift-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.swift == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: swift-sdk
+  #         generator-path: generators/swift
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # rust-model:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.rust == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: rust-model
+  #         generator-path: generators/rust
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+  # rust-sdk:
+  #   runs-on: ubuntu-latest
+  #   needs: [changes, get-all-test-matrices]
+  #   if: >-
+  #     ${{
+  #       (needs.changes.outputs.rust == 'true' 
+  #       && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #     }}
+  #   strategy:
+  #     fail-fast: false # Let all tests run, even if some fail
+  #     max-parallel: 10 # Limit the number of runners for this job to 10
+  #     matrix:
+  #       include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
+  #   steps:
+  #     - name: Echo package
+  #       run: echo '${{toJson(matrix.fixtures)}}' | jq .
+
+  #     # Format for seed tests
+  #     - name: JSON to String
+  #       id: json-to-string
+  #       run: |
+  #         json_data='${{toJson(matrix.fixtures)}}'
+  #         # Convert JSON array to space-separated string
+  #         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+  #         echo "Generated string: '$string_result'"
+  #         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+
+  #     - name: Run seed
+  #       uses: ./.github/actions/cached-seed
+  #       with:
+  #         generator-name: rust-sdk
+  #         generator-path: generators/rust
+  #         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6955/ci-add-job-to-rebalance-seed-packages-on-a-nightly-basis
Closes FER-6955
Closes FER-6952 (these changes approved [here](https://github.com/fern-api/fern/pull/9712) as example, now merging that to main)
Creating a CI workflow to run nightly to update the seed-group files (responsible for balancing seed tests and seed update parallel runs)

## Changes Made
- Committing seed-group files to repo that will be auto-generated nightly by this workflow
- Linted seed.yml file
- Creation of nightly-seed-grouping.yml workflow

## Testing
- Tested with CI and sample outputs shown here: https://github.com/fern-api/fern/pull/9712
