### PR TITLE
chore(ruby): Bump ruby v2 version to 1.0.0-rc28.

### DIFF
--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.0.0-rc28
+  createdAt: "2025-10-01"
+  changelogEntry:
+    - type: fix
+      summary: |
+        Fix gem versioning when building an SDK locally.
+  irVersion: 59
+
 - version: 1.0.0-rc27
   createdAt: "2025-09-29"
   changelogEntry:


### PR DESCRIPTION
## Description
Bump Ruby v2 generator to 1.0.0-rc28 so that we can ship the fix from #9713.
