### PR TITLE
fix(typescript): export pagination and file utilities through top-level namespace

### DIFF
--- a/generators/typescript/sdk/generator/src/SdkGenerator.ts
+++ b/generators/typescript/sdk/generator/src/SdkGenerator.ts
@@ -592,6 +592,22 @@ export class SdkGenerator {
         }
 
         this.coreUtilitiesManager.finalize(this.exportsManager, this.dependencyManager);
+
+        // For convenience, export core/exports.ts from the api directory if it exists
+        if (this.coreUtilitiesManager.hasCoreExports()) {
+            const apiDirectoryPath = this.exportsManager.convertExportedDirectoryPathToFilePath([
+                {
+                    nameOnDisk: "api"
+                }
+            ]);
+            this.exportsManager.addExportDeclarationForDirectory({
+                directory: apiDirectoryPath,
+                moduleSpecifierToExport: "../core/exports.js",
+                exportDeclaration: { exportAll: true },
+                addExportTypeModifier: true
+            });
+        }
+
         this.exportsManager.writeExportsToProject(this.rootDirectory);
         this.context.logger.debug("Generated exports");
 

--- a/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
@@ -104,6 +104,9 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     public buildReadmeAddendums(): Record<FernGeneratorCli.FeatureId, string> {
         const addendums: Record<FernGeneratorCli.FeatureId, string | undefined> = {};
         addendums[ReadmeSnippetBuilder.BINARY_RESPONSE_FEATURE_ID] = this.buildBinaryResponseAddendum();
+        if (this.isPaginationEnabled) {
+            addendums[FernGeneratorCli.StructuredFeatureId.Pagination] = this.buildPaginationAddendum();
+        }
 
         return Object.fromEntries(
             Object.entries(addendums).filter(([_, value]) => value != null) as [FernGeneratorCli.FeatureId, string][]
@@ -333,6 +336,17 @@ const bodyUsed = response.bodyUsed;
         return compileTemplate({
             snippet: this.writeCode(code`const response = await ${this.getMethodCall(binaryResponseEndpoint)}(...);`)
         });
+    }
+
+    private buildPaginationAddendum(): string {
+        const snippet = this.writeCode(
+            code`
+import { ${this.context.namespaceExport} } from "${this.rootPackageName}";
+
+const page: ${this.context.namespaceExport}.Page<MyItemType> = ...;
+`
+        );
+        return `The \`Page\` type used in paginated responses is also accessible through the root-level namespace:\n\n\`\`\`typescript\n${snippet}\`\`\``;
     }
 
     private buildRetrySnippets(): string[] {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.3.6
+  changelogEntry:
+    - summary: |
+        Expose pagination and file core utilities through the root-level API namespace.
+      type: fix
+  createdAt: "2025-10-01"
+  irVersion: 60
 
 - version: 3.3.5
   changelogEntry:
@@ -72,7 +79,7 @@
 - version: 3.2.1
   changelogEntry:
     - summary: |
-        Set `compilerOptions.isolatedModules` and `compilerOptions.isolatedDeclarations` to `true` in _tsconfig.json_, and update the TypeScript code to comply with this setting. 
+        Set `compilerOptions.isolatedModules` and `compilerOptions.isolatedDeclarations` to `true` in _tsconfig.json_, and update the TypeScript code to comply with this setting.
         Users that enable `isolatedModules` can now use the SDK without any TypeScript compilation errors.
         While `isolatedModules` is not turned on by default in TypeScript, more frameworks and tools enable it by default.
 

--- a/generators/typescript/utils/commons/src/core-utilities/CoreUtilitiesManager.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/CoreUtilitiesManager.ts
@@ -51,6 +51,12 @@ export class CoreUtilitiesManager {
     private readonly relativeTestPath: string;
     private readonly generateEndpointMetadata: boolean;
 
+    public hasCoreExports(): boolean {
+        // core/exports.ts will exist if any utility with an exports.ts file is used;
+        // currently these are: file, pagination
+        return this.referencedCoreUtilities["pagination"] != null || this.referencedCoreUtilities["file"] != null;
+    }
+
     constructor({
         streamType,
         formDataSupport,

--- a/generators/typescript/utils/commons/src/exports-manager/ExportsManager.ts
+++ b/generators/typescript/utils/commons/src/exports-manager/ExportsManager.ts
@@ -175,7 +175,7 @@ export class ExportsManager {
         }
     }
 
-    private addExportDeclarationForDirectory({
+    public addExportDeclarationForDirectory({
         directory,
         moduleSpecifierToExport,
         exportDeclaration,
@@ -184,7 +184,7 @@ export class ExportsManager {
         directory: Directory | PathToDirectory;
         moduleSpecifierToExport: ModuleSpecifier;
         exportDeclaration: ExportDeclaration | undefined;
-        addExportTypeModifier: boolean | undefined;
+        addExportTypeModifier?: boolean | undefined;
     }): void {
         const pathToDirectory = typeof directory === "string" ? directory : directory.getPath();
         const exportsForDirectory = (this.exports[pathToDirectory] ??= {});

--- a/generators/typescript/utils/core-utilities/src/core/pagination/exports.ts
+++ b/generators/typescript/utils/core-utilities/src/core/pagination/exports.ts
@@ -1,0 +1,2 @@
+export type { Page } from "./Page";
+export type { Pageable } from "./Pageable";

--- a/seed/ts-sdk/pagination-custom/README.md
+++ b/seed/ts-sdk/pagination-custom/README.md
@@ -96,6 +96,14 @@ while (page.hasNextPage()) {
 }
 ```
 
+The `Page` type used in paginated responses is also accessible through the root-level namespace:
+
+```typescript
+import { SeedPagination } from "@fern/pagination-custom";
+
+const page: SeedPagination.Page<MyItemType> = ...;
+```
+
 ## Advanced
 
 ### Additional Headers

--- a/seed/ts-sdk/pagination/README.md
+++ b/seed/ts-sdk/pagination/README.md
@@ -128,6 +128,14 @@ while (page.hasNextPage()) {
 }
 ```
 
+The `Page` type used in paginated responses is also accessible through the root-level namespace:
+
+```typescript
+import { SeedPagination } from "@fern/pagination";
+
+const page: SeedPagination.Page<MyItemType> = ...;
+```
+
 ## Advanced
 
 ### Additional Headers

--- a/seed/ts-sdk/pagination/src/api/index.ts
+++ b/seed/ts-sdk/pagination/src/api/index.ts
@@ -1,2 +1,3 @@
 export * from "./types/index.js";
 export * from "./resources/index.js";
+export * from "../core/exports.js";

--- a/seed/ts-sdk/pagination/src/core/exports.ts
+++ b/seed/ts-sdk/pagination/src/core/exports.ts
@@ -1,0 +1,1 @@
+export * from "./pagination/exports.js";

--- a/seed/ts-sdk/pagination/src/core/pagination/exports.ts
+++ b/seed/ts-sdk/pagination/src/core/pagination/exports.ts
@@ -1,0 +1,2 @@
+export type { Page } from "./Page.js";
+export type { Pageable } from "./Pageable.js";

--- a/seed/ts-sdk/pagination/src/exports.ts
+++ b/seed/ts-sdk/pagination/src/exports.ts
@@ -1,0 +1,1 @@
+export * from "./core/exports.js";

--- a/seed/ts-sdk/pagination/src/index.ts
+++ b/seed/ts-sdk/pagination/src/index.ts
@@ -1,3 +1,4 @@
 export * as SeedPagination from "./api/index.js";
 export { SeedPaginationError, SeedPaginationTimeoutError } from "./errors/index.js";
 export { SeedPaginationClient } from "./Client.js";
+export * from "./exports.js";


### PR DESCRIPTION
## Description
Linear ticket: Fixes FER-6978
Exposes the `exports.ts`-based `core` exports through the top-level namespace in `api/`, so imports like `PackagePath.Uploadable` work. Also adds `pagination` to the export system so `PackagePath.Page` or `PackagePath.Pageable` work.

## Changes Made
See above! Just a quick extra check in `SdkGenerator.ts` and an added `exports.ts` file.
- [X] Updated README.md generator

## Testing
Against Auth0.
- [X] Unit tests added/updated
- [X] Manual testing completed
