### PR TITLE
feat(ci): Set timeouts for jobs that are hanging and for jobs that cost real money

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
   test:
     if: github.repository == 'fern-api/fern'
     runs-on: Test
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -111,6 +112,7 @@ jobs:
   test-ete:
     if: github.repository == 'fern-api/fern'
     runs-on: Test
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -43,7 +43,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Checkout Repo
@@ -124,7 +124,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   run-seed-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run and cascade errors, will only PR generator updates that passed
       matrix:
@@ -42,7 +43,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Checkout Repo
@@ -93,6 +94,7 @@ jobs:
   # Failing jobs for a generator will continue to fail and won't PR any changes, but we want the changes for the passing generators.
   build-seed-groups:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     if: needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure'
     needs: [run-seed-test]
     strategy:
@@ -122,7 +124,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Make artifacts directory
@@ -164,6 +166,7 @@ jobs:
   # Failing jobs for a generator will continue to fail and won't PR any changes, but we want the changes for the passing generators.
   pr-seed-group-files:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure'
     needs: [build-seed-groups]
     steps:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -25,21 +25,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        generator-name:
-          [
-            ruby,
-            ruby-v2,
-            openapi,
-            python,
-            postman,
-            java,
-            typescript,
-            go,
-            csharp,
-            php,
-            swift,
-            rust,
-          ]
+        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
         include:
           - files: |
               generators/ruby/
@@ -165,7 +151,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     outputs:
       ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -22,9 +22,24 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
-        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
+        generator-name:
+          [
+            ruby,
+            ruby-v2,
+            openapi,
+            python,
+            postman,
+            java,
+            typescript,
+            go,
+            csharp,
+            php,
+            swift,
+            rust,
+          ]
         include:
           - files: |
               generators/ruby/
@@ -123,6 +138,7 @@ jobs:
 
   get-all-test-matrices:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         sdk-name:
@@ -149,7 +165,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     outputs:
       ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}
@@ -208,6 +224,7 @@ jobs:
 
   ruby-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -244,6 +261,7 @@ jobs:
 
   ruby-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -280,6 +298,7 @@ jobs:
 
   ruby-sdk-v2:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -317,6 +336,7 @@ jobs:
 
   pydantic:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -353,6 +373,7 @@ jobs:
 
   python-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
@@ -390,6 +411,7 @@ jobs:
 
   fastapi:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
@@ -426,6 +448,7 @@ jobs:
 
   openapi:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -462,6 +485,7 @@ jobs:
 
   postman:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
@@ -498,6 +522,7 @@ jobs:
 
   java-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
@@ -534,6 +559,7 @@ jobs:
 
   java-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
@@ -570,6 +596,7 @@ jobs:
 
   java-spring:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
@@ -606,6 +633,7 @@ jobs:
 
   typescript-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -644,6 +672,7 @@ jobs:
 
   typescript-express:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
@@ -680,6 +709,7 @@ jobs:
 
   go-fiber:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -717,6 +747,7 @@ jobs:
 
   go-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -754,6 +785,7 @@ jobs:
 
   go-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -790,6 +822,7 @@ jobs:
 
   csharp-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -826,6 +859,7 @@ jobs:
 
   csharp-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -862,6 +896,7 @@ jobs:
 
   php-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -898,6 +933,7 @@ jobs:
 
   php-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -934,6 +970,7 @@ jobs:
 
   swift-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -970,6 +1007,7 @@ jobs:
 
   rust-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
@@ -1006,6 +1044,7 @@ jobs:
 
   rust-sdk:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -35,6 +35,7 @@ jobs:
   setup:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       skip-scripts: ${{ steps.set-update-options.outputs.skip-scripts }}
       update-by-push: ${{ steps.set-update-options.outputs.update-by-push }}
@@ -57,6 +58,7 @@ jobs:
   changes:
     if: github.repository == 'fern-api/fern'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         generator-name: [seed, ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
@@ -171,6 +173,7 @@ jobs:
 
   get-all-test-matrices:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         sdk-name:
@@ -258,6 +261,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -293,6 +297,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.ruby == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -329,6 +334,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.ruby-v2 == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
@@ -366,6 +372,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -402,6 +409,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -438,6 +446,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.python == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -474,6 +483,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.openapi == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -510,6 +520,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.postman == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -546,6 +557,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -582,6 +594,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -618,6 +631,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.java == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -654,6 +668,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -690,6 +705,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.typescript == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -762,6 +778,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -798,6 +815,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.go == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -834,6 +852,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -870,6 +889,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.csharp == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -906,6 +926,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -942,6 +963,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.php == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -978,6 +1000,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.swift == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -1014,6 +1037,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -1050,6 +1074,7 @@ jobs:
     needs: [changes, setup, get-all-test-matrices]
     if: ${{ needs.changes.outputs.rust == 'true' ||  needs.changes.outputs.seed == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 10 # Limit the number of runners for this job to 10
@@ -1121,6 +1146,8 @@ jobs:
         rust-sdk-seed-update
       ]
     runs-on: ubuntu-latest
+
+    timeout-minutes: 10
     steps:
       - name: Extract branch name
         id: extract_branch
@@ -1228,6 +1255,7 @@ jobs:
         rust-sdk-seed-update
       ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         sdk-name:
@@ -1409,6 +1437,7 @@ jobs:
         !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       # Note: this will trigger to the default branch of the repo, not the PR branch
       - name: Trigger seed tests


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7010/ci-look-to-add-job-timeouts
Closes FER-7010
Set timeouts for notable jobs in GitHub Actions. In this context, that refers to jobs that have recently been hanging, and the jobs that are running on our most expensive runner (which aren't hanging now but this is a safety net). Unfortunately, there isn't a catch all default we can set and GitHub's default timeout is 6 hours.

## Changes Made
- Added timeout to handful of jobs, particularly anything running seed tests/updates and anything using a runner besides the cheapest one

## Testing
- Just setting a timeout, will check on the nightly once this merges
