### PR TITLE
fix(go): final wiremock follow-ups

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -1,0 +1,25 @@
+FROM docker:28.4.0-dind-alpine3.22
+
+# Install Go
+ENV GO_VERSION=1.23.8
+RUN apk add --no-cache wget tar \
+    && wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz \
+    && apk del wget tar
+
+ENV PATH="/usr/local/go/bin:${PATH}" \
+    GOPATH="/go" \
+    CGO_ENABLED=0
+
+RUN mkdir -p "${GOPATH}/src" "${GOPATH}/bin"
+
+# Create entrypoint script to start dockerd and execute commands
+RUN echo '#!/bin/sh' > /entrypoint.sh && \
+    echo 'dockerd &' >> /entrypoint.sh && \
+    echo 'sleep 3' >> /entrypoint.sh && \
+    echo 'exec "$@"' >> /entrypoint.sh && \
+    chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["tail", "-f", "/dev/null"]

--- a/generators/go-v2/sdk/src/wire-tests/TestMainFunctionContent.ts
+++ b/generators/go-v2/sdk/src/wire-tests/TestMainFunctionContent.ts
@@ -22,15 +22,43 @@ func TestMain(m *testing.M) {
 
 	// Store global references
 	WireMockContainer = container
-	WireMockClient = container.Client
 
-	// Get the base URL
+	// Try to get the base URL using the standard method first
 	baseURL, err := container.Endpoint(ctx, "")
-	if err != nil {
-		fmt.Printf("Failed to get WireMock container endpoint: %v\\n", err)
-		os.Exit(1)
+	if err == nil {
+		// Standard method worked (running outside DinD)
+		WireMockBaseURL = "http://" + baseURL
+		WireMockClient = container.Client
+	} else {
+		// Standard method failed, use internal IP fallback (DinD environment)
+		fmt.Printf("Standard endpoint resolution failed, using internal IP fallback: %v\\n", err)
+		
+		inspect, err := container.Inspect(ctx)
+		if err != nil {
+			fmt.Printf("Failed to inspect WireMock container: %v\\n", err)
+			os.Exit(1)
+		}
+
+		// Find the IP address from the container's networks
+		var containerIP string
+		for _, network := range inspect.NetworkSettings.Networks {
+			if network.IPAddress != "" {
+				containerIP = network.IPAddress
+				break
+			}
+		}
+
+		if containerIP == "" {
+			fmt.Printf("Failed to get WireMock container IP address\\n")
+			os.Exit(1)
+		}
+
+		// Construct the URL using internal IP and port
+		WireMockBaseURL = fmt.Sprintf("http://%s:8080", containerIP)
+		WireMockClient = gowiremock.NewClient(WireMockBaseURL)
 	}
-	WireMockBaseURL = "http://" + baseURL
+
+	fmt.Printf("WireMock available at: %s\\n", WireMockBaseURL)
 
 	// Run all tests
 	code := m.Run()

--- a/generators/go-v2/sdk/src/wire-tests/TestMainFunctionContent.ts
+++ b/generators/go-v2/sdk/src/wire-tests/TestMainFunctionContent.ts
@@ -26,11 +26,11 @@ func TestMain(m *testing.M) {
 	// Try to get the base URL using the standard method first
 	baseURL, err := container.Endpoint(ctx, "")
 	if err == nil {
-		// Standard method worked (running outside DinD)
+		// Standard method worked (running outside D-in-D)
 		WireMockBaseURL = "http://" + baseURL
 		WireMockClient = container.Client
 	} else {
-		// Standard method failed, use internal IP fallback (DinD environment)
+		// Standard method failed, use internal IP fallback (D-in-D environment)
 		fmt.Printf("Standard endpoint resolution failed, using internal IP fallback: %v\\n", err)
 		
 		inspect, err := container.Inspect(ctx)

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -10,7 +10,7 @@
 - version: 1.13.6
   changelogEntry:
     - summary: |
-        Fix to allow wire tests to run in containerized environments.
+        Fix to allow wire tests to run in containerized environments (seed and CI)
       type: fix
   createdAt: "2025-10-02"
   irVersion: 60

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,8 +1,9 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 1.13.6
+
+- version: 1.13.7
   changelogEntry:
     - summary: |
-        Remove occasional double-running of a build step.
+        Fix to allow wire tests to run in containerized environments (seed and CI)
       type: fix
   createdAt: "2025-10-02"
   irVersion: 60
@@ -10,7 +11,7 @@
 - version: 1.13.6
   changelogEntry:
     - summary: |
-        Fix to allow wire tests to run in containerized environments (seed and CI)
+        Remove occasional double-running of a build step.
       type: fix
   createdAt: "2025-10-02"
   irVersion: 60

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -7,6 +7,14 @@
   createdAt: "2025-10-02"
   irVersion: 60
 
+- version: 1.13.6
+  changelogEntry:
+    - summary: |
+        Fix to allow wire tests to run in containerized environments.
+      type: fix
+  createdAt: "2025-10-02"
+  irVersion: 60
+
 - version: 1.13.5
   changelogEntry:
     - summary: |

--- a/packages/seed/src/commands/test/script-runner/DockerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/DockerScriptRunner.ts
@@ -155,7 +155,18 @@ export class DockerScriptRunner extends ScriptRunner {
             const startSeedCommand = await loggingExeca(
                 context.logger,
                 "docker",
-                ["run", "-dit", "-v", cliVolumeBind, script.docker, "/bin/sh"],
+                [
+                    "run",
+                    "--privileged",
+                    "--cgroupns=host",
+                    "-v",
+                    "/sys/fs/cgroup:/sys/fs/cgroup:rw",
+                    "-dit",
+                    "-v",
+                    cliVolumeBind,
+                    script.docker,
+                    "/bin/sh"
+                ],
                 {
                     doNotPipeOutput: false
                 }

--- a/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
@@ -5,15 +5,16 @@ package imdb_test
 import (
 	context "context"
 	fmt "fmt"
+	http "net/http"
+	os "os"
+	testing "testing"
+
 	fern "github.com/imdb/fern"
 	client "github.com/imdb/fern/client"
 	option "github.com/imdb/fern/option"
 	require "github.com/stretchr/testify/require"
 	gowiremock "github.com/wiremock/go-wiremock"
 	wiremocktestcontainersgo "github.com/wiremock/wiremock-testcontainers-go"
-	http "net/http"
-	os "os"
-	testing "testing"
 )
 
 // TestMain sets up shared test fixtures for all tests in this package// Global test fixtures

--- a/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
@@ -5,16 +5,15 @@ package imdb_test
 import (
 	context "context"
 	fmt "fmt"
-	http "net/http"
-	os "os"
-	testing "testing"
-
 	fern "github.com/imdb/fern"
 	client "github.com/imdb/fern/client"
 	option "github.com/imdb/fern/option"
 	require "github.com/stretchr/testify/require"
 	gowiremock "github.com/wiremock/go-wiremock"
 	wiremocktestcontainersgo "github.com/wiremock/wiremock-testcontainers-go"
+	http "net/http"
+	os "os"
+	testing "testing"
 )
 
 // TestMain sets up shared test fixtures for all tests in this package// Global test fixtures
@@ -88,8 +87,7 @@ func TestMain(m *testing.M) {
 
 		// Construct the URL using internal IP and port
 		WireMockBaseURL = fmt.Sprintf("http://%s:%s", containerIP, containerPort)
-
-		// The container.Client was created with a bad URL, so we need a new one
+		// reconstruct the client with the newly derived internal URL
 		WireMockClient = gowiremock.NewClient(WireMockBaseURL)
 	}
 

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -200,7 +200,7 @@ fixtures:
         useDefaultRequestParameterValues: true
   reserved-keywords: []
 scripts:
-  - docker: golang:1.23.8-alpine3.20
+  - docker: fernapi/go-seed:1.0.0
     commands:
       - CGO_ENABLED=0 go test ./...
 allowedFailures:

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -98,6 +98,9 @@ fixtures:
       customConfig:
         useReaderForBytesRequest: true
   imdb:
+    - outputFolder: with-wiremock-tests
+      customConfig:
+        enableWireTests: true
     - outputFolder: no-custom-config
       customConfig: null
     - outputFolder: package-path


### PR DESCRIPTION
## Description
This should allow wire tests (which use docker-in-docker test containers) to work even in a containerized environment thus allowing them to run in CI as well as locally.

## Changes Made
- publish fernapi/go-seed:1.0.0 image that includes (docker-in-docker)
- Run seed containers in privileged mode to allow full docker-in-docker functionality
- update test logic to use fallback method for acquiring ephemeral ip/port for test-container instances

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
