### PR TITLE
fix(go): nix redundant build step

### DIFF
--- a/generators/go-v2/sdk/build.mjs
+++ b/generators/go-v2/sdk/build.mjs
@@ -9,14 +9,6 @@ const __dirname = dirname(__filename);
 main();
 
 async function main() {
-  await tsup.build({
-    entry: ["src/cli.ts"],
-    format: ["cjs"],
-    minify: false,
-    outDir: "dist",
-    sourcemap: true,
-    clean: true,
-  });
   const filesFoldersToCopy = [
     ["../base/src/asIs", "./dist/asIs"],
   ];

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.13.6
+  changelogEntry:
+    - summary: |
+        Remove occasional double-running of a build step.
+      type: fix
+  createdAt: "2025-10-02"
+  irVersion: 60
 
 - version: 1.13.5
   changelogEntry:


### PR DESCRIPTION
## Description
Linear ticket: Fixes FER-7020
Removes a redundant building step in the `pnpm dist:cli` command for Go.

## Changes Made
Change to `go-v2/sdk/build.mjs`.

## Testing
Reran seed, no changes; can confirm the double build disappears in seed runs.
- [X] Unit tests added/updated
- [X] Manual testing completed
