### PR TITLE
chore(ci): Temporarily turn off python-sdk in nightly balancing (until hanging issues is fixed)

### DIFF
--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -43,7 +43,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Checkout Repo
@@ -124,7 +124,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -43,7 +43,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Checkout Repo
@@ -123,7 +123,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -19,13 +19,12 @@ jobs:
     strategy:
       fail-fast: false # Let all tests run and cascade errors, will only PR generator updates that passed
       matrix:
-        sdk-name:
-          [
+        sdk-name: [
             ruby-model,
             ruby-sdk,
             ruby-sdk-v2,
             pydantic,
-            python-sdk,
+            # python-sdk, Turned off until Python is no longer hangings
             fastapi,
             openapi,
             postman,
@@ -100,12 +99,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk-name: [
+        sdk-name:
+          [
             ruby-model,
             ruby-sdk,
             ruby-sdk-v2,
             pydantic,
-            # python-sdk, Turned off until Python is no longer hanging
+            python-sdk,
             fastapi,
             openapi,
             postman,

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -43,7 +43,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Checkout Repo
@@ -100,13 +100,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk-name:
-          [
+        sdk-name: [
             ruby-model,
             ruby-sdk,
             ruby-sdk-v2,
             pydantic,
-            python-sdk,
+            # python-sdk, Turned off until Python is no longer hanging
             fastapi,
             openapi,
             postman,
@@ -124,7 +123,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -43,7 +43,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Checkout Repo
@@ -124,7 +124,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     steps:
       - name: Make artifacts directory

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -25,21 +25,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        generator-name:
-          [
-            ruby,
-            ruby-v2,
-            openapi,
-            python,
-            postman,
-            java,
-            typescript,
-            go,
-            csharp,
-            php,
-            swift,
-            rust,
-          ]
+        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
         include:
           - files: |
               generators/ruby/
@@ -165,7 +151,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk,
+            rust-sdk
           ]
     outputs:
       ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -25,7 +25,21 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
+        generator-name:
+          [
+            ruby,
+            ruby-v2,
+            openapi,
+            python,
+            postman,
+            java,
+            typescript,
+            go,
+            csharp,
+            php,
+            swift,
+            rust,
+          ]
         include:
           - files: |
               generators/ruby/
@@ -151,7 +165,7 @@ jobs:
             php-sdk,
             swift-sdk,
             rust-model,
-            rust-sdk
+            rust-sdk,
           ]
     outputs:
       ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7025/ci-temporarily-disable-python-sdk-in-nightly-seed-groupings
Closes FER-7025

## Changes Made
- Comment out python-sdk from seed portion of this job

## Testing
- Proof in test branch, skipping python job: https://github.com/fern-api/fern/actions/runs/18198588310
