### PR TITLE
fix(ci): Fix the workflows to pickup after failed jobs while still being cancellable

### DIFF
--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -95,7 +95,7 @@ jobs:
   build-seed-groups:
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure'
+    if: always() && (needs.run-seed-test.result == 'success' || needs.run-seed-test.result == 'failure')
     needs: [run-seed-test]
     strategy:
       fail-fast: false
@@ -167,7 +167,7 @@ jobs:
   pr-seed-group-files:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure'
+    if: always() && (needs.build-seed-groups.result == 'success' || needs.build-seed-groups.result == 'failure')
     needs: [build-seed-groups]
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6999/ci-fix-uses-of-always
Closes FER-6999
Jobs won't pick up from previous failures unless the `always()` call is in the if statement. However, that makes a job un-cancellable so you need to add back other checks alongside it

## Changes Made
- updated if statement for nightly jobs

## Testing
- Tested with CI, continued after python-sdk failure here: https://github.com/fern-api/fern/actions/runs/18201171096
