### PR TITLE
chore(internal): update seed group files

### DIFF
--- a/.github/workflow-resource-files/seed-groups/csharp-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/csharp-model-seed-groups.json
@@ -1,149 +1,150 @@
 {
-  "totalTestTimeSeconds": 14190,
+  "totalTestTimeSeconds": 14247,
   "groups": [
-    {
-      "fixtures": [
-        "query-parameters-openapi",
-        "optional",
-        "literals-unions",
-        "simple-api",
-        "imdb",
-        "single-url-environment-no-default",
-        "empty-clients",
-        "oauth-client-credentials-custom",
-        "objects-with-imports",
-        "trace"
-      ],
-      "groupTotalTimeSeconds": 1460
-    },
-    {
-      "fixtures": [
-        "bytes-upload",
-        "query-parameters",
-        "nullable-optional",
-        "extends",
-        "license",
-        "validation",
-        "error-property",
-        "basic-auth",
-        "mixed-file-directory",
-        "examples"
-      ],
-      "groupTotalTimeSeconds": 1461
-    },
     {
       "fixtures": [
         "version",
         "nullable",
-        "simple-fhir",
-        "no-environment",
-        "file-upload",
-        "websocket-bearer-auth",
-        "path-parameters",
-        "any-auth",
-        "oauth-client-credentials-nested-root",
-        "exhaustive"
-      ],
-      "groupTotalTimeSeconds": 1461
-    },
-    {
-      "fixtures": [
-        "csharp-grpc-proto",
-        "property-access",
-        "public-object",
-        "object",
-        "http-head",
-        "multi-line-docs",
-        "websocket",
-        "oauth-client-credentials-default",
-        "cross-package-type-names",
-        "pagination"
-      ],
-      "groupTotalTimeSeconds": 1460
-    },
-    {
-      "fixtures": [
-        "csharp-system-collision",
-        "api-wide-base-path",
-        "idempotency-headers",
-        "streaming",
-        "pagination-custom",
-        "response-property",
-        "oauth-client-credentials-environment-variables",
-        "enum:forward-compatible-enums",
-        "audiences"
-      ],
-      "groupTotalTimeSeconds": 1391
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "bytes-download",
-        "plain-text",
-        "request-parameters",
-        "unknown",
-        "websocket-inferred-auth",
-        "oauth-client-credentials",
-        "enum:plain-enums",
-        "literal"
-      ],
-      "groupTotalTimeSeconds": 1391
-    },
-    {
-      "fixtures": [
-        "bearer-token-environment-variable",
-        "version-no-default",
-        "reserved-keywords",
-        "streaming-parameter",
-        "undiscriminated-unions",
-        "variables",
-        "inferred-auth-explicit",
+        "optional",
         "csharp-namespace-conflict",
-        "circular-references"
+        "unknown",
+        "empty-clients",
+        "websocket-inferred-auth",
+        "streaming",
+        "client-side-params",
+        "examples"
       ],
-      "groupTotalTimeSeconds": 1391
+      "groupTotalTimeSeconds": 1452
+    },
+    {
+      "fixtures": [
+        "extends",
+        "license",
+        "literals-unions",
+        "single-url-environment-no-default",
+        "public-object",
+        "server-sent-events",
+        "error-property",
+        "custom-auth",
+        "enum:forward-compatible-enums",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 1451
     },
     {
       "fixtures": [
         "accept-header",
-        "auth-environment-variables",
-        "server-sent-event-examples",
-        "server-sent-events",
+        "bytes-upload",
+        "idempotency-headers",
+        "oauth-client-credentials-custom",
+        "multi-url-environment-no-default",
+        "multi-url-environment",
         "single-url-environment-default",
+        "streaming-parameter",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 1392
+    },
+    {
+      "fixtures": [
+        "bytes-download",
+        "content-type",
+        "unions",
+        "undiscriminated-unions",
+        "simple-fhir",
         "csharp-namespace-collision",
-        "client-side-params",
-        "custom-auth",
+        "validation",
+        "objects-with-imports",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 1390
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto",
+        "mixed-case",
+        "csharp-system-collision",
+        "request-parameters",
+        "pagination-custom",
+        "any-auth",
+        "multi-line-docs",
+        "errors",
+        "basic-auth",
         "circular-references-advanced"
       ],
-      "groupTotalTimeSeconds": 1391
+      "groupTotalTimeSeconds": 1452
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto-exhaustive",
+        "nullable-optional",
+        "plain-text",
+        "no-environment",
+        "simple-api",
+        "basic-auth-environment-variables",
+        "inferred-auth-implicit",
+        "extra-properties",
+        "oauth-client-credentials-nested-root",
+        "pagination"
+      ],
+      "groupTotalTimeSeconds": 1450
     },
     {
       "fixtures": [
         "alias",
-        "content-type",
-        "multiple-request-bodies",
+        "query-parameters-openapi-as-objects",
+        "object",
+        "required-nullable",
+        "websocket-bearer-auth",
         "file-download",
-        "basic-auth-environment-variables",
-        "multi-url-environment",
-        "errors",
-        "package-yml",
-        "folders"
+        "websocket",
+        "oauth-client-credentials-with-variables",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 1392
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "version-no-default",
+        "http-head",
+        "reserved-keywords",
+        "path-parameters",
+        "file-upload",
+        "oauth-client-credentials",
+        "mixed-file-directory",
+        "enum:plain-enums"
+      ],
+      "groupTotalTimeSeconds": 1392
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "auth-environment-variables",
+        "imdb",
+        "property-access",
+        "server-sent-event-examples",
+        "inferred-auth-explicit",
+        "variables",
+        "oauth-client-credentials-environment-variables",
+        "cross-package-type-names"
       ],
       "groupTotalTimeSeconds": 1391
     },
     {
       "fixtures": [
-        "alias-extends",
-        "csharp-grpc-proto-exhaustive",
-        "mixed-case",
-        "extra-properties",
-        "unions",
+        "query-parameters-openapi",
+        "bearer-token-environment-variable",
+        "multiple-request-bodies",
+        "oauth-client-credentials-default",
+        "response-property",
         "inferred-auth-implicit-no-expiry",
-        "inferred-auth-implicit",
-        "multi-url-environment-no-default",
-        "oauth-client-credentials-with-variables"
+        "package-yml",
+        "query-parameters",
+        "circular-references",
+        "exhaustive"
       ],
-      "groupTotalTimeSeconds": 1393
+      "groupTotalTimeSeconds": 1485
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/csharp-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/csharp-sdk-seed-groups.json
@@ -1,170 +1,171 @@
 {
-  "totalTestTimeSeconds": 37097,
+  "totalTestTimeSeconds": 37695,
   "groups": [
     {
       "fixtures": [
-        "csharp-grpc-proto-exhaustive:include-exception-handler",
-        "path-parameters:no-custom-config",
-        "nullable",
-        "content-type",
-        "auth-environment-variables",
-        "inferred-auth-implicit-no-expiry",
-        "websocket-inferred-auth",
-        "public-object",
-        "multi-url-environment:no-pascal-case-environments",
-        "basic-auth",
-        "exhaustive:include-exception-handler"
-      ],
-      "groupTotalTimeSeconds": 3680
-    },
-    {
-      "fixtures": [
-        "csharp-grpc-proto-exhaustive:read-only-memory",
-        "bytes-upload",
-        "simple-fhir",
-        "imdb:no-custom-config",
-        "license:mit-license",
-        "csharp-system-collision:system-client",
-        "client-side-params",
-        "undiscriminated-unions",
-        "websocket-bearer-auth",
-        "folders",
-        "audiences",
-        "imdb:exported-client-class-name"
-      ],
-      "groupTotalTimeSeconds": 3685
-    },
-    {
-      "fixtures": [
-        "csharp-grpc-proto",
-        "unions:no-custom-config",
-        "imdb:include-exception-handler",
-        "package-yml",
-        "multi-line-docs",
-        "multiple-request-bodies",
-        "optional:simplify-object-dictionaries",
-        "nullable-optional",
-        "single-url-environment-default",
-        "basic-auth-environment-variables",
-        "exhaustive:no-root-namespace-for-core-classes"
-      ],
-      "groupTotalTimeSeconds": 3678
-    },
-    {
-      "fixtures": [
         "csharp-grpc-proto-exhaustive:no-custom-config",
-        "imdb:extra-dependencies",
-        "file-upload",
-        "license:custom-license",
-        "extra-properties:no-additional-properties",
-        "multi-url-environment-no-default",
-        "query-parameters",
-        "simple-api",
-        "custom-auth",
-        "websocket:no-custom-config",
-        "exhaustive:no-generate-error-types"
-      ],
-      "groupTotalTimeSeconds": 3678
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "csharp-namespace-collision:fully-qualified-namespaces",
-        "oauth-client-credentials:include-exception-handler",
-        "response-property",
-        "optional:no-custom-config",
-        "pagination-custom",
-        "errors",
-        "server-sent-event-examples",
-        "error-property",
-        "examples:readme-config",
-        "exhaustive:explicit-namespaces"
-      ],
-      "groupTotalTimeSeconds": 3672
-    },
-    {
-      "fixtures": [
-        "version-no-default",
-        "version",
-        "extends",
-        "extra-properties:no-custom-config",
-        "path-parameters:no-inline-path-parameters",
-        "empty-clients",
-        "object",
-        "single-url-environment-no-default",
-        "mixed-file-directory",
-        "cross-package-type-names",
-        "pagination:custom-pager-with-exception-handler",
-        "trace"
-      ],
-      "groupTotalTimeSeconds": 3737
-    },
-    {
-      "fixtures": [
-        "bearer-token-environment-variable",
-        "bytes-download",
-        "no-environment",
-        "oauth-client-credentials-default",
-        "http-head",
-        "reserved-keywords",
-        "file-download",
-        "request-parameters",
-        "any-auth",
-        "enum:forward-compatible-enums",
-        "oauth-client-credentials-with-variables"
-      ],
-      "groupTotalTimeSeconds": 3682
-    },
-    {
-      "fixtures": [
-        "alias",
-        "accept-header",
-        "unions:no-discriminated-unions",
         "oauth-client-credentials-environment-variables",
-        "multi-url-environment:environment-class-name",
-        "csharp-namespace-conflict",
-        "mixed-case",
+        "error-property",
         "inferred-auth-implicit",
-        "streaming-parameter",
-        "literal",
-        "circular-references",
-        "pagination:no-custom-config"
+        "license:custom-license",
+        "inferred-auth-explicit",
+        "path-parameters:no-inline-path-parameters",
+        "reserved-keywords",
+        "basic-auth-environment-variables",
+        "mixed-file-directory",
+        "exhaustive:no-generate-error-types",
+        "circular-references-advanced"
       ],
-      "groupTotalTimeSeconds": 3750
-    },
-    {
-      "fixtures": [
-        "alias-extends",
-        "query-parameters-openapi",
-        "idempotency-headers",
-        "oauth-client-credentials-nested-root",
-        "plain-text",
-        "streaming",
-        "unknown",
-        "oauth-client-credentials:no-custom-config",
-        "validation",
-        "examples:no-custom-config",
-        "variables",
-        "pagination:custom-pager"
-      ],
-      "groupTotalTimeSeconds": 3782
+      "groupTotalTimeSeconds": 3805
     },
     {
       "fixtures": [
         "csharp-grpc-proto-exhaustive:package-id",
-        "api-wide-base-path",
-        "imdb:exception-class-names",
-        "inferred-auth-explicit",
-        "literals-unions",
-        "objects-with-imports",
-        "property-access",
-        "websocket:with-websockets",
-        "server-sent-events",
-        "enum:plain-enums",
-        "circular-references-advanced",
+        "unions:no-custom-config",
+        "file-download",
+        "nullable-optional",
+        "content-type",
+        "inferred-auth-implicit-no-expiry",
+        "client-side-params",
+        "oauth-client-credentials:no-custom-config",
+        "multiple-request-bodies",
+        "single-url-environment-no-default",
+        "exhaustive:include-exception-handler",
         "oauth-client-credentials-custom"
       ],
-      "groupTotalTimeSeconds": 3753
+      "groupTotalTimeSeconds": 3813
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto-exhaustive:include-exception-handler",
+        "imdb:no-custom-config",
+        "pagination-custom",
+        "extra-properties:no-custom-config",
+        "package-yml",
+        "path-parameters:no-custom-config",
+        "unknown",
+        "undiscriminated-unions",
+        "optional:simplify-object-dictionaries",
+        "enum:forward-compatible-enums",
+        "exhaustive:explicit-namespaces"
+      ],
+      "groupTotalTimeSeconds": 3701
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "imdb:extra-dependencies",
+        "bytes-download",
+        "response-property",
+        "unions:no-discriminated-unions",
+        "extra-properties:no-additional-properties",
+        "oauth-client-credentials:include-exception-handler",
+        "plain-text",
+        "empty-clients",
+        "enum:plain-enums",
+        "websocket:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 3700
+    },
+    {
+      "fixtures": [
+        "csharp-grpc-proto",
+        "csharp-namespace-collision:fully-qualified-namespaces",
+        "imdb:exception-class-names",
+        "extends",
+        "public-object",
+        "simple-fhir",
+        "literals-unions",
+        "server-sent-event-examples",
+        "websocket-bearer-auth",
+        "object",
+        "examples:readme-config"
+      ],
+      "groupTotalTimeSeconds": 3702
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "version-no-default",
+        "csharp-system-collision:system-client",
+        "any-auth",
+        "imdb:include-exception-handler",
+        "idempotency-headers",
+        "request-parameters",
+        "websocket:with-websockets",
+        "streaming-parameter",
+        "audiences",
+        "imdb:exported-client-class-name",
+        "pagination:custom-pager-with-exception-handler"
+      ],
+      "groupTotalTimeSeconds": 3834
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "api-wide-base-path",
+        "websocket-inferred-auth",
+        "file-upload",
+        "optional:no-custom-config",
+        "multi-url-environment:environment-class-name",
+        "mixed-case",
+        "query-parameters",
+        "basic-auth",
+        "examples:no-custom-config",
+        "pagination:custom-pager",
+        "circular-references"
+      ],
+      "groupTotalTimeSeconds": 3813
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "version",
+        "csharp-namespace-conflict",
+        "multi-url-environment-no-default",
+        "multi-line-docs",
+        "multi-url-environment:no-pascal-case-environments",
+        "simple-api",
+        "single-url-environment-default",
+        "custom-auth",
+        "folders",
+        "variables",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 3816
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "csharp-grpc-proto-exhaustive:read-only-memory",
+        "errors",
+        "objects-with-imports",
+        "oauth-client-credentials-default",
+        "oauth-client-credentials-nested-root",
+        "server-sent-events",
+        "auth-environment-variables",
+        "streaming",
+        "cross-package-type-names",
+        "exhaustive:no-root-namespace-for-core-classes",
+        "pagination:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 3814
+    },
+    {
+      "fixtures": [
+        "alias",
+        "bearer-token-environment-variable",
+        "http-head",
+        "required-nullable",
+        "property-access",
+        "license:mit-license",
+        "nullable",
+        "validation",
+        "no-environment",
+        "literal",
+        "oauth-client-credentials-with-variables"
+      ],
+      "groupTotalTimeSeconds": 3697
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/fastapi-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/fastapi-seed-groups.json
@@ -1,159 +1,160 @@
 {
-  "totalTestTimeSeconds": 3209,
+  "totalTestTimeSeconds": 3301,
   "groups": [
     {
       "fixtures": [
         "trace",
-        "query-parameters-openapi-as-objects",
-        "bearer-token-environment-variable",
-        "mixed-case",
-        "websocket-bearer-auth",
+        "validation",
+        "circular-references:no-custom-config",
+        "variables",
+        "oauth-client-credentials",
+        "single-url-environment-default",
         "imdb:includes-extra-fields",
-        "multi-line-docs",
         "request-parameters",
-        "imdb:async-handlers",
-        "streaming"
+        "http-head",
+        "streaming",
+        "exhaustive:ignore-extra-fields"
       ],
-      "groupTotalTimeSeconds": 315
+      "groupTotalTimeSeconds": 337
     },
     {
       "fixtures": [
         "accept-header",
-        "exhaustive:pydantic-v1",
-        "basic-auth",
+        "unions:no-inheritance-for-extended-models",
+        "bytes-download",
         "circular-references:no-inheritance-for-extended-models",
-        "simple-fhir:no-inheritance-for-extended-models",
-        "public-object",
-        "simple-fhir:no-custom-config",
-        "response-property",
+        "errors",
+        "exhaustive:pydantic-v1",
+        "plain-text",
+        "pagination:no-inheritance-for-extended-models",
         "inferred-auth-explicit",
-        "audiences",
-        "examples"
+        "multiple-request-bodies"
       ],
-      "groupTotalTimeSeconds": 329
-    },
-    {
-      "fixtures": [
-        "alias-extends:no-custom-config",
-        "circular-references-advanced:no-custom-config",
-        "validation",
-        "custom-auth",
-        "undiscriminated-unions",
-        "variables",
-        "client-side-params",
-        "single-url-environment-no-default",
-        "idempotency-headers",
-        "literal",
-        "exhaustive:include-validators"
-      ],
-      "groupTotalTimeSeconds": 329
+      "groupTotalTimeSeconds": 322
     },
     {
       "fixtures": [
         "content-type",
-        "circular-references-advanced:no-inheritance-for-extended-models",
-        "websocket",
+        "unknown",
+        "bytes-upload",
         "empty-clients",
-        "license",
-        "package-yml",
-        "path-parameters",
-        "single-url-environment-default",
-        "any-auth",
-        "enum"
+        "literals-unions",
+        "optional",
+        "simple-api",
+        "query-parameters",
+        "mixed-file-directory",
+        "websocket-inferred-auth"
       ],
-      "groupTotalTimeSeconds": 316
+      "groupTotalTimeSeconds": 322
+    },
+    {
+      "fixtures": [
+        "alias",
+        "nullable-optional",
+        "websocket",
+        "package-yml",
+        "mixed-case",
+        "property-access",
+        "custom-auth",
+        "objects-with-imports",
+        "server-sent-event-examples",
+        "audiences",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 337
     },
     {
       "fixtures": [
         "version",
-        "unions:no-inheritance-for-extended-models",
+        "query-parameters-openapi",
         "auth-environment-variables",
-        "nullable-optional",
-        "oauth-client-credentials-custom",
+        "multi-line-docs",
+        "nullable",
+        "public-object",
+        "error-property",
         "pagination:no-custom-config",
-        "property-access",
-        "mixed-file-directory",
-        "query-parameters",
-        "server-sent-event-examples",
-        "exhaustive:frozen_utils"
+        "file-download:no-custom-config",
+        "response-property",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 338
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "query-parameters-openapi-as-objects",
+        "basic-auth",
+        "multi-url-environment",
+        "single-url-environment-no-default",
+        "required-nullable",
+        "multi-url-environment-no-default",
+        "extra-properties",
+        "oauth-client-credentials-with-variables",
+        "server-sent-events",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 338
+    },
+    {
+      "fixtures": [
+        "alias-extends:no-custom-config",
+        "file-download:no-inheritance-for-extended-models",
+        "exhaustive:pydantic-v2",
+        "websocket-bearer-auth",
+        "object",
+        "client-side-params",
+        "oauth-client-credentials-custom",
+        "file-upload",
+        "imdb:v1_on_v2",
+        "cross-package-type-names"
       ],
       "groupTotalTimeSeconds": 326
     },
     {
       "fixtures": [
-        "version-no-default",
-        "query-parameters-openapi",
-        "unions:no-custom-config",
-        "unknown",
-        "oauth-client-credentials-default",
-        "pagination-custom",
-        "error-property",
-        "objects-with-imports",
-        "http-head",
-        "file-download:no-inheritance-for-extended-models"
-      ],
-      "groupTotalTimeSeconds": 316
-    },
-    {
-      "fixtures": [
-        "alias",
-        "exhaustive:no-custom-config",
-        "bytes-download",
-        "multi-url-environment-no-default",
-        "no-environment",
-        "oauth-client-credentials-nested-root",
-        "extra-properties",
-        "inferred-auth-implicit",
-        "reserved-keywords",
-        "server-sent-events",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 328
-    },
-    {
-      "fixtures": [
         "alias-extends:no-inheritance-for-extended-models",
-        "exhaustive:pydantic-v2",
-        "bytes-upload",
-        "nullable",
-        "oauth-client-credentials-environment-variables",
-        "optional",
-        "literals-unions",
-        "inferred-auth-implicit-no-expiry",
-        "file-upload",
-        "streaming-parameter"
+        "circular-references-advanced:no-inheritance-for-extended-models",
+        "circular-references-advanced:no-custom-config",
+        "simple-fhir:no-inheritance-for-extended-models",
+        "undiscriminated-unions",
+        "simple-fhir:no-custom-config",
+        "oauth-client-credentials-default",
+        "any-auth",
+        "idempotency-headers",
+        "inferred-auth-implicit-no-expiry"
       ],
-      "groupTotalTimeSeconds": 316
+      "groupTotalTimeSeconds": 322
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "exhaustive:ignore-extra-fields",
-        "basic-auth-environment-variables",
-        "exhaustive:skip-formatting",
-        "plain-text",
-        "errors",
-        "imdb:v1_on_v2",
-        "oauth-client-credentials-with-variables",
+        "pagination-custom",
+        "bearer-token-environment-variable",
+        "path-parameters",
+        "license",
+        "reserved-keywords",
+        "oauth-client-credentials-nested-root",
+        "inferred-auth-implicit",
         "imdb:no-custom-config",
-        "websocket-inferred-auth"
+        "streaming-parameter"
       ],
-      "groupTotalTimeSeconds": 316
+      "groupTotalTimeSeconds": 322
     },
     {
       "fixtures": [
         "extends",
-        "file-download:no-custom-config",
-        "circular-references:no-custom-config",
-        "oauth-client-credentials",
-        "object",
-        "pagination:no-inheritance-for-extended-models",
-        "multi-url-environment",
-        "multiple-request-bodies",
-        "simple-api",
-        "folders"
+        "exhaustive:no-custom-config",
+        "basic-auth-environment-variables",
+        "unions:no-custom-config",
+        "no-environment",
+        "exhaustive:skip-formatting",
+        "exhaustive:frozen_utils",
+        "oauth-client-credentials-environment-variables",
+        "imdb:async-handlers",
+        "enum",
+        "exhaustive:include-validators"
       ],
-      "groupTotalTimeSeconds": 318
+      "groupTotalTimeSeconds": 337
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/go-fiber-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-fiber-seed-groups.json
@@ -1,135 +1,123 @@
 {
-  "totalTestTimeSeconds": 4107,
+  "totalTestTimeSeconds": 3954,
   "groups": [
     {
       "fixtures": [
         "accept-header",
-        "go-bytes-request",
-        "error-property",
-        "oauth-client-credentials-default",
-        "variables",
-        "exhaustive",
-        "literal"
+        "bearer-token-environment-variable",
+        "multi-url-environment",
+        "path-parameters",
+        "request-parameters"
       ],
-      "groupTotalTimeSeconds": 414
+      "groupTotalTimeSeconds": 396
+    },
+    {
+      "fixtures": [
+        "alias",
+        "examples",
+        "imdb",
+        "server-sent-event-examples",
+        "response-property",
+        "single-url-environment-no-default",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 396
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "go-bytes-request",
+        "inferred-auth-explicit",
+        "variables",
+        "single-url-environment-default",
+        "streaming:."
+      ],
+      "groupTotalTimeSeconds": 394
     },
     {
       "fixtures": [
         "query-parameters-openapi",
         "alias-extends",
-        "public-object",
-        "simple-fhir",
-        "server-sent-event-examples",
-        "errors",
-        "multiple-request-bodies",
-        "pagination-custom",
-        "circular-references",
-        "circular-references-advanced",
-        "package-yml",
-        "streaming:.",
-        "pagination",
+        "object",
+        "optional",
+        "plain-text",
         "custom-auth",
+        "oauth-client-credentials",
+        "basic-auth-environment-variables",
         "extra-properties",
-        "streaming-parameter",
-        "any-auth",
-        "folders",
-        "reserved-keywords"
+        "no-environment",
+        "oauth-client-credentials-nested-root",
+        "unions",
+        "unknown",
+        "websocket-bearer-auth",
+        "required-nullable",
+        "mixed-file-directory",
+        "idempotency-headers:.",
+        "streaming-parameter"
       ],
-      "groupTotalTimeSeconds": 413
+      "groupTotalTimeSeconds": 395
     },
     {
       "fixtures": [
         "version",
-        "nullable",
+        "mixed-case",
+        "simple-fhir",
+        "circular-references",
         "query-parameters",
-        "path-parameters",
-        "plain-text",
-        "trace",
-        "multi-line-docs",
-        "no-environment",
-        "server-sent-events",
-        "inferred-auth-implicit-no-expiry",
-        "response-property",
-        "basic-auth",
-        "multi-url-environment",
-        "simple-api",
-        "inferred-auth-explicit",
-        "enum",
-        "websocket",
-        "go-content-type",
-        "request-parameters"
+        "errors",
+        "oauth-client-credentials-environment-variables",
+        "circular-references-advanced",
+        "inferred-auth-implicit",
+        "oauth-client-credentials-custom",
+        "public-object",
+        "any-auth",
+        "error-property",
+        "validation",
+        "multi-url-environment-no-default",
+        "license",
+        "audiences",
+        "go-content-type"
       ],
-      "groupTotalTimeSeconds": 411
+      "groupTotalTimeSeconds": 394
     },
     {
       "fixtures": [
         "version-no-default",
-        "client-side-params",
+        "nullable",
         "nullable-optional",
-        "optional",
         "property-access",
-        "websocket-inferred-auth",
-        "multi-url-environment-no-default",
-        "object",
-        "unions",
-        "mixed-case",
-        "single-url-environment-default",
-        "inferred-auth-implicit",
-        "oauth-client-credentials",
-        "unknown",
-        "mixed-file-directory",
-        "literals-unions",
-        "websocket-bearer-auth",
-        "idempotency-headers:."
-      ],
-      "groupTotalTimeSeconds": 409
-    },
-    {
-      "fixtures": ["alias", "content-type", "oauth-client-credentials-nested-root", "basic-auth-environment-variables"],
-      "groupTotalTimeSeconds": 409
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
-        "extends",
+        "multiple-request-bodies",
+        "client-side-params",
+        "inferred-auth-implicit-no-expiry",
+        "objects-with-imports",
+        "multi-line-docs",
+        "oauth-client-credentials-default",
+        "trace",
+        "basic-auth",
+        "pagination",
+        "websocket",
         "oauth-client-credentials-with-variables",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 409
-    },
-    {
-      "fixtures": ["auth-environment-variables", "file-download", "single-url-environment-no-default", "http-head"],
-      "groupTotalTimeSeconds": 409
-    },
-    {
-      "fixtures": [
-        "bearer-token-environment-variable",
-        "query-parameters-openapi-as-objects",
-        "undiscriminated-unions",
-        "imdb"
-      ],
-      "groupTotalTimeSeconds": 409
-    },
-    {
-      "fixtures": [
-        "bytes-download",
-        "file-upload",
-        "oauth-client-credentials-environment-variables",
-        "audiences",
-        "objects-with-imports"
-      ],
-      "groupTotalTimeSeconds": 415
-    },
-    {
-      "fixtures": [
-        "bytes-upload",
-        "examples",
+        "literals-unions",
         "empty-clients",
-        "oauth-client-credentials-custom",
-        "validation",
-        "license"
+        "package-yml"
       ],
-      "groupTotalTimeSeconds": 409
+      "groupTotalTimeSeconds": 394
+    },
+    {
+      "fixtures": ["api-wide-base-path", "extends", "server-sent-events", "undiscriminated-unions"],
+      "groupTotalTimeSeconds": 394
+    },
+    {
+      "fixtures": ["bytes-download", "file-download", "simple-api", "cross-package-type-names", "http-head"],
+      "groupTotalTimeSeconds": 398
+    },
+    {
+      "fixtures": ["bytes-upload", "file-upload", "websocket-inferred-auth", "folders", "exhaustive"],
+      "groupTotalTimeSeconds": 397
+    },
+    {
+      "fixtures": ["content-type", "query-parameters-openapi-as-objects", "enum", "pagination-custom", "literal"],
+      "groupTotalTimeSeconds": 396
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/go-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-model-seed-groups.json
@@ -1,115 +1,125 @@
 {
-  "totalTestTimeSeconds": 4225,
+  "totalTestTimeSeconds": 4067,
   "groups": [
     {
       "fixtures": [
         "version",
-        "nullable",
-        "errors",
+        "validation",
         "multiple-request-bodies",
-        "path-parameters",
-        "multi-line-docs",
-        "server-sent-event-examples",
         "optional",
-        "idempotency-headers:.",
-        "pagination",
-        "error-property",
-        "public-object",
-        "custom-auth",
-        "objects-with-imports",
-        "imdb",
-        "inferred-auth-implicit"
-      ],
-      "groupTotalTimeSeconds": 422
-    },
-    {
-      "fixtures": ["accept-header", "extends", "mixed-file-directory", "literal"],
-      "groupTotalTimeSeconds": 422
-    },
-    {
-      "fixtures": ["alias", "file-download", "oauth-client-credentials-default", "variables"],
-      "groupTotalTimeSeconds": 422
-    },
-    {
-      "fixtures": ["alias-extends", "go-bytes-request", "oauth-client-credentials-with-variables", "websocket"],
-      "groupTotalTimeSeconds": 422
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi",
-        "object",
-        "circular-references",
-        "response-property",
-        "bytes-download",
-        "multi-url-environment",
-        "server-sent-events",
         "simple-fhir",
-        "oauth-client-credentials-custom",
-        "simple-api",
-        "folders",
-        "single-url-environment-default",
-        "examples",
-        "query-parameters",
-        "undiscriminated-unions",
-        "reserved-keywords",
-        "exhaustive"
-      ],
-      "groupTotalTimeSeconds": 426
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "plain-text",
-        "client-side-params",
+        "empty-clients",
         "websocket-inferred-auth",
-        "request-parameters",
-        "multi-url-environment-no-default",
-        "literals-unions",
-        "mixed-case",
-        "streaming:.",
-        "single-url-environment-no-default",
+        "basic-auth-environment-variables",
         "inferred-auth-implicit-no-expiry",
-        "streaming-parameter",
-        "extra-properties",
-        "unions",
-        "unknown",
-        "trace"
+        "single-url-environment-no-default",
+        "path-parameters",
+        "oauth-client-credentials-environment-variables",
+        "single-url-environment-default",
+        "mixed-file-directory",
+        "query-parameters",
+        "enum"
       ],
-      "groupTotalTimeSeconds": 421
+      "groupTotalTimeSeconds": 409
     },
     {
       "fixtures": [
         "version-no-default",
-        "property-access",
-        "pagination-custom",
-        "circular-references-advanced",
-        "nullable-optional",
-        "license",
-        "package-yml",
+        "websocket-bearer-auth",
+        "nullable",
+        "any-auth",
         "no-environment",
+        "websocket",
+        "inferred-auth-explicit",
         "http-head",
-        "oauth-client-credentials-environment-variables",
-        "audiences",
         "oauth-client-credentials",
-        "cross-package-type-names",
-        "oauth-client-credentials-nested-root",
-        "validation",
-        "enum",
-        "basic-auth"
+        "basic-auth",
+        "oauth-client-credentials-custom",
+        "response-property",
+        "variables",
+        "multi-url-environment",
+        "server-sent-event-examples",
+        "literal"
       ],
-      "groupTotalTimeSeconds": 426
+      "groupTotalTimeSeconds": 409
     },
     {
-      "fixtures": ["api-wide-base-path", "bytes-upload", "any-auth", "websocket-bearer-auth"],
-      "groupTotalTimeSeconds": 422
+      "fixtures": [
+        "query-parameters-openapi",
+        "undiscriminated-unions",
+        "literals-unions",
+        "nullable-optional",
+        "plain-text",
+        "unions",
+        "imdb",
+        "inferred-auth-implicit",
+        "oauth-client-credentials-default",
+        "circular-references",
+        "package-yml",
+        "extra-properties",
+        "oauth-client-credentials-with-variables",
+        "client-side-params",
+        "folders",
+        "oauth-client-credentials-nested-root"
+      ],
+      "groupTotalTimeSeconds": 409
     },
     {
-      "fixtures": ["auth-environment-variables", "content-type", "basic-auth-environment-variables", "go-content-type"],
-      "groupTotalTimeSeconds": 421
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "unknown",
+        "mixed-case",
+        "object",
+        "property-access",
+        "circular-references-advanced",
+        "streaming-parameter",
+        "streaming:.",
+        "pagination",
+        "license",
+        "pagination-custom",
+        "multi-line-docs",
+        "simple-api",
+        "idempotency-headers:.",
+        "go-content-type",
+        "objects-with-imports"
+      ],
+      "groupTotalTimeSeconds": 409
     },
     {
-      "fixtures": ["bearer-token-environment-variable", "file-upload", "empty-clients", "inferred-auth-explicit"],
-      "groupTotalTimeSeconds": 421
+      "fixtures": ["accept-header", "bytes-download", "errors", "server-sent-events"],
+      "groupTotalTimeSeconds": 403
+    },
+    {
+      "fixtures": ["alias", "content-type", "examples", "exhaustive", "request-parameters"],
+      "groupTotalTimeSeconds": 409
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "bytes-upload",
+        "cross-package-type-names",
+        "go-bytes-request",
+        "required-nullable"
+      ],
+      "groupTotalTimeSeconds": 408
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "extends",
+        "custom-auth",
+        "multi-url-environment-no-default",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 407
+    },
+    {
+      "fixtures": ["auth-environment-variables", "file-upload", "error-property", "public-object"],
+      "groupTotalTimeSeconds": 402
+    },
+    {
+      "fixtures": ["bearer-token-environment-variable", "file-download", "audiences", "trace"],
+      "groupTotalTimeSeconds": 402
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/go-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-sdk-seed-groups.json
@@ -1,166 +1,165 @@
 {
-  "totalTestTimeSeconds": 9459,
+  "totalTestTimeSeconds": 8582,
   "groups": [
     {
       "fixtures": [
-        "accept-header",
-        "imdb:with-wiremock-tests",
-        "package-yml:no-custom-config",
-        "path-parameters:v0",
-        "multi-url-environment",
-        "nullable",
-        "single-url-environment-no-default",
-        "objects-with-imports",
-        "client-side-params",
-        "idempotency-headers:.",
-        "examples:package-path",
-        "unions:no-custom-config"
-      ],
-      "groupTotalTimeSeconds": 944
-    },
-    {
-      "fixtures": [
         "version",
-        "path-parameters:with-wire-tests",
-        "extra-properties",
-        "path-parameters:no-custom-config",
-        "path-parameters:package-name",
-        "imdb:deep-package-path",
-        "undiscriminated-unions:v0",
-        "inferred-auth-implicit-no-expiry",
-        "server-sent-events",
-        "query-parameters",
-        "basic-auth",
-        "alias-extends",
-        "unions:package-name"
-      ],
-      "groupTotalTimeSeconds": 946
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
-        "file-upload:package-name",
-        "error-property",
-        "multiple-request-bodies",
-        "oauth-client-credentials-nested-root",
+        "pagination",
         "oauth-client-credentials-custom",
-        "websocket",
-        "server-sent-event-examples",
-        "examples:client-name-with-custom-constructor-name",
-        "circular-references-advanced",
-        "unions:v0"
+        "audiences",
+        "cross-package-type-names",
+        "examples:client-name",
+        "imdb:package-path",
+        "variables",
+        "license",
+        "errors",
+        "query-parameters",
+        "examples:readme-config",
+        "basic-auth"
       ],
-      "groupTotalTimeSeconds": 950
+      "groupTotalTimeSeconds": 857
     },
     {
       "fixtures": [
         "query-parameters-openapi",
-        "examples:always-send-required-properties",
-        "response-property",
-        "mixed-case:no-custom-config",
-        "mixed-case:default-values",
+        "oauth-client-credentials-with-variables",
         "mixed-file-directory",
-        "unknown",
-        "public-object",
-        "any-auth",
+        "oauth-client-credentials-nested-root",
+        "folders",
+        "path-parameters:no-custom-config",
+        "multi-line-docs",
         "circular-references",
-        "empty-clients"
+        "go-content-type",
+        "circular-references-advanced",
+        "unions:package-name",
+        "any-auth",
+        "client-side-params"
       ],
-      "groupTotalTimeSeconds": 954
+      "groupTotalTimeSeconds": 854
     },
     {
       "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "examples:no-custom-config",
-        "errors",
-        "license",
-        "inferred-auth-explicit",
-        "literals-unions:no-custom-config",
-        "undiscriminated-unions:no-custom-config",
-        "enum",
-        "basic-auth-environment-variables",
-        "examples:exported-client-name",
-        "websocket-bearer-auth"
+        "accept-header",
+        "file-upload:v0",
+        "oauth-client-credentials-environment-variables",
+        "examples:package-path",
+        "streaming:.",
+        "package-yml:no-custom-config",
+        "optional",
+        "http-head",
+        "bytes-download",
+        "examples:v0",
+        "streaming-parameter"
       ],
-      "groupTotalTimeSeconds": 952
+      "groupTotalTimeSeconds": 855
     },
     {
       "fixtures": [
         "alias",
+        "file-upload:package-name",
+        "simple-fhir",
+        "idempotency-headers:.",
+        "undiscriminated-unions:no-custom-config",
+        "response-property",
+        "simple-api",
+        "custom-auth",
+        "alias-extends",
+        "examples:always-send-required-properties",
+        "request-parameters"
+      ],
+      "groupTotalTimeSeconds": 853
+    },
+    {
+      "fixtures": [
         "version-no-default",
-        "imdb:no-custom-config",
-        "oauth-client-credentials",
-        "streaming:.",
-        "oauth-client-credentials-environment-variables",
-        "go-bytes-request:no-custom-config",
-        "examples:v0",
-        "examples:export-all-requests-at-root",
-        "examples:client-name"
-      ],
-      "groupTotalTimeSeconds": 943
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
-        "bearer-token-environment-variable",
-        "nullable-optional",
-        "oauth-client-credentials-default",
-        "go-content-type",
-        "single-url-environment-default",
-        "go-bytes-request:use-reader-for-bytes-request",
-        "plain-text",
-        "bytes-download",
-        "examples:readme-config"
-      ],
-      "groupTotalTimeSeconds": 946
-    },
-    {
-      "fixtures": [
-        "bytes-upload",
-        "content-type",
-        "optional",
-        "oauth-client-credentials-with-variables",
-        "http-head",
+        "examples:exported-client-name",
+        "enum",
+        "unions:v0",
+        "undiscriminated-unions:v0",
         "validation",
-        "multi-url-environment-no-default",
-        "property-access",
-        "exhaustive",
+        "single-url-environment-default",
+        "go-bytes-request:no-custom-config",
+        "inferred-auth-implicit-no-expiry",
+        "examples:getters-pass-by-value",
         "trace"
       ],
-      "groupTotalTimeSeconds": 942
+      "groupTotalTimeSeconds": 865
     },
     {
       "fixtures": [
-        "extends",
-        "file-upload:v0",
-        "pagination",
-        "simple-api",
-        "imdb:package-path",
-        "audiences",
-        "cross-package-type-names",
-        "folders",
-        "examples:getters-pass-by-value",
-        "variables"
+        "api-wide-base-path",
+        "file-download",
+        "path-parameters:v0",
+        "multi-url-environment-no-default",
+        "mixed-case:default-values",
+        "nullable-optional",
+        "literals-unions:no-custom-config",
+        "inferred-auth-implicit",
+        "property-access",
+        "basic-auth-environment-variables"
       ],
-      "groupTotalTimeSeconds": 943
+      "groupTotalTimeSeconds": 861
     },
     {
       "fixtures": [
         "file-upload:no-custom-config",
-        "file-download",
-        "multi-line-docs",
-        "no-environment",
-        "simple-fhir",
-        "object",
+        "examples:no-custom-config",
+        "objects-with-imports",
+        "imdb:no-custom-config",
+        "unknown",
         "websocket-inferred-auth",
-        "inferred-auth-implicit",
-        "custom-auth",
-        "literal",
-        "streaming-parameter",
-        "pagination-custom",
-        "request-parameters"
+        "websocket",
+        "required-nullable",
+        "public-object",
+        "exhaustive",
+        "pagination-custom"
       ],
-      "groupTotalTimeSeconds": 939
+      "groupTotalTimeSeconds": 854
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "content-type",
+        "server-sent-events",
+        "path-parameters:package-name",
+        "no-environment",
+        "oauth-client-credentials-default",
+        "multiple-request-bodies",
+        "websocket-bearer-auth",
+        "examples:client-name-with-custom-constructor-name",
+        "empty-clients"
+      ],
+      "groupTotalTimeSeconds": 861
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "query-parameters-openapi-as-objects",
+        "single-url-environment-no-default",
+        "server-sent-event-examples",
+        "nullable",
+        "object",
+        "go-bytes-request:use-reader-for-bytes-request",
+        "unions:no-custom-config",
+        "literal",
+        "plain-text"
+      ],
+      "groupTotalTimeSeconds": 861
+    },
+    {
+      "fixtures": [
+        "bytes-upload",
+        "extends",
+        "oauth-client-credentials",
+        "multi-url-environment",
+        "imdb:deep-package-path",
+        "mixed-case:no-custom-config",
+        "extra-properties",
+        "error-property",
+        "examples:export-all-requests-at-root",
+        "inferred-auth-explicit"
+      ],
+      "groupTotalTimeSeconds": 861
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/java-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/java-model-seed-groups.json
@@ -1,150 +1,151 @@
 {
-  "totalTestTimeSeconds": 29186,
+  "totalTestTimeSeconds": 29299,
   "groups": [
     {
       "fixtures": [
         "java-inline-types",
-        "simple-api",
-        "api-wide-base-path",
-        "oauth-client-credentials",
-        "oauth-client-credentials-with-variables",
-        "error-property",
-        "errors",
+        "response-property",
+        "query-parameters-openapi-as-objects",
+        "bearer-token-environment-variable",
+        "java-custom-package-prefix",
+        "client-side-params",
+        "objects-with-imports",
         "query-parameters",
-        "request-parameters",
-        "simple-fhir"
+        "single-url-environment-default",
+        "alias-extends"
       ],
-      "groupTotalTimeSeconds": 2958
+      "groupTotalTimeSeconds": 2938
     },
     {
       "fixtures": [
         "nullable-optional",
+        "simple-fhir",
         "version",
-        "accept-header",
-        "file-upload",
-        "optional",
-        "path-parameters",
-        "undiscriminated-unions",
-        "http-head",
-        "reserved-keywords"
-      ],
-      "groupTotalTimeSeconds": 2879
-    },
-    {
-      "fixtures": [
-        "websocket-bearer-auth",
+        "api-wide-base-path",
         "java-nullable-named-request-types",
-        "inferred-auth-explicit",
-        "content-type",
-        "response-property",
-        "extra-properties",
-        "websocket",
-        "unknown",
-        "mixed-file-directory"
-      ],
-      "groupTotalTimeSeconds": 2877
-    },
-    {
-      "fixtures": [
-        "any-auth",
-        "version-no-default",
-        "auth-environment-variables",
-        "java-builder-extension",
-        "java-custom-package-prefix",
-        "multi-url-environment-no-default",
         "basic-auth",
-        "oauth-client-credentials-custom",
-        "empty-clients",
-        "exhaustive"
+        "trace",
+        "inferred-auth-implicit",
+        "required-nullable"
       ],
-      "groupTotalTimeSeconds": 2943
+      "groupTotalTimeSeconds": 2911
     },
     {
       "fixtures": [
-        "literals-unions",
-        "file-download",
-        "unions",
-        "bytes-download",
-        "oauth-client-credentials-nested-root",
-        "custom-auth",
-        "imdb:disable-required-property-builder-checks",
-        "pagination",
-        "server-sent-events"
-      ],
-      "groupTotalTimeSeconds": 2885
-    },
-    {
-      "fixtures": [
-        "object",
-        "websocket-inferred-auth",
-        "single-url-environment-default",
-        "bearer-token-environment-variable",
-        "circular-references-advanced",
+        "nullable",
         "package-yml",
-        "variables",
-        "imdb:enable-public-constructors",
-        "streaming"
+        "content-type",
+        "java-builder-extension",
+        "oauth-client-credentials-nested-root",
+        "oauth-client-credentials-with-variables",
+        "unknown",
+        "oauth-client-credentials-custom",
+        "examples",
+        "server-sent-event-examples"
       ],
-      "groupTotalTimeSeconds": 2888
+      "groupTotalTimeSeconds": 2967
     },
     {
       "fixtures": [
-        "multiple-request-bodies",
-        "circular-references",
-        "query-parameters-openapi",
-        "inferred-auth-implicit-no-expiry",
-        "license",
-        "client-side-params",
-        "validation",
-        "literal",
-        "cross-package-type-names",
-        "alias-extends"
-      ],
-      "groupTotalTimeSeconds": 2949
-    },
-    {
-      "fixtures": [
-        "plain-text",
-        "java-single-property-endpoint",
-        "server-sent-event-examples",
-        "extends",
+        "undiscriminated-unions",
+        "literals-unions",
+        "server-sent-events",
+        "reserved-keywords",
         "oauth-client-credentials-default",
-        "pagination-custom",
-        "property-access",
-        "oauth-client-credentials-environment-variables",
-        "single-url-environment-no-default",
-        "folders"
+        "imdb:disable-required-property-builder-checks",
+        "idempotency-headers",
+        "cross-package-type-names",
+        "inferred-auth-implicit-no-expiry",
+        "simple-api"
       ],
-      "groupTotalTimeSeconds": 2956
-    },
-    {
-      "fixtures": [
-        "mixed-case",
-        "multi-url-environment",
-        "bytes-upload",
-        "public-object",
-        "objects-with-imports",
-        "multi-line-docs",
-        "enum",
-        "streaming-parameter",
-        "audiences",
-        "examples"
-      ],
-      "groupTotalTimeSeconds": 2955
+      "groupTotalTimeSeconds": 2972
     },
     {
       "fixtures": [
         "java-pagination-deep-cursor-path",
-        "no-environment",
-        "alias",
-        "query-parameters-openapi-as-objects",
-        "nullable",
-        "basic-auth-environment-variables",
-        "inferred-auth-implicit",
-        "trace",
-        "idempotency-headers"
+        "mixed-case",
+        "property-access",
+        "bytes-upload",
+        "object",
+        "enum",
+        "streaming-parameter",
+        "extra-properties",
+        "pagination-custom",
+        "exhaustive"
       ],
-      "groupTotalTimeSeconds": 2896
+      "groupTotalTimeSeconds": 2971
+    },
+    {
+      "fixtures": [
+        "custom-auth",
+        "errors",
+        "file-download",
+        "circular-references",
+        "inferred-auth-explicit",
+        "websocket",
+        "oauth-client-credentials-environment-variables",
+        "path-parameters",
+        "public-object"
+      ],
+      "groupTotalTimeSeconds": 2880
+    },
+    {
+      "fixtures": [
+        "any-auth",
+        "optional",
+        "accept-header",
+        "extends",
+        "alias",
+        "pagination",
+        "multi-line-docs",
+        "oauth-client-credentials",
+        "request-parameters"
+      ],
+      "groupTotalTimeSeconds": 2907
+    },
+    {
+      "fixtures": [
+        "validation",
+        "license",
+        "auth-environment-variables",
+        "plain-text",
+        "file-upload",
+        "audiences",
+        "literal",
+        "multi-url-environment-no-default",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 2882
+    },
+    {
+      "fixtures": [
+        "variables",
+        "error-property",
+        "multi-url-environment",
+        "query-parameters-openapi",
+        "java-single-property-endpoint",
+        "mixed-file-directory",
+        "unions",
+        "http-head",
+        "websocket-inferred-auth",
+        "empty-clients"
+      ],
+      "groupTotalTimeSeconds": 2920
+    },
+    {
+      "fixtures": [
+        "multiple-request-bodies",
+        "basic-auth-environment-variables",
+        "bytes-download",
+        "version-no-default",
+        "no-environment",
+        "websocket-bearer-auth",
+        "imdb:enable-public-constructors",
+        "streaming",
+        "circular-references-advanced",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 2951
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/java-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/java-sdk-seed-groups.json
@@ -1,175 +1,176 @@
 {
-  "totalTestTimeSeconds": 51121,
+  "totalTestTimeSeconds": 50577,
   "groups": [
     {
       "fixtures": [
         "trace",
-        "public-object",
-        "nullable:no-custom-config",
-        "java-pagination-deep-cursor-path:wire-tests",
-        "error-property",
-        "exhaustive:custom-license",
-        "exhaustive:enable-public-constructors",
-        "validation",
         "nullable-optional:with-nullable-annotation",
-        "extra-properties",
-        "path-parameters"
-      ],
-      "groupTotalTimeSeconds": 5092
-    },
-    {
-      "fixtures": [
-        "version:no-custom-config",
-        "file-download",
-        "variables",
+        "plain-text",
+        "object",
         "java-inline-types:no-inline",
-        "alias",
-        "examples:default",
-        "java-pagination-deep-cursor-path",
-        "examples:no-custom-config",
-        "http-head",
-        "enum:no-custom-config",
-        "property-access",
-        "bytes-download"
+        "exhaustive:custom-error-names",
+        "java-inline-types:enable-forward-compatible-enums",
+        "oauth-client-credentials-nested-root",
+        "exhaustive:flat-package-layout",
+        "literal",
+        "single-url-environment-no-default",
+        "exhaustive:publish-to"
       ],
-      "groupTotalTimeSeconds": 5155
+      "groupTotalTimeSeconds": 5072
     },
     {
       "fixtures": [
-        "java-nullable-named-request-types:custom-config",
+        "response-property",
         "java-single-property-endpoint",
-        "nullable:wrapped-aliases",
-        "errors",
-        "literal",
-        "no-environment",
-        "exhaustive:json-include-non-empty",
-        "basic-auth-environment-variables",
-        "client-side-params:default",
-        "enum:forward-compatible-enums",
-        "oauth-client-credentials",
+        "java-pagination-deep-cursor-path",
+        "extends",
+        "query-parameters-openapi-as-objects",
+        "license",
+        "java-inline-types:inline",
+        "examples:no-custom-config",
+        "property-access",
+        "query-parameters",
+        "server-sent-event-examples",
         "pagination-custom"
       ],
-      "groupTotalTimeSeconds": 5081
+      "groupTotalTimeSeconds": 5032
     },
     {
       "fixtures": [
-        "auth-environment-variables",
-        "multi-url-environment",
-        "circular-references",
-        "query-parameters-openapi",
-        "java-builder-extension:base-client",
-        "java-inline-types:no-wrapped-aliases",
-        "imdb:disable-required-property-builder-checks",
-        "java-builder-extension:extensible-builders",
-        "basic-auth",
-        "oauth-client-credentials-nested-root",
-        "reserved-keywords",
-        "exhaustive:local-files"
-      ],
-      "groupTotalTimeSeconds": 5134
-    },
-    {
-      "fixtures": [
-        "bearer-token-environment-variable",
-        "single-url-environment-default",
-        "multiple-request-bodies",
+        "multi-url-environment-no-default",
+        "version:forward-compatible-enums",
         "java-custom-package-prefix",
-        "multi-line-docs",
-        "folders",
+        "request-parameters",
+        "circular-references",
+        "mixed-case",
         "file-upload:no-custom-config",
-        "streaming",
+        "exhaustive:custom-dependency",
         "websocket",
+        "variables",
+        "exhaustive:local-files",
+        "exhaustive:forward-compatible-enums"
+      ],
+      "groupTotalTimeSeconds": 5110
+    },
+    {
+      "fixtures": [
+        "basic-auth-environment-variables",
         "objects-with-imports",
-        "exhaustive:custom-client-class-name",
+        "mixed-file-directory",
+        "optional",
+        "path-parameters",
+        "nullable:no-custom-config",
+        "empty-clients",
+        "any-auth",
+        "websocket-bearer-auth",
+        "exhaustive:json-include-non-empty",
+        "simple-fhir",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 5108
+    },
+    {
+      "fixtures": [
+        "oauth-client-credentials-custom",
+        "accept-header",
+        "public-object",
+        "content-type",
+        "unions:default",
+        "literals-unions",
+        "oauth-client-credentials",
+        "error-property",
+        "http-head",
+        "undiscriminated-unions",
+        "folders",
         "alias-extends"
       ],
-      "groupTotalTimeSeconds": 5154
+      "groupTotalTimeSeconds": 5074
     },
     {
       "fixtures": [
+        "custom-auth",
         "api-wide-base-path",
-        "circular-references-advanced",
-        "package-yml",
-        "query-parameters-openapi-as-objects",
-        "version-no-default",
-        "exhaustive:custom-error-names",
-        "pagination:default",
+        "bearer-token-environment-variable",
+        "nullable:wrapped-aliases",
+        "cross-package-type-names",
+        "multi-url-environment",
+        "exhaustive:custom-client-class-name",
+        "unknown",
+        "exhaustive:no-custom-config",
+        "enum:forward-compatible-enums",
+        "simple-api",
+        "inferred-auth-explicit"
+      ],
+      "groupTotalTimeSeconds": 5024
+    },
+    {
+      "fixtures": [
+        "oauth-client-credentials-default",
+        "alias",
+        "no-environment",
+        "enum:no-custom-config",
+        "version:no-custom-config",
+        "client-side-params:default",
+        "basic-auth",
         "idempotency-headers",
-        "server-sent-event-examples",
-        "unions:default",
-        "request-parameters",
+        "imdb:disable-required-property-builder-checks",
+        "audiences",
+        "exhaustive:signed_publish",
+        "inferred-auth-implicit-no-expiry"
+      ],
+      "groupTotalTimeSeconds": 5024
+    },
+    {
+      "fixtures": [
+        "circular-references-advanced",
+        "file-upload:inline-file-properties",
+        "multiple-request-bodies",
+        "java-nullable-named-request-types:custom-config",
+        "query-parameters-openapi",
+        "java-inline-types:no-wrapped-aliases",
+        "multi-line-docs",
+        "imdb:flat-package-layout",
+        "examples:inline-file-properties",
+        "exhaustive:enable-public-constructors",
+        "exhaustive:custom-license",
+        "inferred-auth-implicit",
         "websocket-inferred-auth"
       ],
-      "groupTotalTimeSeconds": 5081
-    },
-    {
-      "fixtures": [
-        "bytes-upload",
-        "query-parameters",
-        "custom-auth",
-        "mixed-file-directory",
-        "multi-url-environment-no-default",
-        "file-upload:wrapped-aliases",
-        "mixed-case",
-        "unknown",
-        "cross-package-type-names",
-        "server-sent-events",
-        "empty-clients",
-        "streaming-parameter",
-        "inferred-auth-implicit"
-      ],
-      "groupTotalTimeSeconds": 5082
+      "groupTotalTimeSeconds": 5031
     },
     {
       "fixtures": [
         "oauth-client-credentials-environment-variables",
-        "nullable-optional:legacy",
-        "license",
-        "accept-header",
-        "java-inline-types:enable-forward-compatible-enums",
-        "exhaustive:forward-compatible-enums",
-        "undiscriminated-unions",
-        "examples:inline-file-properties",
-        "exhaustive:custom-dependency",
-        "file-upload:inline-file-properties",
-        "exhaustive:signed_publish"
-      ],
-      "groupTotalTimeSeconds": 5091
-    },
-    {
-      "fixtures": [
-        "simple-fhir",
-        "oauth-client-credentials-default",
-        "any-auth",
-        "literals-unions",
-        "object",
-        "audiences",
-        "examples:readme-config",
-        "imdb:flat-package-layout",
-        "websocket-bearer-auth",
-        "oauth-client-credentials-custom",
-        "plain-text",
-        "inferred-auth-explicit",
-        "inferred-auth-implicit-no-expiry"
-      ],
-      "groupTotalTimeSeconds": 5082
-    },
-    {
-      "fixtures": [
-        "single-url-environment-no-default",
-        "extends",
-        "response-property",
+        "pagination:default",
+        "single-url-environment-default",
+        "auth-environment-variables",
+        "file-download",
+        "package-yml",
+        "extra-properties",
+        "java-builder-extension:extensible-builders",
         "oauth-client-credentials-with-variables",
-        "version:forward-compatible-enums",
-        "content-type",
-        "java-inline-types:inline",
-        "simple-api",
-        "exhaustive:no-custom-config",
-        "exhaustive:flat-package-layout",
-        "optional",
-        "exhaustive:publish-to"
+        "examples:readme-config",
+        "required-nullable",
+        "bytes-download"
       ],
-      "groupTotalTimeSeconds": 5169
+      "groupTotalTimeSeconds": 5074
+    },
+    {
+      "fixtures": [
+        "nullable-optional:legacy",
+        "bytes-upload",
+        "version-no-default",
+        "reserved-keywords",
+        "file-upload:wrapped-aliases",
+        "java-pagination-deep-cursor-path:wire-tests",
+        "errors",
+        "java-builder-extension:base-client",
+        "validation",
+        "examples:default",
+        "streaming",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 5028
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/java-spring-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/java-spring-seed-groups.json
@@ -1,151 +1,152 @@
 {
-  "totalTestTimeSeconds": 2184,
+  "totalTestTimeSeconds": 2200,
   "groups": [
     {
       "fixtures": [
         "trace",
-        "circular-references",
-        "inferred-auth-implicit-no-expiry",
-        "simple-api",
-        "validation",
-        "error-property",
-        "oauth-client-credentials-nested-root",
+        "websocket-inferred-auth",
+        "basic-auth",
+        "inferred-auth-explicit",
+        "multi-url-environment-no-default",
+        "multi-url-environment",
+        "single-url-environment-no-default",
         "license"
       ],
-      "groupTotalTimeSeconds": 212
-    },
-    {
-      "fixtures": [
-        "nullable-optional:with-nullable-annotation",
-        "bytes-download",
-        "file-upload",
-        "oauth-client-credentials",
-        "custom-auth",
-        "pagination-custom",
-        "java-pagination-deep-cursor-path",
-        "oauth-client-credentials-with-variables",
-        "audiences",
-        "literals-unions"
-      ],
-      "groupTotalTimeSeconds": 224
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "alias",
-        "java-inline-types",
-        "undiscriminated-unions",
-        "empty-clients",
-        "path-parameters",
-        "multiple-request-bodies",
-        "server-sent-events",
-        "cross-package-type-names",
-        "folders"
-      ],
-      "groupTotalTimeSeconds": 223
-    },
-    {
-      "fixtures": [
-        "content-type:package-prefix",
-        "api-wide-base-path",
-        "nullable",
-        "basic-auth",
-        "oauth-client-credentials-custom",
-        "property-access",
-        "objects-with-imports",
-        "single-url-environment-default",
-        "examples",
-        "idempotency-headers"
-      ],
-      "groupTotalTimeSeconds": 223
-    },
-    {
-      "fixtures": [
-        "java-nullable-named-request-types",
-        "auth-environment-variables",
-        "request-parameters",
-        "inferred-auth-explicit",
-        "oauth-client-credentials-default",
-        "query-parameters",
-        "package-yml",
-        "unknown",
-        "imdb:enable-public-constructors",
-        "no-environment"
-      ],
-      "groupTotalTimeSeconds": 223
+      "groupTotalTimeSeconds": 214
     },
     {
       "fixtures": [
         "nullable-optional:legacy",
-        "bearer-token-environment-variable",
-        "pagination",
-        "circular-references-advanced",
-        "reserved-keywords",
+        "bytes-download",
+        "java-inline-types",
+        "inferred-auth-implicit-no-expiry",
+        "query-parameters",
+        "any-auth",
         "response-property",
-        "single-url-environment-no-default",
-        "public-object",
-        "java-builder-extension",
+        "oauth-client-credentials-with-variables",
+        "literals-unions",
+        "imdb:disable-required-property-builder-checks"
+      ],
+      "groupTotalTimeSeconds": 223
+    },
+    {
+      "fixtures": [
+        "nullable-optional:with-nullable-annotation",
+        "alias-extends",
+        "unions",
+        "object",
+        "websocket-bearer-auth",
+        "empty-clients",
+        "server-sent-event-examples",
+        "objects-with-imports",
+        "mixed-file-directory",
         "http-head"
       ],
       "groupTotalTimeSeconds": 221
     },
     {
       "fixtures": [
-        "query-parameters-openapi",
-        "extends",
-        "errors",
-        "any-auth",
-        "mixed-case",
-        "multi-url-environment",
-        "websocket",
-        "enum",
-        "optional",
-        "imdb:disable-required-property-builder-checks"
+        "accept-header",
+        "auth-environment-variables",
+        "exhaustive",
+        "inferred-auth-implicit",
+        "circular-references",
+        "multi-line-docs",
+        "oauth-client-credentials-default",
+        "multiple-request-bodies",
+        "plain-text",
+        "file-upload"
       ],
-      "groupTotalTimeSeconds": 220
+      "groupTotalTimeSeconds": 217
+    },
+    {
+      "fixtures": [
+        "java-nullable-named-request-types",
+        "bearer-token-environment-variable",
+        "circular-references-advanced",
+        "path-parameters",
+        "mixed-case",
+        "oauth-client-credentials-custom",
+        "oauth-client-credentials-environment-variables",
+        "optional",
+        "public-object"
+      ],
+      "groupTotalTimeSeconds": 211
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "content-type:package-prefix",
+        "pagination-custom",
+        "request-parameters",
+        "oauth-client-credentials",
+        "reserved-keywords",
+        "oauth-client-credentials-nested-root",
+        "required-nullable",
+        "idempotency-headers",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 223
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "simple-fhir",
-        "exhaustive",
-        "websocket-inferred-auth",
-        "multi-line-docs",
-        "oauth-client-credentials-environment-variables",
-        "websocket-bearer-auth",
-        "java-custom-package-prefix",
-        "plain-text",
-        "file-download"
+        "extends",
+        "undiscriminated-unions",
+        "validation",
+        "pagination",
+        "simple-api",
+        "package-yml",
+        "server-sent-events",
+        "imdb:enable-public-constructors",
+        "cross-package-type-names"
       ],
-      "groupTotalTimeSeconds": 216
+      "groupTotalTimeSeconds": 223
     },
     {
       "fixtures": [
         "version",
-        "client-side-params",
-        "unions",
+        "simple-fhir",
+        "file-download",
+        "property-access",
         "basic-auth-environment-variables",
-        "multi-url-environment-no-default",
-        "object",
-        "extra-properties",
-        "mixed-file-directory",
-        "java-single-property-endpoint"
+        "streaming",
+        "streaming-parameter",
+        "single-url-environment-default",
+        "java-builder-extension",
+        "examples"
       ],
-      "groupTotalTimeSeconds": 211
+      "groupTotalTimeSeconds": 223
     },
     {
       "fixtures": [
         "version-no-default",
-        "alias-extends",
+        "client-side-params",
         "bytes-upload",
-        "inferred-auth-implicit",
-        "server-sent-event-examples",
-        "streaming-parameter",
-        "streaming",
-        "literal",
-        "variables"
+        "unknown",
+        "custom-auth",
+        "variables",
+        "error-property",
+        "java-custom-package-prefix",
+        "enum",
+        "java-single-property-endpoint"
       ],
-      "groupTotalTimeSeconds": 211
+      "groupTotalTimeSeconds": 223
+    },
+    {
+      "fixtures": [
+        "alias",
+        "api-wide-base-path",
+        "nullable",
+        "websocket",
+        "errors",
+        "java-pagination-deep-cursor-path",
+        "extra-properties",
+        "no-environment",
+        "literal",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 222
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/openapi-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/openapi-seed-groups.json
@@ -1,148 +1,149 @@
 {
-  "totalTestTimeSeconds": 1069,
+  "totalTestTimeSeconds": 1007,
   "groups": [
     {
       "fixtures": [
-        "version",
-        "objects-with-imports",
+        "query-parameters-openapi",
+        "oauth-client-credentials-environment-variables",
+        "oauth-client-credentials-custom",
         "pagination",
-        "nullable-optional",
-        "inferred-auth-implicit",
-        "inferred-auth-implicit-no-expiry",
+        "folders",
         "imdb:json-format",
-        "property-access",
-        "response-property",
-        "multi-url-environment",
-        "error-property"
+        "any-auth",
+        "package-yml",
+        "multi-line-docs",
+        "server-sent-events",
+        "exhaustive"
       ],
-      "groupTotalTimeSeconds": 107
+      "groupTotalTimeSeconds": 102
+    },
+    {
+      "fixtures": [
+        "version",
+        "enum:no-custom-config",
+        "enum:custom-overrides",
+        "oauth-client-credentials-with-variables",
+        "audiences",
+        "client-side-params",
+        "literals-unions",
+        "path-parameters",
+        "multi-url-environment",
+        "single-url-environment-default",
+        "extra-properties"
+      ],
+      "groupTotalTimeSeconds": 102
     },
     {
       "fixtures": [
         "accept-header",
         "bytes-upload",
-        "websocket-inferred-auth",
-        "path-parameters",
-        "oauth-client-credentials-custom",
-        "basic-auth-environment-variables",
-        "streaming-parameter",
-        "validation"
+        "nullable",
+        "inferred-auth-implicit-no-expiry",
+        "custom-auth",
+        "plain-text",
+        "multi-url-environment-no-default",
+        "single-url-environment-no-default",
+        "oauth-client-credentials"
       ],
-      "groupTotalTimeSeconds": 107
+      "groupTotalTimeSeconds": 102
     },
     {
       "fixtures": [
         "alias",
-        "file-upload",
-        "trace",
+        "content-type",
         "optional",
-        "literals-unions",
-        "simple-api",
-        "undiscriminated-unions",
-        "variables"
-      ],
-      "groupTotalTimeSeconds": 107
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi",
-        "oauth-client-credentials-nested-root",
-        "inferred-auth-explicit",
-        "oauth-client-credentials-with-variables",
-        "literal",
-        "mixed-case",
         "license",
-        "server-sent-events",
-        "single-url-environment-no-default",
-        "request-parameters",
-        "extra-properties"
-      ],
-      "groupTotalTimeSeconds": 107
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "oauth-client-credentials-default",
-        "enum:custom-overrides",
-        "mixed-file-directory",
-        "audiences",
-        "examples",
-        "imdb:no-custom-config",
+        "errors",
+        "property-access",
         "pagination-custom",
-        "public-object",
-        "imdb:override",
-        "websocket"
+        "streaming-parameter",
+        "websocket-inferred-auth"
       ],
-      "groupTotalTimeSeconds": 107
-    },
-    {
-      "fixtures": [
-        "version-no-default",
-        "oauth-client-credentials-environment-variables",
-        "exhaustive",
-        "nullable",
-        "enum:no-custom-config",
-        "folders",
-        "imdb:custom-filename",
-        "plain-text",
-        "query-parameters",
-        "imdb:custom-overrides",
-        "websocket-bearer-auth"
-      ],
-      "groupTotalTimeSeconds": 107
+      "groupTotalTimeSeconds": 102
     },
     {
       "fixtures": [
         "alias-extends",
-        "bytes-download",
-        "empty-clients",
-        "idempotency-headers",
-        "object",
-        "multiple-request-bodies",
-        "unions",
-        "custom-auth",
-        "multi-line-docs"
+        "extends",
+        "circular-references",
+        "inferred-auth-explicit",
+        "http-head",
+        "reserved-keywords",
+        "public-object",
+        "undiscriminated-unions"
       ],
-      "groupTotalTimeSeconds": 109
+      "groupTotalTimeSeconds": 99
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "content-type",
+        "file-upload",
         "circular-references-advanced",
-        "simple-fhir",
-        "package-yml",
-        "oauth-client-credentials",
-        "any-auth",
-        "reserved-keywords"
+        "multiple-request-bodies",
+        "idempotency-headers",
+        "streaming",
+        "query-parameters",
+        "unknown"
       ],
-      "groupTotalTimeSeconds": 106
+      "groupTotalTimeSeconds": 99
     },
     {
       "fixtures": [
         "auth-environment-variables",
-        "extends",
-        "client-side-params",
-        "circular-references",
-        "multi-url-environment-no-default",
-        "single-url-environment-default",
-        "basic-auth",
-        "server-sent-event-examples"
+        "file-download",
+        "literal",
+        "simple-fhir",
+        "inferred-auth-implicit",
+        "unions",
+        "request-parameters",
+        "variables"
       ],
-      "groupTotalTimeSeconds": 106
+      "groupTotalTimeSeconds": 99
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "mixed-file-directory",
+        "oauth-client-credentials-default",
+        "nullable-optional",
+        "cross-package-type-names",
+        "imdb:custom-overrides",
+        "no-environment",
+        "validation",
+        "required-nullable",
+        "websocket"
+      ],
+      "groupTotalTimeSeconds": 99
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "objects-with-imports",
+        "oauth-client-credentials-nested-root",
+        "trace",
+        "examples",
+        "imdb:custom-filename",
+        "object",
+        "basic-auth",
+        "imdb:no-custom-config",
+        "response-property",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 102
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "file-download",
-        "cross-package-type-names",
-        "http-head",
-        "no-environment",
-        "streaming",
-        "errors",
-        "unknown"
+        "bytes-download",
+        "mixed-case",
+        "empty-clients",
+        "simple-api",
+        "basic-auth-environment-variables",
+        "imdb:override",
+        "server-sent-event-examples",
+        "error-property"
       ],
-      "groupTotalTimeSeconds": 106
+      "groupTotalTimeSeconds": 101
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/php-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/php-model-seed-groups.json
@@ -1,143 +1,144 @@
 {
-  "totalTestTimeSeconds": 4238,
+  "totalTestTimeSeconds": 4338,
   "groups": [
     {
       "fixtures": [
-        "version-no-default",
-        "nullable",
-        "mixed-case",
-        "basic-auth-environment-variables",
-        "license",
-        "server-sent-events",
-        "any-auth",
-        "custom-auth",
-        "enum"
-      ],
-      "groupTotalTimeSeconds": 426
-    },
-    {
-      "fixtures": [
         "alias-extends",
-        "unions",
-        "inferred-auth-explicit",
-        "multi-url-environment",
-        "query-parameters",
-        "multi-url-environment-no-default",
+        "nullable-optional",
+        "error-property",
+        "circular-references-advanced",
+        "license",
         "errors",
-        "literals-unions",
-        "audiences"
+        "websocket-bearer-auth",
+        "oauth-client-credentials-with-variables",
+        "mixed-file-directory"
       ],
-      "groupTotalTimeSeconds": 424
+      "groupTotalTimeSeconds": 438
     },
     {
       "fixtures": [
         "query-parameters-openapi",
         "client-side-params",
+        "property-access",
         "basic-auth",
-        "circular-references-advanced",
-        "oauth-client-credentials-environment-variables",
-        "variables",
-        "http-head",
-        "public-object",
-        "examples"
+        "circular-references",
+        "streaming-parameter",
+        "request-parameters",
+        "multi-url-environment-no-default",
+        "enum"
       ],
-      "groupTotalTimeSeconds": 424
+      "groupTotalTimeSeconds": 435
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "nullable-optional",
-        "empty-clients",
-        "extra-properties",
-        "oauth-client-credentials-nested-root",
-        "multi-line-docs",
-        "error-property",
-        "imdb",
-        "literal"
-      ],
-      "groupTotalTimeSeconds": 426
-    },
-    {
-      "fixtures": [
-        "extends",
-        "file-download",
-        "objects-with-imports",
-        "websocket-bearer-auth",
-        "unknown",
-        "pagination-custom",
-        "plain-text",
-        "optional",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 432
-    },
-    {
-      "fixtures": [
-        "bearer-token-environment-variable",
-        "bytes-upload",
-        "inferred-auth-implicit",
-        "oauth-client-credentials-default",
-        "request-parameters",
-        "oauth-client-credentials-with-variables",
-        "idempotency-headers",
-        "server-sent-event-examples",
-        "folders"
-      ],
-      "groupTotalTimeSeconds": 430
-    },
-    {
-      "fixtures": [
-        "file-upload",
-        "content-type",
-        "oauth-client-credentials-custom",
-        "single-url-environment-no-default",
-        "reserved-keywords",
+        "unions",
         "object",
-        "oauth-client-credentials",
-        "streaming",
-        "exhaustive"
-      ],
-      "groupTotalTimeSeconds": 429
-    },
-    {
-      "fixtures": [
-        "alias",
-        "auth-environment-variables",
-        "property-access",
-        "websocket-inferred-auth",
-        "no-environment",
-        "path-parameters",
-        "response-property",
-        "single-url-environment-default"
-      ],
-      "groupTotalTimeSeconds": 408
-    },
-    {
-      "fixtures": [
-        "version",
-        "bytes-download",
-        "simple-fhir",
-        "circular-references",
-        "websocket",
         "undiscriminated-unions",
-        "simple-api",
-        "mixed-file-directory",
+        "extra-properties",
+        "unknown",
+        "simple-fhir",
+        "websocket",
         "trace"
       ],
-      "groupTotalTimeSeconds": 431
+      "groupTotalTimeSeconds": 434
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "mixed-case",
+        "nullable",
+        "single-url-environment-default",
+        "streaming",
+        "custom-auth",
+        "oauth-client-credentials-default",
+        "variables",
+        "audiences"
+      ],
+      "groupTotalTimeSeconds": 433
     },
     {
       "fixtures": [
         "accept-header",
-        "api-wide-base-path",
-        "streaming-parameter",
+        "extends",
+        "imdb",
+        "inferred-auth-implicit",
+        "oauth-client-credentials-environment-variables",
         "inferred-auth-implicit-no-expiry",
-        "multiple-request-bodies",
+        "required-nullable",
+        "multi-url-environment",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 438
+    },
+    {
+      "fixtures": [
+        "alias",
+        "file-download",
+        "oauth-client-credentials",
+        "multi-line-docs",
+        "oauth-client-credentials-nested-root",
+        "path-parameters",
+        "reserved-keywords",
+        "pagination-custom",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 437
+    },
+    {
+      "fixtures": [
+        "version",
+        "file-upload",
+        "query-parameters",
+        "oauth-client-credentials-custom",
+        "objects-with-imports",
+        "server-sent-event-examples",
+        "response-property",
+        "literals-unions",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 438
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "bytes-download",
+        "http-head",
+        "plain-text",
         "package-yml",
+        "simple-api",
+        "server-sent-events",
         "pagination",
+        "cross-package-type-names"
+      ],
+      "groupTotalTimeSeconds": 437
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "bytes-upload",
+        "websocket-inferred-auth",
+        "public-object",
+        "single-url-environment-no-default",
+        "basic-auth-environment-variables",
+        "any-auth",
+        "optional",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 436
+    },
+    {
+      "fixtures": [
+        "bearer-token-environment-variable",
+        "content-type",
+        "idempotency-headers",
+        "empty-clients",
+        "multiple-request-bodies",
+        "inferred-auth-explicit",
+        "no-environment",
         "validation"
       ],
-      "groupTotalTimeSeconds": 408
+      "groupTotalTimeSeconds": 412
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/php-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/php-sdk-seed-groups.json
@@ -1,157 +1,158 @@
 {
-  "totalTestTimeSeconds": 8100,
+  "totalTestTimeSeconds": 7461,
   "groups": [
     {
       "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "pagination:property-accessors",
-        "path-parameters:inline-path-parameters",
-        "oauth-client-credentials-custom",
-        "path-parameters:inline-path-parameters-private",
-        "imdb:clientName",
-        "property-access",
-        "server-sent-events",
-        "public-object",
-        "websocket-bearer-auth"
-      ],
-      "groupTotalTimeSeconds": 822
-    },
-    {
-      "fixtures": [
         "query-parameters-openapi",
-        "nullable",
-        "pagination:no-custom-config",
-        "enum",
-        "websocket-inferred-auth",
+        "oauth-client-credentials-environment-variables",
+        "inferred-auth-explicit",
+        "custom-auth",
+        "basic-auth-environment-variables",
+        "undiscriminated-unions",
+        "single-url-environment-default",
+        "extra-properties",
         "objects-with-imports",
-        "query-parameters:no-custom-config",
-        "single-url-environment-no-default",
-        "streaming-parameter",
-        "circular-references-advanced"
+        "trace"
       ],
-      "groupTotalTimeSeconds": 821
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
-        "any-auth",
-        "errors",
-        "alias:composer-json",
-        "response-property",
-        "multi-line-docs",
-        "reserved-keywords",
-        "audiences",
-        "cross-package-type-names",
-        "folders"
-      ],
-      "groupTotalTimeSeconds": 822
+      "groupTotalTimeSeconds": 734
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "inferred-auth-explicit",
-        "custom-auth",
         "mixed-case",
-        "imdb:no-custom-config",
-        "imdb:packageName",
-        "imdb:private",
-        "package-yml:no-custom-config",
-        "literals-unions",
-        "exhaustive"
-      ],
-      "groupTotalTimeSeconds": 784
-    },
-    {
-      "fixtures": [
-        "alias-extends",
-        "inferred-auth-implicit",
-        "unions:no-custom-config",
-        "oauth-client-credentials-with-variables",
-        "license",
-        "inferred-auth-implicit-no-expiry",
-        "imdb:package-path",
-        "simple-api",
-        "single-url-environment-default",
-        "multi-url-environment",
-        "multi-url-environment-no-default",
-        "pagination-custom"
-      ],
-      "groupTotalTimeSeconds": 768
-    },
-    {
-      "fixtures": [
-        "version",
-        "unions:property-accessors",
-        "oauth-client-credentials-default",
-        "client-side-params",
-        "validation",
+        "path-parameters:inline-path-parameters-private",
+        "errors",
         "file-upload",
-        "nullable-optional",
-        "unknown",
-        "empty-clients",
-        "examples:no-custom-config"
+        "any-auth",
+        "variables",
+        "audiences",
+        "cross-package-type-names",
+        "single-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 815
-    },
-    {
-      "fixtures": [
-        "bytes-upload",
-        "extends:private",
-        "oauth-client-credentials-environment-variables",
-        "path-parameters:no-custom-config",
-        "request-parameters",
-        "server-sent-event-examples",
-        "basic-auth",
-        "plain-text",
-        "http-head",
-        "trace"
-      ],
-      "groupTotalTimeSeconds": 813
+      "groupTotalTimeSeconds": 761
     },
     {
       "fixtures": [
         "content-type",
-        "file-download",
         "oauth-client-credentials-nested-root",
-        "query-parameters:private",
-        "alias:no-custom-config",
-        "undiscriminated-unions",
-        "multiple-request-bodies",
-        "variables",
-        "object",
+        "pagination:no-custom-config",
+        "imdb:namespace",
+        "nullable",
+        "imdb:package-path",
+        "client-side-params",
+        "empty-clients",
+        "literal",
         "examples:readme-config"
       ],
-      "groupTotalTimeSeconds": 812
+      "groupTotalTimeSeconds": 730
     },
     {
       "fixtures": [
-        "accept-header",
-        "bytes-download",
-        "error-property",
-        "imdb:namespace",
-        "extra-properties",
+        "extends:no-custom-config",
+        "pagination:property-accessors",
         "oauth-client-credentials",
-        "optional",
-        "websocket",
-        "circular-references",
-        "literal"
+        "oauth-client-credentials-default",
+        "property-access",
+        "multi-line-docs",
+        "error-property",
+        "nullable-optional",
+        "public-object",
+        "exhaustive"
       ],
-      "groupTotalTimeSeconds": 822
+      "groupTotalTimeSeconds": 730
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "unions:property-accessors",
+        "oauth-client-credentials-with-variables",
+        "request-parameters",
+        "query-parameters:no-custom-config",
+        "package-yml:private",
+        "imdb:clientName",
+        "optional",
+        "folders",
+        "circular-references"
+      ],
+      "groupTotalTimeSeconds": 760
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "bytes-upload",
+        "inferred-auth-implicit-no-expiry",
+        "oauth-client-credentials-custom",
+        "validation",
+        "simple-api",
+        "license",
+        "server-sent-event-examples",
+        "literals-unions",
+        "imdb:private"
+      ],
+      "groupTotalTimeSeconds": 760
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "bytes-download",
+        "unions:no-custom-config",
+        "enum",
+        "required-nullable",
+        "imdb:packageName",
+        "multiple-request-bodies",
+        "http-head",
+        "websocket-bearer-auth",
+        "streaming",
+        "multi-url-environment-no-default",
+        "multi-url-environment",
+        "pagination-custom"
+      ],
+      "groupTotalTimeSeconds": 719
+    },
+    {
+      "fixtures": [
+        "alias:no-custom-config",
+        "accept-header",
+        "query-parameters:private",
+        "path-parameters:no-custom-config",
+        "alias:composer-json",
+        "no-environment",
+        "path-parameters:inline-path-parameters",
+        "reserved-keywords",
+        "circular-references-advanced",
+        "simple-fhir"
+      ],
+      "groupTotalTimeSeconds": 760
+    },
+    {
+      "fixtures": [
+        "extends:private",
+        "version-no-default",
+        "response-property",
+        "basic-auth",
+        "websocket-inferred-auth",
+        "idempotency-headers",
+        "imdb:no-custom-config",
+        "unknown",
+        "object",
+        "websocket"
+      ],
+      "groupTotalTimeSeconds": 755
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "version-no-default",
-        "basic-auth-environment-variables",
-        "no-environment",
+        "version",
         "mixed-file-directory",
-        "idempotency-headers",
-        "package-yml:private",
-        "simple-fhir",
-        "extends:no-custom-config",
-        "streaming"
+        "inferred-auth-implicit",
+        "server-sent-events",
+        "package-yml:no-custom-config",
+        "plain-text",
+        "streaming-parameter",
+        "file-download",
+        "examples:no-custom-config"
       ],
-      "groupTotalTimeSeconds": 821
+      "groupTotalTimeSeconds": 752
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/postman-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/postman-seed-groups.json
@@ -1,144 +1,145 @@
 {
-  "totalTestTimeSeconds": 960,
+  "totalTestTimeSeconds": 1035,
   "groups": [
-    {
-      "fixtures": [
-        "accept-header",
-        "file-upload",
-        "inferred-auth-explicit",
-        "property-access",
-        "circular-references-advanced",
-        "oauth-client-credentials-default",
-        "websocket",
-        "simple-api"
-      ],
-      "groupTotalTimeSeconds": 96
-    },
     {
       "fixtures": [
         "query-parameters-openapi",
         "pagination",
-        "oauth-client-credentials-with-variables",
-        "examples",
-        "multiple-request-bodies",
-        "error-property",
-        "oauth-client-credentials-custom",
-        "package-yml",
-        "websocket-bearer-auth",
-        "validation"
+        "oauth-client-credentials-nested-root",
+        "trace",
+        "literal",
+        "public-object",
+        "errors",
+        "server-sent-event-examples",
+        "websocket-inferred-auth",
+        "request-parameters",
+        "reserved-keywords"
       ],
-      "groupTotalTimeSeconds": 96
+      "groupTotalTimeSeconds": 106
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
+        "oauth-client-credentials",
         "oauth-client-credentials-environment-variables",
-        "mixed-file-directory",
-        "trace",
-        "inferred-auth-implicit",
-        "http-head",
-        "objects-with-imports",
-        "pagination-custom",
-        "custom-auth",
-        "request-parameters"
+        "audiences",
+        "enum",
+        "multi-url-environment",
+        "response-property",
+        "server-sent-events",
+        "basic-auth",
+        "inferred-auth-implicit-no-expiry"
       ],
-      "groupTotalTimeSeconds": 96
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "version",
-        "audiences",
-        "enum",
-        "nullable",
-        "folders",
-        "oauth-client-credentials",
+        "oauth-client-credentials-custom",
+        "objects-with-imports",
+        "cross-package-type-names",
+        "examples",
         "optional",
-        "path-parameters",
-        "multi-line-docs",
-        "reserved-keywords"
+        "unions",
+        "simple-api",
+        "circular-references",
+        "license"
       ],
-      "groupTotalTimeSeconds": 96
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "version-no-default",
-        "cross-package-type-names",
-        "literal",
-        "nullable-optional",
-        "imdb:no-custom-config",
-        "oauth-client-credentials-nested-root",
-        "public-object",
-        "response-property",
-        "multi-url-environment",
-        "streaming-parameter"
+        "oauth-client-credentials-default",
+        "mixed-file-directory",
+        "oauth-client-credentials-with-variables",
+        "folders",
+        "property-access",
+        "any-auth",
+        "multi-line-docs",
+        "streaming-parameter",
+        "multi-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 96
+      "groupTotalTimeSeconds": 103
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "bytes-upload",
+        "nullable",
+        "object",
+        "extra-properties",
+        "single-url-environment-default",
+        "custom-auth",
+        "package-yml"
+      ],
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "alias",
-        "bytes-download",
-        "license",
-        "imdb:collection-name",
-        "websocket-inferred-auth",
-        "simple-fhir",
-        "query-parameters",
-        "undiscriminated-unions"
+        "content-type",
+        "nullable-optional",
+        "plain-text",
+        "http-head",
+        "single-url-environment-no-default",
+        "inferred-auth-explicit",
+        "path-parameters"
       ],
-      "groupTotalTimeSeconds": 96
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "alias-extends",
-        "bytes-upload",
-        "mixed-case",
-        "inferred-auth-implicit-no-expiry",
-        "any-auth",
-        "errors",
-        "single-url-environment-default",
+        "extends",
+        "client-side-params",
+        "simple-fhir",
+        "literals-unions",
+        "streaming",
+        "inferred-auth-implicit",
         "unknown"
       ],
-      "groupTotalTimeSeconds": 96
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "content-type",
-        "no-environment",
-        "literals-unions",
-        "basic-auth",
-        "extra-properties",
-        "single-url-environment-no-default",
+        "file-download",
+        "imdb:no-custom-config",
         "empty-clients",
-        "variables"
+        "basic-auth-environment-variables",
+        "no-environment",
+        "undiscriminated-unions",
+        "websocket"
       ],
-      "groupTotalTimeSeconds": 98
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "auth-environment-variables",
-        "extends",
-        "client-side-params",
-        "object",
-        "basic-auth-environment-variables",
+        "file-upload",
+        "mixed-case",
         "idempotency-headers",
-        "streaming",
-        "server-sent-event-examples"
+        "circular-references-advanced",
+        "pagination-custom",
+        "validation",
+        "websocket-bearer-auth"
       ],
-      "groupTotalTimeSeconds": 95
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "file-download",
+        "bytes-download",
+        "multiple-request-bodies",
+        "imdb:collection-name",
+        "error-property",
+        "query-parameters",
+        "variables",
         "exhaustive",
-        "plain-text",
-        "circular-references",
-        "multi-url-environment-no-default",
-        "unions",
-        "server-sent-events"
+        "required-nullable"
       ],
-      "groupTotalTimeSeconds": 95
+      "groupTotalTimeSeconds": 105
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/pydantic-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/pydantic-seed-groups.json
@@ -1,151 +1,152 @@
 {
-  "totalTestTimeSeconds": 4637,
+  "totalTestTimeSeconds": 4849,
   "groups": [
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "nullable",
+        "oauth-client-credentials-environment-variables",
         "nullable-optional",
-        "circular-references:no-custom-config",
-        "property-access",
-        "circular-references-advanced:no-inheritance-for-extended-models",
-        "single-url-environment-default",
-        "circular-references:no-inheritance-for-extended-models",
-        "mixed-file-directory",
-        "cross-package-type-names"
+        "oauth-client-credentials-custom",
+        "http-head",
+        "undiscriminated-unions",
+        "multi-url-environment",
+        "server-sent-event-examples",
+        "path-parameters",
+        "public-object"
       ],
-      "groupTotalTimeSeconds": 480
+      "groupTotalTimeSeconds": 499
     },
     {
       "fixtures": [
         "query-parameters-openapi",
-        "unions:no-custom-config",
-        "oauth-client-credentials",
-        "extra-properties",
-        "mixed-case",
-        "circular-references-advanced:no-custom-config",
-        "simple-api",
+        "inferred-auth-explicit",
+        "inferred-auth-implicit-no-expiry",
+        "nullable",
+        "simple-fhir:no-custom-config",
+        "circular-references:no-custom-config",
+        "streaming",
         "websocket-bearer-auth",
-        "license",
-        "pagination-custom"
+        "trace",
+        "audiences"
       ],
-      "groupTotalTimeSeconds": 480
+      "groupTotalTimeSeconds": 498
     },
     {
       "fixtures": [
         "accept-header",
-        "bytes-upload",
-        "errors",
-        "any-auth",
-        "reserved-keywords",
-        "package-yml",
-        "inferred-auth-implicit-no-expiry",
-        "streaming",
-        "folders",
-        "examples"
+        "bearer-token-environment-variable",
+        "mixed-case",
+        "empty-clients",
+        "property-access",
+        "oauth-client-credentials-nested-root",
+        "single-url-environment-default",
+        "idempotency-headers",
+        "mixed-file-directory"
       ],
-      "groupTotalTimeSeconds": 480
+      "groupTotalTimeSeconds": 460
     },
     {
       "fixtures": [
         "alias",
-        "content-type",
-        "multiple-request-bodies",
-        "basic-auth-environment-variables",
+        "bytes-download",
+        "multi-line-docs",
+        "inferred-auth-implicit",
         "server-sent-events",
-        "pagination:no-custom-config",
-        "multi-url-environment",
+        "optional",
+        "single-url-environment-no-default",
         "oauth-client-credentials-default",
-        "variables"
+        "query-parameters"
       ],
-      "groupTotalTimeSeconds": 443
+      "groupTotalTimeSeconds": 460
     },
     {
       "fixtures": [
         "alias-extends:no-custom-config",
-        "extends",
-        "simple-fhir:no-custom-config",
-        "error-property",
-        "unknown",
-        "pagination:no-inheritance-for-extended-models",
-        "no-environment",
+        "bytes-upload",
+        "unions:no-custom-config",
+        "multiple-request-bodies",
+        "simple-api",
+        "required-nullable",
+        "websocket",
         "oauth-client-credentials-with-variables",
-        "enum",
-        "exhaustive:pydantic-v2"
+        "examples",
+        "enum"
       ],
-      "groupTotalTimeSeconds": 475
+      "groupTotalTimeSeconds": 498
     },
     {
       "fixtures": [
         "alias-extends:no-inheritance-for-extended-models",
-        "file-download:no-custom-config",
-        "undiscriminated-unions",
-        "inferred-auth-explicit",
-        "validation",
-        "path-parameters",
+        "extends",
+        "any-auth",
+        "object",
+        "simple-fhir:no-inheritance-for-extended-models",
         "response-property",
-        "objects-with-imports",
-        "literals-unions",
-        "exhaustive:pydantic-v1"
+        "request-parameters",
+        "imdb",
+        "cross-package-type-names",
+        "folders"
       ],
-      "groupTotalTimeSeconds": 474
+      "groupTotalTimeSeconds": 498
+    },
+    {
+      "fixtures": [
+        "unions:no-inheritance-for-extended-models",
+        "content-type",
+        "circular-references-advanced:no-custom-config",
+        "basic-auth",
+        "license",
+        "circular-references:no-inheritance-for-extended-models",
+        "multi-url-environment-no-default",
+        "objects-with-imports",
+        "pagination-custom",
+        "file-download:no-inheritance-for-extended-models"
+      ],
+      "groupTotalTimeSeconds": 496
     },
     {
       "fixtures": [
         "version",
-        "oauth-client-credentials-custom",
-        "simple-fhir:no-inheritance-for-extended-models",
-        "inferred-auth-implicit",
-        "optional",
-        "empty-clients",
-        "single-url-environment-no-default",
-        "http-head",
-        "public-object"
+        "file-download:no-custom-config",
+        "custom-auth",
+        "basic-auth-environment-variables",
+        "pagination:no-inheritance-for-extended-models",
+        "file-upload",
+        "package-yml",
+        "no-environment",
+        "literal",
+        "exhaustive:pydantic-v2"
       ],
-      "groupTotalTimeSeconds": 442
+      "groupTotalTimeSeconds": 491
     },
     {
       "fixtures": [
         "version-no-default",
-        "oauth-client-credentials-environment-variables",
-        "unions:no-inheritance-for-extended-models",
-        "multi-line-docs",
-        "plain-text",
-        "multi-url-environment-no-default",
+        "client-side-params",
+        "errors",
+        "extra-properties",
+        "oauth-client-credentials",
         "streaming-parameter",
-        "idempotency-headers",
-        "trace"
+        "unknown",
+        "websocket-inferred-auth",
+        "validation",
+        "exhaustive:pydantic-v1"
       ],
-      "groupTotalTimeSeconds": 442
+      "groupTotalTimeSeconds": 490
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "bearer-token-environment-variable",
-        "client-side-params",
-        "object",
-        "websocket",
-        "request-parameters",
-        "server-sent-event-examples",
-        "file-upload",
-        "literal"
-      ],
-      "groupTotalTimeSeconds": 442
-    },
-    {
-      "fixtures": [
         "auth-environment-variables",
-        "bytes-download",
-        "custom-auth",
-        "websocket-inferred-auth",
-        "basic-auth",
-        "oauth-client-credentials-nested-root",
-        "imdb",
-        "query-parameters",
-        "file-download:no-inheritance-for-extended-models",
-        "audiences"
+        "error-property",
+        "circular-references-advanced:no-inheritance-for-extended-models",
+        "plain-text",
+        "literals-unions",
+        "reserved-keywords",
+        "pagination:no-custom-config",
+        "variables"
       ],
-      "groupTotalTimeSeconds": 479
+      "groupTotalTimeSeconds": 459
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ruby-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-model-seed-groups.json
@@ -1,144 +1,145 @@
 {
-  "totalTestTimeSeconds": 2177,
+  "totalTestTimeSeconds": 2181,
   "groups": [
     {
       "fixtures": [
         "nullable-optional",
-        "bytes-upload",
-        "path-parameters",
-        "multi-line-docs",
-        "audiences",
-        "unknown",
-        "basic-auth-environment-variables",
-        "optional"
-      ],
-      "groupTotalTimeSeconds": 208
-    },
-    {
-      "fixtures": [
-        "unions",
-        "bytes-download",
-        "nullable",
-        "error-property",
-        "enum",
-        "websocket",
-        "server-sent-event-examples",
-        "query-parameters",
+        "objects-with-imports",
+        "oauth-client-credentials-with-variables",
+        "literal",
+        "examples",
+        "property-access",
+        "validation",
+        "mixed-case",
         "public-object"
       ],
       "groupTotalTimeSeconds": 220
     },
     {
       "fixtures": [
-        "client-side-params",
-        "bearer-token-environment-variable",
-        "simple-api",
-        "extra-properties",
-        "mixed-file-directory",
-        "cross-package-type-names",
-        "validation",
-        "inferred-auth-implicit-no-expiry",
-        "http-head"
-      ],
-      "groupTotalTimeSeconds": 219
-    },
-    {
-      "fixtures": [
-        "file-upload",
-        "query-parameters-openapi",
-        "file-download",
-        "object",
-        "oauth-client-credentials-with-variables",
-        "multi-url-environment-no-default",
-        "any-auth",
-        "single-url-environment-default",
+        "unions",
+        "oauth-client-credentials",
+        "errors",
+        "custom-auth",
+        "websocket-inferred-auth",
+        "path-parameters",
+        "empty-clients",
+        "basic-auth",
         "idempotency-headers"
       ],
       "groupTotalTimeSeconds": 219
     },
     {
       "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "api-wide-base-path",
-        "inferred-auth-implicit",
+        "client-side-params",
+        "alias",
+        "file-download",
         "undiscriminated-unions",
-        "literal",
-        "examples",
+        "cross-package-type-names",
         "folders",
-        "single-url-environment-no-default",
+        "required-nullable",
+        "inferred-auth-explicit",
         "imdb"
       ],
       "groupTotalTimeSeconds": 219
     },
     {
       "fixtures": [
-        "version",
-        "auth-environment-variables",
-        "oauth-client-credentials-default",
-        "errors",
-        "objects-with-imports",
-        "package-yml",
-        "websocket-bearer-auth",
-        "basic-auth",
-        "plain-text"
-      ],
-      "groupTotalTimeSeconds": 219
-    },
-    {
-      "fixtures": [
         "alias-extends",
-        "version-no-default",
-        "ruby-reserved-word-properties",
-        "streaming-parameter",
-        "streaming",
-        "pagination-custom",
-        "empty-clients",
-        "oauth-client-credentials",
-        "literals-unions"
-      ],
-      "groupTotalTimeSeconds": 219
-    },
-    {
-      "fixtures": [
-        "extends",
-        "accept-header",
         "oauth-client-credentials-nested-root",
-        "custom-auth",
-        "oauth-client-credentials-environment-variables",
-        "multi-url-environment",
-        "exhaustive",
-        "reserved-keywords",
+        "bytes-upload",
+        "circular-references-advanced",
+        "multi-line-docs",
+        "websocket",
+        "server-sent-events",
+        "inferred-auth-implicit",
         "circular-references"
       ],
       "groupTotalTimeSeconds": 218
     },
     {
       "fixtures": [
-        "simple-fhir",
-        "alias",
-        "circular-references-advanced",
-        "response-property",
-        "mixed-case",
-        "property-access",
-        "server-sent-events",
-        "inferred-auth-explicit",
+        "file-upload",
+        "version",
+        "content-type",
+        "error-property",
+        "ruby-reserved-word-properties",
+        "pagination-custom",
+        "any-auth",
+        "plain-text",
+        "http-head"
+      ],
+      "groupTotalTimeSeconds": 218
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "version-no-default",
+        "pagination",
+        "extra-properties",
+        "audiences",
+        "package-yml",
+        "reserved-keywords",
+        "simple-api",
         "license"
       ],
       "groupTotalTimeSeconds": 218
     },
     {
       "fixtures": [
-        "trace",
-        "pagination",
-        "content-type",
-        "websocket-inferred-auth",
-        "oauth-client-credentials-custom",
-        "request-parameters",
-        "variables",
-        "multiple-request-bodies",
+        "query-parameters-openapi-as-objects",
+        "accept-header",
+        "api-wide-base-path",
+        "enum",
+        "basic-auth-environment-variables",
+        "query-parameters",
+        "server-sent-event-examples",
+        "unknown",
         "no-environment"
       ],
-      "groupTotalTimeSeconds": 218
+      "groupTotalTimeSeconds": 217
+    },
+    {
+      "fixtures": [
+        "extends",
+        "nullable",
+        "auth-environment-variables",
+        "mixed-file-directory",
+        "multi-url-environment",
+        "streaming",
+        "streaming-parameter",
+        "variables",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 214
+    },
+    {
+      "fixtures": [
+        "simple-fhir",
+        "oauth-client-credentials-default",
+        "bearer-token-environment-variable",
+        "object",
+        "request-parameters",
+        "multi-url-environment-no-default",
+        "single-url-environment-default",
+        "inferred-auth-implicit-no-expiry",
+        "literals-unions"
+      ],
+      "groupTotalTimeSeconds": 219
+    },
+    {
+      "fixtures": [
+        "trace",
+        "oauth-client-credentials-environment-variables",
+        "bytes-download",
+        "response-property",
+        "websocket-bearer-auth",
+        "oauth-client-credentials-custom",
+        "single-url-environment-no-default",
+        "optional",
+        "multiple-request-bodies"
+      ],
+      "groupTotalTimeSeconds": 219
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ruby-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-sdk-seed-groups.json
@@ -1,139 +1,140 @@
 {
-  "totalTestTimeSeconds": 1143,
+  "totalTestTimeSeconds": 1132,
   "groups": [
     {
       "fixtures": [
         "accept-header",
-        "file-download",
-        "pagination-custom",
-        "variables",
-        "imdb",
-        "ruby-reserved-word-properties"
-      ],
-      "groupTotalTimeSeconds": 114
-    },
-    {
-      "fixtures": [
-        "alias-extends",
         "file-upload",
-        "property-access",
-        "websocket",
-        "mixed-file-directory",
-        "server-sent-event-examples"
+        "basic-auth",
+        "error-property",
+        "multi-url-environment",
+        "reserved-keywords",
+        "idempotency-headers"
       ],
-      "groupTotalTimeSeconds": 114
+      "groupTotalTimeSeconds": 115
     },
     {
       "fixtures": [
         "query-parameters-openapi",
-        "nullable-optional",
-        "examples",
-        "circular-references",
-        "exhaustive:extra-deps",
+        "pagination",
+        "oauth-client-credentials",
+        "simple-fhir",
+        "errors",
         "inferred-auth-explicit",
-        "literal",
-        "nullable",
-        "oauth-client-credentials-environment-variables",
-        "streaming",
+        "multiple-request-bodies",
+        "object",
+        "query-parameters",
         "basic-auth-environment-variables",
+        "exhaustive:extra-deps",
         "multi-url-environment-no-default",
+        "ruby-reserved-word-properties",
         "server-sent-events"
       ],
-      "groupTotalTimeSeconds": 114
+      "groupTotalTimeSeconds": 115
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "pagination",
-        "websocket-inferred-auth",
-        "circular-references-advanced",
-        "exhaustive:flattened-module-structure",
-        "inferred-auth-implicit",
-        "mixed-case",
-        "oauth-client-credentials",
-        "oauth-client-credentials-nested-root",
-        "streaming-parameter",
-        "cross-package-type-names",
-        "oauth-client-credentials-with-variables",
-        "single-url-environment-no-default"
+        "unions",
+        "oauth-client-credentials-custom",
+        "audiences",
+        "circular-references",
+        "exhaustive:no-custom-config",
+        "inferred-auth-implicit-no-expiry",
+        "no-environment",
+        "objects-with-imports",
+        "response-property",
+        "extra-properties",
+        "oauth-client-credentials-default",
+        "server-sent-event-examples",
+        "variables"
       ],
-      "groupTotalTimeSeconds": 114
+      "groupTotalTimeSeconds": 115
     },
     {
       "fixtures": [
         "version",
         "client-side-params",
-        "trace",
-        "empty-clients",
+        "examples",
+        "oauth-client-credentials-environment-variables",
+        "circular-references-advanced",
+        "exhaustive:flattened-module-structure",
+        "literal",
+        "nullable",
+        "property-access",
         "undiscriminated-unions",
-        "inferred-auth-implicit-no-expiry",
-        "multi-line-docs",
-        "oauth-client-credentials-custom",
-        "objects-with-imports",
-        "unknown",
-        "custom-auth",
-        "object",
-        "http-head",
-        "multiple-request-bodies"
+        "folders",
+        "optional",
+        "simple-api"
       ],
-      "groupTotalTimeSeconds": 116
+      "groupTotalTimeSeconds": 112
     },
     {
       "fixtures": [
         "version-no-default",
-        "simple-fhir",
-        "unions",
-        "exhaustive:no-custom-config",
-        "enum",
-        "errors",
-        "license",
-        "multi-url-environment",
-        "oauth-client-credentials-default",
-        "query-parameters",
-        "websocket-bearer-auth",
-        "optional",
-        "literals-unions",
-        "no-environment"
+        "trace",
+        "nullable-optional",
+        "oauth-client-credentials-nested-root",
+        "empty-clients",
+        "imdb",
+        "mixed-case",
+        "oauth-client-credentials-with-variables",
+        "public-object",
+        "unknown",
+        "http-head",
+        "package-yml",
+        "single-url-environment-default"
       ],
-      "groupTotalTimeSeconds": 116
+      "groupTotalTimeSeconds": 112
     },
     {
       "fixtures": [
         "alias",
         "bytes-download",
-        "response-property",
-        "any-auth",
-        "error-property",
-        "path-parameters",
-        "request-parameters"
+        "cross-package-type-names",
+        "inferred-auth-implicit",
+        "pagination-custom",
+        "single-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 116
+      "groupTotalTimeSeconds": 112
     },
     {
-      "fixtures": ["api-wide-base-path", "bytes-upload", "simple-api", "audiences", "extra-properties", "plain-text"],
-      "groupTotalTimeSeconds": 113
+      "fixtures": ["alias-extends", "bytes-upload", "custom-auth", "license", "path-parameters", "streaming"],
+      "groupTotalTimeSeconds": 112
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "content-type",
+        "validation",
+        "literals-unions",
+        "plain-text",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 112
     },
     {
       "fixtures": [
         "auth-environment-variables",
-        "content-type",
-        "single-url-environment-default",
-        "basic-auth",
-        "folders",
-        "public-object"
+        "extends",
+        "websocket-inferred-auth",
+        "mixed-file-directory",
+        "request-parameters",
+        "websocket"
       ],
-      "groupTotalTimeSeconds": 113
+      "groupTotalTimeSeconds": 112
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "extends",
-        "package-yml",
-        "validation",
-        "idempotency-headers",
-        "reserved-keywords"
+        "file-download",
+        "any-auth",
+        "enum",
+        "multi-line-docs",
+        "required-nullable",
+        "websocket-bearer-auth"
       ],
-      "groupTotalTimeSeconds": 113
+      "groupTotalTimeSeconds": 115
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ruby-sdk-v2-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-sdk-v2-seed-groups.json
@@ -1,145 +1,146 @@
 {
-  "totalTestTimeSeconds": 18096,
+  "totalTestTimeSeconds": 19545,
   "groups": [
     {
       "fixtures": [
-        "bearer-token-environment-variable",
+        "alias-extends",
         "oauth-client-credentials-environment-variables",
-        "oauth-client-credentials-with-variables",
-        "response-property",
-        "public-object",
-        "single-url-environment-default",
-        "reserved-keywords",
-        "empty-clients",
-        "folders"
-      ],
-      "groupTotalTimeSeconds": 1797
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
-        "pagination",
         "package-yml",
-        "property-access",
-        "mixed-case",
-        "error-property",
-        "basic-auth",
-        "server-sent-event-examples",
-        "exhaustive"
+        "multi-url-environment",
+        "streaming",
+        "extra-properties",
+        "public-object",
+        "validation",
+        "mixed-file-directory"
       ],
-      "groupTotalTimeSeconds": 1791
+      "groupTotalTimeSeconds": 1950
     },
     {
       "fixtures": [
         "file-upload",
         "oauth-client-credentials-nested-root",
         "objects-with-imports",
-        "path-parameters",
-        "optional",
+        "nullable-optional",
+        "reserved-keywords",
+        "query-parameters",
         "server-sent-events",
-        "any-auth",
-        "basic-auth-environment-variables",
-        "examples:no-custom-config"
+        "websocket",
+        "oauth-client-credentials-with-variables"
       ],
-      "groupTotalTimeSeconds": 1797
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
-        "version-no-default",
-        "extra-properties",
-        "undiscriminated-unions",
-        "unknown",
-        "idempotency-headers",
-        "streaming-parameter",
-        "circular-references-advanced",
-        "literal"
-      ],
-      "groupTotalTimeSeconds": 1830
-    },
-    {
-      "fixtures": [
-        "content-type",
-        "client-side-params",
-        "simple-fhir",
-        "variables",
-        "oauth-client-credentials-custom",
-        "single-url-environment-no-default",
-        "no-environment",
-        "websocket-bearer-auth",
-        "enum"
-      ],
-      "groupTotalTimeSeconds": 1829
+      "groupTotalTimeSeconds": 1950
     },
     {
       "fixtures": [
         "file-download",
-        "alias-extends",
-        "nullable-optional",
-        "validation",
-        "websocket",
-        "multiple-request-bodies",
-        "literals-unions",
+        "client-side-params",
+        "pagination-custom",
+        "streaming-parameter",
+        "server-sent-event-examples",
+        "response-property",
+        "any-auth",
         "websocket-inferred-auth",
-        "examples:readme-config"
-      ],
-      "groupTotalTimeSeconds": 1796
-    },
-    {
-      "fixtures": [
-        "bytes-upload",
-        "bytes-download",
-        "multi-url-environment",
-        "custom-auth",
-        "plain-text",
-        "http-head",
-        "license",
-        "ruby-reserved-word-properties",
         "cross-package-type-names"
       ],
-      "groupTotalTimeSeconds": 1805
+      "groupTotalTimeSeconds": 1940
     },
     {
       "fixtures": [
-        "query-parameters-openapi",
-        "version",
-        "errors",
-        "pagination-custom",
-        "inferred-auth-implicit-no-expiry",
-        "streaming",
-        "simple-api",
-        "circular-references",
-        "trace"
-      ],
-      "groupTotalTimeSeconds": 1797
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "query-parameters-openapi-as-objects",
-        "multi-url-environment-no-default",
-        "request-parameters",
-        "nullable",
+        "auth-environment-variables",
+        "bytes-upload",
+        "undiscriminated-unions",
+        "websocket-bearer-auth",
         "inferred-auth-implicit",
-        "unions",
-        "query-parameters",
-        "mixed-file-directory"
+        "single-url-environment-no-default",
+        "ruby-reserved-word-properties",
+        "basic-auth",
+        "audiences"
       ],
-      "groupTotalTimeSeconds": 1838
+      "groupTotalTimeSeconds": 1942
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "pagination",
+        "unknown",
+        "nullable",
+        "inferred-auth-implicit-no-expiry",
+        "imdb",
+        "multiple-request-bodies",
+        "property-access",
+        "examples:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 1933
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "version-no-default",
+        "variables",
+        "oauth-client-credentials",
+        "circular-references-advanced",
+        "idempotency-headers",
+        "single-url-environment-default",
+        "request-parameters",
+        "examples:readme-config",
+        "exhaustive"
+      ],
+      "groupTotalTimeSeconds": 2065
+    },
+    {
+      "fixtures": [
+        "alias",
+        "version",
+        "multi-url-environment-no-default",
+        "inferred-auth-explicit",
+        "plain-text",
+        "errors",
+        "mixed-case",
+        "required-nullable",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 1944
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "bytes-download",
+        "multi-line-docs",
+        "oauth-client-credentials-custom",
+        "no-environment",
+        "literals-unions",
+        "basic-auth-environment-variables",
+        "http-head",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 1937
     },
     {
       "fixtures": [
         "extends",
-        "alias",
-        "multi-line-docs",
-        "object",
-        "oauth-client-credentials",
+        "accept-header",
+        "unions",
         "oauth-client-credentials-default",
-        "inferred-auth-explicit",
-        "imdb",
-        "audiences"
+        "simple-fhir",
+        "custom-auth",
+        "object",
+        "circular-references",
+        "enum"
       ],
-      "groupTotalTimeSeconds": 1816
+      "groupTotalTimeSeconds": 1950
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "bearer-token-environment-variable",
+        "path-parameters",
+        "error-property",
+        "optional",
+        "simple-api",
+        "empty-clients",
+        "license",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 1934
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/rust-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/rust-model-seed-groups.json
@@ -1,143 +1,144 @@
 {
-  "totalTestTimeSeconds": 757,
+  "totalTestTimeSeconds": 737,
   "groups": [
     {
       "fixtures": [
         "query-parameters-openapi",
         "unions",
-        "pagination",
-        "basic-auth-environment-variables",
-        "objects-with-imports",
-        "inferred-auth-implicit",
-        "plain-text",
-        "http-head",
-        "reserved-keywords",
-        "folders"
+        "oauth-client-credentials",
+        "query-parameters",
+        "request-parameters",
+        "inferred-auth-explicit",
+        "path-parameters",
+        "error-property",
+        "required-nullable",
+        "idempotency-headers"
       ],
-      "groupTotalTimeSeconds": 76
+      "groupTotalTimeSeconds": 75
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "client-side-params",
-        "oauth-client-credentials-custom",
-        "query-parameters",
-        "path-parameters",
-        "inferred-auth-implicit-no-expiry",
+        "circular-references-advanced",
+        "mixed-case",
+        "oauth-client-credentials-environment-variables",
+        "pagination",
+        "basic-auth-environment-variables",
+        "no-environment",
         "trace",
-        "imdb",
-        "server-sent-event-examples",
-        "idempotency-headers"
+        "multi-url-environment",
+        "variables"
       ],
-      "groupTotalTimeSeconds": 76
+      "groupTotalTimeSeconds": 74
     },
     {
       "fixtures": [
         "version",
-        "circular-references-advanced",
+        "client-side-params",
         "nullable",
         "property-access",
-        "empty-clients",
-        "undiscriminated-unions",
-        "oauth-client-credentials",
-        "cross-package-type-names",
-        "literals-unions",
-        "single-url-environment-no-default"
-      ],
-      "groupTotalTimeSeconds": 76
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "file-upload",
-        "object",
-        "enum",
-        "oauth-client-credentials-nested-root",
+        "plain-text",
         "custom-auth",
-        "multi-line-docs",
-        "streaming"
-      ],
-      "groupTotalTimeSeconds": 76
-    },
-    {
-      "fixtures": [
-        "alias",
-        "file-download",
-        "errors",
-        "websocket",
         "oauth-client-credentials-with-variables",
-        "error-property",
-        "multi-url-environment",
-        "streaming-parameter"
-      ],
-      "groupTotalTimeSeconds": 76
-    },
-    {
-      "fixtures": [
-        "version-no-default",
-        "nullable-optional",
-        "oauth-client-credentials-environment-variables",
-        "simple-fhir",
-        "public-object",
-        "mixed-file-directory",
         "unknown",
-        "inferred-auth-explicit",
-        "server-sent-events",
+        "multi-url-environment-no-default",
+        "cross-package-type-names",
         "exhaustive"
       ],
       "groupTotalTimeSeconds": 75
     },
     {
       "fixtures": [
-        "alias-extends",
-        "bytes-upload",
-        "mixed-case",
-        "websocket-bearer-auth",
-        "optional",
-        "examples",
-        "pagination-custom",
-        "validation"
+        "accept-header",
+        "file-upload",
+        "public-object",
+        "empty-clients",
+        "object",
+        "websocket",
+        "multiple-request-bodies",
+        "folders"
       ],
-      "groupTotalTimeSeconds": 76
+      "groupTotalTimeSeconds": 73
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "file-download",
+        "websocket-bearer-auth",
+        "extra-properties",
+        "optional",
+        "websocket-inferred-auth",
+        "oauth-client-credentials-default",
+        "http-head"
+      ],
+      "groupTotalTimeSeconds": 73
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "nullable-optional",
+        "oauth-client-credentials-custom",
+        "simple-fhir",
+        "reserved-keywords",
+        "inferred-auth-implicit",
+        "response-property",
+        "examples",
+        "server-sent-event-examples",
+        "imdb"
+      ],
+      "groupTotalTimeSeconds": 75
+    },
+    {
+      "fixtures": [
+        "alias",
+        "bytes-download",
+        "circular-references",
+        "undiscriminated-unions",
+        "package-yml",
+        "audiences",
+        "license",
+        "single-url-environment-default"
+      ],
+      "groupTotalTimeSeconds": 73
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "content-type",
-        "multiple-request-bodies",
-        "websocket-inferred-auth",
-        "package-yml",
-        "extra-properties",
-        "request-parameters",
-        "variables"
+        "bytes-upload",
+        "errors",
+        "validation",
+        "pagination-custom",
+        "enum",
+        "literal",
+        "single-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 76
+      "groupTotalTimeSeconds": 73
     },
     {
       "fixtures": [
         "auth-environment-variables",
-        "extends",
-        "oauth-client-credentials-default",
-        "basic-auth",
-        "multi-url-environment-no-default",
+        "content-type",
+        "oauth-client-credentials-nested-root",
         "any-auth",
-        "license",
-        "simple-api"
+        "inferred-auth-implicit-no-expiry",
+        "server-sent-events",
+        "literals-unions",
+        "streaming"
       ],
-      "groupTotalTimeSeconds": 75
+      "groupTotalTimeSeconds": 73
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "bytes-download",
-        "circular-references",
-        "response-property",
-        "no-environment",
-        "audiences",
-        "literal",
-        "single-url-environment-default"
+        "extends",
+        "objects-with-imports",
+        "basic-auth",
+        "mixed-file-directory",
+        "simple-api",
+        "multi-line-docs",
+        "streaming-parameter"
       ],
-      "groupTotalTimeSeconds": 75
+      "groupTotalTimeSeconds": 73
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/rust-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/rust-sdk-seed-groups.json
@@ -1,147 +1,148 @@
 {
-  "totalTestTimeSeconds": 3002,
+  "totalTestTimeSeconds": 3208,
   "groups": [
     {
       "fixtures": [
         "client-side-params",
+        "bearer-token-environment-variable",
         "response-property",
-        "inferred-auth-explicit",
-        "plain-text",
-        "error-property",
-        "package-yml",
-        "single-url-environment-default:custom-environment",
+        "property-access",
+        "multi-url-environment-no-default",
         "exhaustive",
-        "objects-with-imports"
+        "streaming",
+        "plain-text",
+        "circular-references-advanced"
       ],
-      "groupTotalTimeSeconds": 298
+      "groupTotalTimeSeconds": 317
     },
     {
       "fixtures": [
         "errors",
-        "path-parameters",
-        "custom-auth",
-        "oauth-client-credentials-nested-root",
-        "imdb",
-        "streaming",
-        "single-url-environment-default:full-custom",
-        "simple-api",
-        "public-object"
+        "accept-header",
+        "nullable",
+        "oauth-client-credentials-with-variables",
+        "bytes-download",
+        "required-nullable",
+        "streaming-parameter",
+        "folders",
+        "circular-references"
       ],
-      "groupTotalTimeSeconds": 298
+      "groupTotalTimeSeconds": 316
     },
     {
       "fixtures": [
         "nullable-optional",
-        "file-upload",
-        "basic-auth",
-        "websocket-inferred-auth",
-        "server-sent-event-examples",
-        "variables",
-        "streaming-parameter",
-        "folders",
-        "audiences"
+        "version-no-default",
+        "unions",
+        "basic-auth-environment-variables",
+        "any-auth",
+        "pagination-custom",
+        "simple-fhir",
+        "audiences",
+        "cross-package-type-names"
       ],
-      "groupTotalTimeSeconds": 307
+      "groupTotalTimeSeconds": 330
+    },
+    {
+      "fixtures": [
+        "examples:no-custom-config",
+        "undiscriminated-unions",
+        "mixed-case",
+        "request-parameters",
+        "query-parameters",
+        "optional",
+        "multi-url-environment",
+        "idempotency-headers",
+        "http-head"
+      ],
+      "groupTotalTimeSeconds": 319
+    },
+    {
+      "fixtures": [
+        "oauth-client-credentials",
+        "version",
+        "path-parameters",
+        "basic-auth",
+        "mixed-file-directory",
+        "license",
+        "reserved-keywords",
+        "server-sent-event-examples",
+        "object",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 318
+    },
+    {
+      "fixtures": [
+        "pagination",
+        "query-parameters-openapi-as-objects",
+        "inferred-auth-implicit",
+        "package-yml",
+        "multiple-request-bodies",
+        "trace",
+        "variables",
+        "single-url-environment-default:full-custom",
+        "public-object"
+      ],
+      "groupTotalTimeSeconds": 314
     },
     {
       "fixtures": [
         "content-type",
-        "file-download",
-        "bytes-download",
-        "mixed-case",
-        "basic-auth-environment-variables",
-        "unknown",
-        "trace",
-        "single-url-environment-no-default",
-        "object",
-        "literals-unions"
-      ],
-      "groupTotalTimeSeconds": 301
-    },
-    {
-      "fixtures": [
-        "version-no-default",
-        "extends",
-        "oauth-client-credentials-environment-variables",
-        "oauth-client-credentials-custom",
-        "multiple-request-bodies",
+        "query-parameters-openapi",
+        "file-upload",
+        "oauth-client-credentials-nested-root",
+        "inferred-auth-implicit-no-expiry",
         "validation",
-        "idempotency-headers",
-        "enum",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 309
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "query-parameters-openapi-as-objects",
-        "pagination",
-        "request-parameters",
-        "oauth-client-credentials-with-variables",
         "extra-properties",
-        "pagination-custom",
-        "literal",
-        "websocket"
+        "single-url-environment-no-default",
+        "objects-with-imports",
+        "empty-clients"
       ],
-      "groupTotalTimeSeconds": 297
+      "groupTotalTimeSeconds": 317
     },
     {
       "fixtures": [
         "alias",
-        "version",
-        "undiscriminated-unions",
-        "inferred-auth-implicit-no-expiry",
-        "property-access",
-        "mixed-file-directory",
-        "examples:no-custom-config",
-        "server-sent-events",
-        "websocket-bearer-auth"
+        "auth-environment-variables",
+        "bytes-upload",
+        "oauth-client-credentials-default",
+        "inferred-auth-explicit",
+        "unknown",
+        "literal",
+        "examples:readme-config",
+        "websocket",
+        "literals-unions"
       ],
-      "groupTotalTimeSeconds": 297
+      "groupTotalTimeSeconds": 317
     },
     {
       "fixtures": [
         "alias-extends",
-        "api-wide-base-path",
-        "unions",
-        "inferred-auth-implicit",
-        "any-auth",
+        "oauth-client-credentials-custom",
+        "extends",
+        "custom-auth",
         "no-environment",
-        "simple-fhir",
-        "license",
-        "http-head"
-      ],
-      "groupTotalTimeSeconds": 298
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
-        "bearer-token-environment-variable",
-        "nullable",
-        "optional",
-        "reserved-keywords",
-        "multi-line-docs",
-        "multi-url-environment-no-default",
-        "single-url-environment-default:basic",
-        "circular-references",
-        "empty-clients"
-      ],
-      "groupTotalTimeSeconds": 300
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi",
-        "bytes-upload",
-        "oauth-client-credentials",
+        "enum",
         "imdb:imdb-custom-config",
-        "query-parameters",
-        "multi-url-environment",
-        "oauth-client-credentials-default",
-        "examples:readme-config",
-        "circular-references-advanced"
+        "simple-api",
+        "server-sent-events"
       ],
-      "groupTotalTimeSeconds": 297
+      "groupTotalTimeSeconds": 330
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "oauth-client-credentials-environment-variables",
+        "file-download",
+        "imdb",
+        "multi-line-docs",
+        "error-property",
+        "websocket-inferred-auth",
+        "single-url-environment-default:basic",
+        "single-url-environment-default:custom-environment"
+      ],
+      "groupTotalTimeSeconds": 330
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/swift-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/swift-sdk-seed-groups.json
@@ -1,148 +1,149 @@
 {
-  "totalTestTimeSeconds": 5171,
+  "totalTestTimeSeconds": 5217,
   "groups": [
     {
       "fixtures": [
-        "client-side-params:with-custom-config",
-        "response-property",
-        "oauth-client-credentials-nested-root",
-        "basic-auth-environment-variables",
-        "any-auth",
-        "query-parameters-openapi",
-        "single-url-environment-default:with-custom-config",
-        "variables",
-        "cross-package-type-names",
-        "nullable-optional"
+        "client-side-params:no-custom-config",
+        "oauth-client-credentials",
+        "websocket-inferred-auth",
+        "oauth-client-credentials-default",
+        "multiple-request-bodies",
+        "http-head",
+        "validation",
+        "folders",
+        "enum",
+        "cross-package-type-names"
       ],
-      "groupTotalTimeSeconds": 533
+      "groupTotalTimeSeconds": 536
     },
     {
       "fixtures": [
-        "client-side-params:no-custom-config",
+        "content-type",
+        "bytes-download",
         "auth-environment-variables",
-        "oauth-client-credentials",
-        "undiscriminated-unions",
-        "imdb",
-        "query-parameters-openapi-as-objects",
-        "plain-text",
-        "no-environment",
-        "examples:readme-config",
-        "property-access"
+        "basic-auth",
+        "error-property",
+        "query-parameters-openapi",
+        "websocket",
+        "public-object",
+        "reserved-keywords"
       ],
-      "groupTotalTimeSeconds": 532
+      "groupTotalTimeSeconds": 513
     },
     {
       "fixtures": [
         "file-upload",
         "api-wide-base-path",
-        "inferred-auth-explicit",
-        "package-yml",
-        "server-sent-events",
-        "server-sent-event-examples",
-        "request-parameters",
+        "response-property",
+        "extra-properties",
+        "simple-api",
+        "unknown",
+        "single-url-environment-default:no-custom-config",
         "literals-unions",
+        "mixed-file-directory"
+      ],
+      "groupTotalTimeSeconds": 513
+    },
+    {
+      "fixtures": [
+        "client-side-params:with-custom-config",
+        "file-download",
+        "oauth-client-credentials-custom",
+        "imdb",
+        "streaming",
+        "empty-clients",
+        "server-sent-events",
+        "unions",
         "trace"
       ],
       "groupTotalTimeSeconds": 513
     },
     {
       "fixtures": [
-        "extends",
-        "oauth-client-credentials-custom",
-        "websocket-inferred-auth",
-        "extra-properties",
-        "unknown",
+        "version",
+        "bytes-upload",
+        "oauth-client-credentials-environment-variables",
+        "mixed-case",
         "idempotency-headers",
-        "streaming-parameter",
-        "reserved-keywords",
-        "literal"
+        "query-parameters-openapi-as-objects",
+        "object",
+        "variables",
+        "simple-fhir"
       ],
-      "groupTotalTimeSeconds": 511
+      "groupTotalTimeSeconds": 513
     },
     {
       "fixtures": [
         "alias-extends",
-        "file-download",
-        "nullable",
-        "inferred-auth-implicit",
-        "multi-line-docs",
-        "license",
-        "http-head",
-        "circular-references",
-        "query-parameters"
-      ],
-      "groupTotalTimeSeconds": 512
-    },
-    {
-      "fixtures": [
-        "content-type",
         "accept-header",
-        "bytes-download",
-        "multiple-request-bodies",
-        "empty-clients",
-        "oauth-client-credentials-default",
-        "validation",
-        "public-object",
-        "simple-fhir"
-      ],
-      "groupTotalTimeSeconds": 511
-    },
-    {
-      "fixtures": [
-        "version",
-        "bearer-token-environment-variable",
-        "bytes-upload",
+        "oauth-client-credentials-nested-root",
+        "any-auth",
+        "basic-auth-environment-variables",
         "multi-url-environment",
-        "multi-url-environment-no-default",
-        "optional",
-        "websocket",
+        "streaming-parameter",
         "circular-references-advanced",
-        "exhaustive"
+        "exhaustive",
+        "property-access"
       ],
-      "groupTotalTimeSeconds": 512
-    },
-    {
-      "fixtures": [
-        "pagination:custom-pager-with-exception-handler",
-        "pagination:custom-pager",
-        "custom-auth",
-        "basic-auth",
-        "oauth-client-credentials-with-variables",
-        "simple-api",
-        "websocket-bearer-auth",
-        "folders",
-        "enum"
-      ],
-      "groupTotalTimeSeconds": 509
+      "groupTotalTimeSeconds": 535
     },
     {
       "fixtures": [
         "pagination:no-custom-config",
-        "alias",
+        "bearer-token-environment-variable",
+        "inferred-auth-explicit",
         "inferred-auth-implicit-no-expiry",
-        "mixed-case",
         "path-parameters",
-        "streaming",
-        "object",
-        "single-url-environment-no-default",
-        "audiences"
+        "pagination-custom",
+        "websocket-bearer-auth",
+        "circular-references",
+        "literal",
+        "examples:readme-config"
       ],
-      "groupTotalTimeSeconds": 509
+      "groupTotalTimeSeconds": 533
     },
     {
       "fixtures": [
-        "version-no-default",
+        "extends",
+        "alias",
+        "custom-auth",
+        "package-yml",
+        "license",
+        "server-sent-event-examples",
+        "single-url-environment-default:with-custom-config",
+        "plain-text",
+        "nullable-optional"
+      ],
+      "groupTotalTimeSeconds": 513
+    },
+    {
+      "fixtures": [
+        "pagination:custom-pager-with-exception-handler",
         "errors",
-        "oauth-client-credentials-environment-variables",
-        "pagination-custom",
-        "error-property",
+        "nullable",
         "objects-with-imports",
-        "single-url-environment-default:no-custom-config",
-        "unions",
-        "mixed-file-directory",
+        "multi-url-environment-no-default",
+        "oauth-client-credentials-with-variables",
+        "optional",
+        "no-environment",
+        "query-parameters"
+      ],
+      "groupTotalTimeSeconds": 514
+    },
+    {
+      "fixtures": [
+        "pagination:custom-pager",
+        "version-no-default",
+        "inferred-auth-implicit",
+        "multi-line-docs",
+        "undiscriminated-unions",
+        "required-nullable",
+        "request-parameters",
+        "single-url-environment-no-default",
+        "audiences",
         "examples:no-custom-config"
       ],
-      "groupTotalTimeSeconds": 529
+      "groupTotalTimeSeconds": 534
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ts-express-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ts-express-seed-groups.json
@@ -1,157 +1,158 @@
 {
-  "totalTestTimeSeconds": 5767,
+  "totalTestTimeSeconds": 5830,
   "groups": [
     {
       "fixtures": [
         "trace:no-custom-config",
-        "bearer-token-environment-variable",
-        "inferred-auth-implicit-no-expiry",
-        "oauth-client-credentials-custom",
-        "path-parameters",
-        "enum",
-        "exhaustive:union-utils",
-        "file-upload",
-        "variables"
-      ],
-      "groupTotalTimeSeconds": 573
-    },
-    {
-      "fixtures": [
-        "exhaustive:no-optional-properties",
-        "property-access",
-        "api-wide-base-path",
-        "package-yml",
+        "pagination",
+        "extra-properties",
+        "query-parameters",
+        "oauth-client-credentials-with-variables",
         "error-property",
         "websocket-inferred-auth",
-        "inferred-auth-explicit",
-        "ts-inline-types",
-        "exhaustive:test-package-path",
-        "ts-express-casing:no-serde-layer"
-      ],
-      "groupTotalTimeSeconds": 574
-    },
-    {
-      "fixtures": [
-        "exhaustive:retain-original-casing",
-        "version-no-default",
-        "client-side-params",
-        "request-parameters",
-        "oauth-client-credentials-environment-variables",
-        "basic-auth",
-        "circular-references-advanced",
-        "websocket",
-        "idempotency-headers",
-        "single-url-environment-no-default"
-      ],
-      "groupTotalTimeSeconds": 582
-    },
-    {
-      "fixtures": [
-        "nullable-optional",
-        "no-environment",
-        "accept-header",
-        "query-parameters",
-        "oauth-client-credentials-default",
-        "mixed-file-directory",
-        "cross-package-type-names",
         "bytes-download",
-        "ts-express-casing:no-custom-config",
-        "plain-text"
+        "imdb:no-custom-config"
       ],
-      "groupTotalTimeSeconds": 568
-    },
-    {
-      "fixtures": [
-        "nullable",
-        "version",
-        "object",
-        "oauth-client-credentials",
-        "multi-line-docs",
-        "literal",
-        "imdb:validation-status-code",
-        "bytes-upload",
-        "simple-fhir",
-        "multiple-request-bodies",
-        "server-sent-event-examples"
-      ],
-      "groupTotalTimeSeconds": 578
-    },
-    {
-      "fixtures": [
-        "content-type",
-        "auth-environment-variables",
-        "optional",
-        "errors",
-        "custom-auth",
-        "oauth-client-credentials-with-variables",
-        "inferred-auth-implicit",
-        "exhaustive:allow-extra-fields",
-        "simple-api",
-        "public-object",
-        "streaming"
-      ],
-      "groupTotalTimeSeconds": 573
-    },
-    {
-      "fixtures": [
-        "mixed-case:no-custom-config",
-        "query-parameters-openapi",
-        "imdb:output-compiled",
-        "undiscriminated-unions",
-        "literals-unions",
-        "response-property",
-        "validation",
-        "file-download",
-        "unknown",
-        "server-sent-events",
-        "streaming-parameter"
-      ],
-      "groupTotalTimeSeconds": 573
-    },
-    {
-      "fixtures": [
-        "alias-extends",
-        "extends",
-        "unions",
-        "pagination",
-        "reserved-keywords",
-        "pagination-custom",
-        "circular-references",
-        "folders",
-        "imdb:no-custom-config",
-        "imdb:skip-response-validation"
-      ],
-      "groupTotalTimeSeconds": 582
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "mixed-case:retain-original-casing",
-        "extra-properties",
-        "multi-url-environment",
-        "oauth-client-credentials-nested-root",
-        "any-auth",
-        "audiences",
-        "empty-clients",
-        "single-url-environment-default",
-        "exhaustive:no-custom-config"
-      ],
-      "groupTotalTimeSeconds": 581
+      "groupTotalTimeSeconds": 586
     },
     {
       "fixtures": [
         "trace:no-zurg-trace",
-        "alias",
-        "license",
-        "multi-url-environment-no-default",
-        "basic-auth-environment-variables",
-        "objects-with-imports",
-        "examples",
-        "websocket-bearer-auth",
-        "http-head",
-        "imdb:skip-request-validation"
+        "exhaustive:no-optional-properties",
+        "api-wide-base-path",
+        "mixed-file-directory",
+        "audiences",
+        "enum",
+        "inferred-auth-implicit",
+        "exhaustive:retain-original-casing",
+        "ts-express-casing:no-serde-layer",
+        "file-upload",
+        "streaming"
       ],
       "groupTotalTimeSeconds": 583
+    },
+    {
+      "fixtures": [
+        "nullable-optional",
+        "bearer-token-environment-variable",
+        "imdb:skip-request-validation",
+        "oauth-client-credentials",
+        "websocket",
+        "errors",
+        "pagination-custom",
+        "ts-express-casing:no-custom-config",
+        "exhaustive:allow-extra-fields",
+        "imdb:validation-status-code"
+      ],
+      "groupTotalTimeSeconds": 586
+    },
+    {
+      "fixtures": [
+        "unions",
+        "property-access",
+        "mixed-case:no-custom-config",
+        "oauth-client-credentials-custom",
+        "any-auth",
+        "package-yml",
+        "websocket-bearer-auth",
+        "unknown",
+        "file-download",
+        "public-object",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 577
+    },
+    {
+      "fixtures": [
+        "nullable",
+        "version-no-default",
+        "accept-header",
+        "license",
+        "request-parameters",
+        "required-nullable",
+        "circular-references-advanced",
+        "examples",
+        "variables",
+        "simple-api"
+      ],
+      "groupTotalTimeSeconds": 585
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "client-side-params",
+        "no-environment",
+        "oauth-client-credentials-environment-variables",
+        "multi-url-environment",
+        "ts-inline-types",
+        "cross-package-type-names",
+        "undiscriminated-unions",
+        "imdb:skip-response-validation",
+        "single-url-environment-default"
+      ],
+      "groupTotalTimeSeconds": 587
+    },
+    {
+      "fixtures": [
+        "idempotency-headers",
+        "version",
+        "multi-line-docs",
+        "literals-unions",
+        "basic-auth",
+        "custom-auth",
+        "validation",
+        "exhaustive:no-custom-config",
+        "bytes-upload",
+        "plain-text",
+        "server-sent-event-examples"
+      ],
+      "groupTotalTimeSeconds": 577
+    },
+    {
+      "fixtures": [
+        "extends",
+        "auth-environment-variables",
+        "object",
+        "oauth-client-credentials-nested-root",
+        "basic-auth-environment-variables",
+        "inferred-auth-implicit-no-expiry",
+        "multi-url-environment-no-default",
+        "empty-clients",
+        "exhaustive:test-package-path",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 587
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "query-parameters-openapi",
+        "optional",
+        "objects-with-imports",
+        "imdb:output-compiled",
+        "literal",
+        "path-parameters",
+        "folders",
+        "simple-fhir",
+        "http-head"
+      ],
+      "groupTotalTimeSeconds": 585
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "alias",
+        "mixed-case:retain-original-casing",
+        "oauth-client-credentials-default",
+        "inferred-auth-explicit",
+        "reserved-keywords",
+        "response-property",
+        "circular-references",
+        "exhaustive:union-utils",
+        "multiple-request-bodies",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 577
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ts-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ts-sdk-seed-groups.json
@@ -1,204 +1,205 @@
 {
-  "totalTestTimeSeconds": 28810,
+  "totalTestTimeSeconds": 28581,
   "groups": [
     {
       "fixtures": [
         "trace:serde-trace",
-        "accept-header",
-        "alias",
-        "query-parameters:serde-layer-query",
-        "file-upload:form-data-node16",
-        "single-url-environment-no-default",
-        "oauth-client-credentials-nested-root:never-throw-errors",
-        "simple-api",
-        "response-property",
-        "mixed-case:no-custom-config",
-        "ts-express-casing",
-        "server-sent-events",
-        "object",
-        "exhaustive:bundle"
+        "examples:retain-original-casing",
+        "bytes-upload",
+        "websocket:serde",
+        "exhaustive:never-throw-errors",
+        "websocket-inferred-auth:websockets",
+        "nullable-optional",
+        "multi-url-environment",
+        "path-parameters:default",
+        "multiple-request-bodies",
+        "empty-clients",
+        "streaming-parameter",
+        "exhaustive:consolidate-type-files",
+        "literals-unions"
       ],
-      "groupTotalTimeSeconds": 2890
+      "groupTotalTimeSeconds": 2847
     },
     {
       "fixtures": [
         "trace:serde-no-throwing",
-        "examples:retain-original-casing",
-        "file-upload:use-jest",
+        "exhaustive:retain-original-casing",
+        "auth-environment-variables",
         "version",
-        "exhaustive:consolidate-type-files",
-        "inferred-auth-explicit",
-        "websocket-inferred-auth:websockets",
+        "enum",
+        "exhaustive:with-audiences",
+        "imdb:branded-string-aliases",
         "basic-auth-environment-variables",
-        "package-yml",
+        "accept-header",
         "custom-auth",
-        "empty-clients",
-        "unknown:unknown-as-any",
-        "circular-references-advanced",
-        "exhaustive:omit-fern-headers"
+        "server-sent-events",
+        "ts-inline-types:no-inline",
+        "license",
+        "exhaustive:legacy-exports"
       ],
-      "groupTotalTimeSeconds": 2888
+      "groupTotalTimeSeconds": 2845
     },
     {
       "fixtures": [
         "exhaustive:use-yarn",
-        "examples:examples-with-api-reference",
-        "version-no-default",
-        "bytes-upload",
-        "exhaustive:bigint",
-        "exhaustive:with-audiences",
+        "bearer-token-environment-variable",
+        "exhaustive:allow-extra-fields",
         "file-download:stream",
-        "basic-auth",
-        "optional",
-        "websocket-bearer-auth:websockets",
-        "request-parameters:flatten-request-parameters",
-        "server-sent-event-examples",
-        "variables",
-        "literals-unions"
+        "mixed-file-directory",
+        "client-side-params",
+        "single-url-environment-no-default",
+        "streaming:no-serde-layer",
+        "simple-api",
+        "response-property",
+        "property-access:no-custom-config",
+        "property-access:generate-read-write-only-types",
+        "alias-extends",
+        "object",
+        "bytes-download"
       ],
-      "groupTotalTimeSeconds": 2864
+      "groupTotalTimeSeconds": 2855
     },
     {
       "fixtures": [
-        "trace:exhaustive",
-        "exhaustive:use-jest",
-        "auth-environment-variables",
-        "query-parameters-openapi-as-objects:no-custom-config",
-        "oauth-client-credentials-with-variables",
-        "oauth-client-credentials-environment-variables",
+        "exhaustive:serde-layer",
+        "examples:examples-with-api-reference",
+        "query-parameters:serde-layer-query",
+        "api-wide-base-path",
         "exhaustive:node-fetch",
-        "path-parameters:inline-path-parameters",
-        "imdb:no-custom-config",
-        "no-environment",
-        "request-parameters:no-custom-config",
-        "license",
-        "property-access:no-custom-config",
-        "file-upload:inline",
-        "bytes-download",
-        "exhaustive:serde-layer"
+        "oauth-client-credentials-nested-root:no-custom-config",
+        "inferred-auth-implicit-no-expiry",
+        "path-parameters:inline-path-parameters-retain-original-casing",
+        "oauth-client-credentials-environment-variables",
+        "request-parameters:flatten-request-parameters",
+        "nullable",
+        "required-nullable",
+        "unknown:unknown-as-any",
+        "undiscriminated-unions:skip-response-validation",
+        "exhaustive:dev-dependencies"
       ],
-      "groupTotalTimeSeconds": 2890
+      "groupTotalTimeSeconds": 2876
     },
     {
       "fixtures": [
         "file-download:wrapper",
-        "path-parameters:inline-path-parameters-serde",
-        "api-wide-base-path",
-        "extends",
-        "mixed-file-directory",
+        "streaming:wrapper",
+        "exhaustive:bigint",
+        "query-parameters-openapi:no-custom-config",
+        "audiences:with-partner-audience",
+        "file-upload:form-data-node16",
         "inferred-auth-implicit",
-        "oauth-client-credentials:no-custom-config",
-        "nullable-optional",
+        "oauth-client-credentials-nested-root:never-throw-errors",
+        "basic-auth",
+        "any-auth:no-custom-config",
+        "server-sent-event-examples",
         "error-property:union-utils",
-        "multi-line-docs",
-        "query-parameters:no-custom-config",
-        "reserved-keywords",
-        "file-download:no-custom-config",
-        "websocket:no-websocket-clients",
-        "exhaustive:local-files-no-source",
-        "exhaustive:local-files"
+        "mixed-case:retain-original-casing",
+        "variables",
+        "exhaustive:custom-package-json"
       ],
-      "groupTotalTimeSeconds": 2888
+      "groupTotalTimeSeconds": 2850
+    },
+    {
+      "fixtures": [
+        "trace:no-custom-config",
+        "exhaustive:bigint-serde-layer",
+        "alias",
+        "exhaustive:jsr",
+        "cross-package-type-names",
+        "file-upload:inline",
+        "unions",
+        "single-url-environment-default",
+        "path-parameters:retain-original-casing",
+        "optional",
+        "streaming:allow-custom-fetcher",
+        "multi-line-docs",
+        "ts-inline-types:inline",
+        "circular-references-advanced",
+        "exhaustive:bundle"
+      ],
+      "groupTotalTimeSeconds": 2869
     },
     {
       "fixtures": [
         "file-upload:wrapper",
-        "streaming:wrapper",
-        "query-parameters-openapi:no-custom-config",
+        "pagination",
+        "content-type",
+        "folders",
+        "file-upload:no-custom-config",
+        "inferred-auth-explicit",
+        "mixed-case:no-custom-config",
+        "oauth-client-credentials-default",
+        "request-parameters:use-big-int-and-default-request-parameter-values",
+        "package-yml",
+        "plain-text",
+        "http-head",
+        "request-parameters:use-default-request-parameter-values",
+        "public-object",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 2850
+    },
+    {
+      "fixtures": [
+        "exhaustive:omit-fern-headers",
+        "trace:exhaustive",
+        "path-parameters:inline-path-parameters-serde",
+        "file-download:no-custom-config",
         "exhaustive:web-stream-wrapper",
         "literal",
-        "file-upload:no-custom-config",
+        "imdb:no-custom-config",
         "multi-url-environment-no-default",
-        "path-parameters:inline-path-parameters-retain-original-casing",
-        "single-url-environment-default",
-        "idempotency-headers",
         "streaming:no-custom-config",
-        "any-auth:generate-endpoint-metadata",
-        "ts-inline-types:no-inline",
-        "streaming-parameter",
-        "circular-references"
+        "path-parameters:inline-path-parameters",
+        "unknown:no-custom-config",
+        "ts-express-casing",
+        "simple-fhir",
+        "websocket:no-websocket-clients",
+        "oauth-client-credentials-custom",
+        "exhaustive:local-files"
       ],
-      "groupTotalTimeSeconds": 2853
+      "groupTotalTimeSeconds": 2860
+    },
+    {
+      "fixtures": [
+        "exhaustive:package-path",
+        "oauth-client-credentials:serde",
+        "file-upload:use-jest",
+        "file-download:file-download-response-headers",
+        "imdb:noScripts",
+        "audiences:no-custom-config",
+        "oauth-client-credentials:no-custom-config",
+        "objects-with-imports",
+        "no-environment",
+        "pagination-custom",
+        "websocket-bearer-auth:websockets",
+        "any-auth:generate-endpoint-metadata",
+        "undiscriminated-unions:no-custom-config",
+        "websocket:no-serde",
+        "exhaustive:use-jest"
+      ],
+      "groupTotalTimeSeconds": 2859
     },
     {
       "fixtures": [
         "exhaustive:no-custom-config",
-        "exhaustive:retain-original-casing",
-        "folders",
-        "cross-package-type-names",
-        "imdb:noScripts",
-        "inferred-auth-implicit-no-expiry",
-        "http-head",
-        "unions",
-        "undiscriminated-unions:skip-response-validation",
-        "property-access:generate-read-write-only-types",
-        "streaming:no-serde-layer",
-        "simple-fhir",
-        "undiscriminated-unions:no-custom-config",
-        "objects-with-imports",
-        "exhaustive:dev-dependencies"
-      ],
-      "groupTotalTimeSeconds": 2896
-    },
-    {
-      "fixtures": [
-        "pagination",
-        "trace:no-custom-config",
-        "file-download:file-download-response-headers",
-        "websocket:serde",
-        "audiences:no-custom-config",
-        "audiences:with-partner-audience",
-        "client-side-params",
-        "multi-url-environment",
-        "imdb:omit-undefined",
-        "errors",
-        "ts-inline-types:inline",
-        "mixed-case:retain-original-casing",
-        "public-object",
-        "plain-text",
-        "oauth-client-credentials-custom"
-      ],
-      "groupTotalTimeSeconds": 2849
-    },
-    {
-      "fixtures": [
         "file-upload:serde",
-        "exhaustive:bigint-serde-layer",
-        "alias-extends",
-        "content-type",
-        "exhaustive:never-throw-errors",
-        "imdb:branded-string-aliases",
-        "multiple-request-bodies",
-        "path-parameters:default",
-        "pagination-custom",
-        "streaming:allow-custom-fetcher",
-        "request-parameters:use-default-request-parameter-values",
-        "unknown:no-custom-config",
-        "websocket:no-serde",
-        "exhaustive:legacy-exports",
-        "exhaustive:allow-extra-fields"
-      ],
-      "groupTotalTimeSeconds": 2897
-    },
-    {
-      "fixtures": [
-        "oauth-client-credentials:serde",
-        "exhaustive:package-path",
-        "exhaustive:jsr",
-        "bearer-token-environment-variable",
-        "enum",
-        "oauth-client-credentials-default",
-        "request-parameters:use-big-int-and-default-request-parameter-values",
-        "oauth-client-credentials-nested-root:no-custom-config",
-        "path-parameters:retain-original-casing",
-        "extra-properties",
-        "nullable",
-        "validation",
-        "any-auth:no-custom-config",
+        "version-no-default",
+        "query-parameters-openapi-as-objects:no-custom-config",
+        "extends",
+        "oauth-client-credentials-with-variables",
+        "errors",
+        "imdb:omit-undefined",
+        "query-parameters:no-custom-config",
         "exhaustive:export-all-requests-at-root",
-        "exhaustive:custom-package-json"
+        "extra-properties",
+        "reserved-keywords",
+        "validation",
+        "request-parameters:no-custom-config",
+        "circular-references",
+        "exhaustive:local-files-no-source"
       ],
-      "groupTotalTimeSeconds": 2895
+      "groupTotalTimeSeconds": 2870
     }
   ]
 }


### PR DESCRIPTION
Auto-generated PR, triggered by nightly-seed-grouping workflow with: push from branch: mallinson/run-on-failure-cases-test.
GitHub workflow run: https://github.com/fern-api/fern/actions/runs/18201171096