### PR TITLE
chore(internal): update seed group files

### DIFF
--- a/.github/workflow-resource-files/seed-groups/fastapi-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/fastapi-seed-groups.json
@@ -1,160 +1,160 @@
 {
-  "totalTestTimeSeconds": 3301,
+  "totalTestTimeSeconds": 3294,
   "groups": [
     {
       "fixtures": [
         "trace",
-        "validation",
+        "unions:no-custom-config",
         "circular-references:no-custom-config",
-        "variables",
-        "oauth-client-credentials",
-        "single-url-environment-default",
+        "single-url-environment-no-default",
         "imdb:includes-extra-fields",
-        "request-parameters",
-        "http-head",
-        "streaming",
-        "exhaustive:ignore-extra-fields"
+        "literals-unions",
+        "websocket-inferred-auth",
+        "imdb:async-handlers",
+        "streaming-parameter",
+        "examples",
+        "folders"
       ],
       "groupTotalTimeSeconds": 337
     },
     {
       "fixtures": [
         "accept-header",
-        "unions:no-inheritance-for-extended-models",
-        "bytes-download",
-        "circular-references:no-inheritance-for-extended-models",
-        "errors",
-        "exhaustive:pydantic-v1",
-        "plain-text",
-        "pagination:no-inheritance-for-extended-models",
-        "inferred-auth-explicit",
-        "multiple-request-bodies"
-      ],
-      "groupTotalTimeSeconds": 322
-    },
-    {
-      "fixtures": [
-        "content-type",
+        "query-parameters-openapi",
+        "auth-environment-variables",
         "unknown",
-        "bytes-upload",
-        "empty-clients",
-        "literals-unions",
-        "optional",
-        "simple-api",
-        "query-parameters",
-        "mixed-file-directory",
-        "websocket-inferred-auth"
+        "multi-url-environment-no-default",
+        "plain-text",
+        "custom-auth",
+        "inferred-auth-explicit",
+        "any-auth",
+        "objects-with-imports"
       ],
       "groupTotalTimeSeconds": 322
     },
     {
       "fixtures": [
-        "alias",
-        "nullable-optional",
+        "version",
+        "query-parameters-openapi-as-objects",
+        "bearer-token-environment-variable",
+        "basic-auth",
         "websocket",
-        "package-yml",
-        "mixed-case",
         "property-access",
-        "custom-auth",
-        "objects-with-imports",
-        "server-sent-event-examples",
-        "audiences",
-        "literal"
+        "object",
+        "inferred-auth-implicit-no-expiry",
+        "file-upload",
+        "mixed-file-directory",
+        "exhaustive:include-validators"
       ],
       "groupTotalTimeSeconds": 337
     },
     {
       "fixtures": [
-        "version",
-        "query-parameters-openapi",
-        "auth-environment-variables",
-        "multi-line-docs",
+        "version-no-default",
+        "simple-fhir:no-inheritance-for-extended-models",
+        "bytes-download",
+        "basic-auth-environment-variables",
+        "empty-clients",
         "nullable",
-        "public-object",
-        "error-property",
-        "pagination:no-custom-config",
-        "file-download:no-custom-config",
-        "response-property",
-        "examples"
+        "required-nullable",
+        "query-parameters",
+        "idempotency-headers",
+        "request-parameters",
+        "literal"
       ],
-      "groupTotalTimeSeconds": 338
+      "groupTotalTimeSeconds": 336
     },
     {
       "fixtures": [
-        "version-no-default",
-        "query-parameters-openapi-as-objects",
-        "basic-auth",
-        "multi-url-environment",
-        "single-url-environment-no-default",
-        "required-nullable",
-        "multi-url-environment-no-default",
-        "extra-properties",
-        "oauth-client-credentials-with-variables",
-        "server-sent-events",
-        "folders"
+        "alias",
+        "multi-line-docs",
+        "nullable-optional",
+        "mixed-case",
+        "exhaustive:no-custom-config",
+        "error-property",
+        "variables",
+        "response-property",
+        "oauth-client-credentials-environment-variables",
+        "server-sent-event-examples"
       ],
-      "groupTotalTimeSeconds": 338
+      "groupTotalTimeSeconds": 321
     },
     {
       "fixtures": [
         "alias-extends:no-custom-config",
-        "file-download:no-inheritance-for-extended-models",
-        "exhaustive:pydantic-v2",
-        "websocket-bearer-auth",
-        "object",
-        "client-side-params",
-        "oauth-client-credentials-custom",
-        "file-upload",
-        "imdb:v1_on_v2",
-        "cross-package-type-names"
+        "package-yml",
+        "circular-references-advanced:no-inheritance-for-extended-models",
+        "exhaustive:ignore-extra-fields",
+        "undiscriminated-unions",
+        "extra-properties",
+        "multi-url-environment",
+        "inferred-auth-implicit",
+        "pagination:no-inheritance-for-extended-models",
+        "oauth-client-credentials-with-variables",
+        "enum"
       ],
-      "groupTotalTimeSeconds": 326
+      "groupTotalTimeSeconds": 336
     },
     {
       "fixtures": [
         "alias-extends:no-inheritance-for-extended-models",
-        "circular-references-advanced:no-inheritance-for-extended-models",
-        "circular-references-advanced:no-custom-config",
-        "simple-fhir:no-inheritance-for-extended-models",
-        "undiscriminated-unions",
-        "simple-fhir:no-custom-config",
-        "oauth-client-credentials-default",
-        "any-auth",
-        "idempotency-headers",
-        "inferred-auth-implicit-no-expiry"
+        "pagination-custom",
+        "bytes-upload",
+        "exhaustive:skip-formatting",
+        "no-environment",
+        "public-object",
+        "oauth-client-credentials",
+        "pagination:no-custom-config",
+        "file-download:no-custom-config",
+        "oauth-client-credentials-nested-root"
       ],
       "groupTotalTimeSeconds": 322
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "pagination-custom",
-        "bearer-token-environment-variable",
         "path-parameters",
-        "license",
-        "reserved-keywords",
-        "oauth-client-credentials-nested-root",
-        "inferred-auth-implicit",
-        "imdb:no-custom-config",
-        "streaming-parameter"
+        "circular-references-advanced:no-custom-config",
+        "exhaustive:pydantic-v2",
+        "simple-fhir:no-custom-config",
+        "websocket-bearer-auth",
+        "single-url-environment-default",
+        "simple-api",
+        "http-head",
+        "multiple-request-bodies"
       ],
-      "groupTotalTimeSeconds": 322
+      "groupTotalTimeSeconds": 321
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "exhaustive:pydantic-v1",
+        "unions:no-inheritance-for-extended-models",
+        "errors",
+        "license",
+        "optional",
+        "reserved-keywords",
+        "imdb:no-custom-config",
+        "streaming",
+        "audiences",
+        "exhaustive:frozen_utils"
+      ],
+      "groupTotalTimeSeconds": 336
     },
     {
       "fixtures": [
         "extends",
-        "exhaustive:no-custom-config",
-        "basic-auth-environment-variables",
-        "unions:no-custom-config",
-        "no-environment",
-        "exhaustive:skip-formatting",
-        "exhaustive:frozen_utils",
-        "oauth-client-credentials-environment-variables",
-        "imdb:async-handlers",
-        "enum",
-        "exhaustive:include-validators"
+        "file-download:no-inheritance-for-extended-models",
+        "circular-references:no-inheritance-for-extended-models",
+        "validation",
+        "imdb:v1_on_v2",
+        "oauth-client-credentials-default",
+        "client-side-params",
+        "server-sent-events",
+        "oauth-client-credentials-custom",
+        "cross-package-type-names"
       ],
-      "groupTotalTimeSeconds": 337
+      "groupTotalTimeSeconds": 326
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/go-fiber-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-fiber-seed-groups.json
@@ -1,123 +1,117 @@
 {
-  "totalTestTimeSeconds": 3954,
+  "totalTestTimeSeconds": 4022,
   "groups": [
-    {
-      "fixtures": [
-        "accept-header",
-        "bearer-token-environment-variable",
-        "multi-url-environment",
-        "path-parameters",
-        "request-parameters"
-      ],
-      "groupTotalTimeSeconds": 396
-    },
-    {
-      "fixtures": [
-        "alias",
-        "examples",
-        "imdb",
-        "server-sent-event-examples",
-        "response-property",
-        "single-url-environment-no-default",
-        "reserved-keywords"
-      ],
-      "groupTotalTimeSeconds": 396
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
-        "go-bytes-request",
-        "inferred-auth-explicit",
-        "variables",
-        "single-url-environment-default",
-        "streaming:."
-      ],
-      "groupTotalTimeSeconds": 394
-    },
     {
       "fixtures": [
         "query-parameters-openapi",
         "alias-extends",
-        "object",
-        "optional",
-        "plain-text",
-        "custom-auth",
-        "oauth-client-credentials",
-        "basic-auth-environment-variables",
-        "extra-properties",
-        "no-environment",
-        "oauth-client-credentials-nested-root",
+        "property-access",
         "unions",
+        "no-environment",
+        "inferred-auth-implicit-no-expiry",
+        "package-yml",
+        "any-auth",
+        "oauth-client-credentials-default",
         "unknown",
-        "websocket-bearer-auth",
-        "required-nullable",
-        "mixed-file-directory",
-        "idempotency-headers:.",
-        "streaming-parameter"
+        "basic-auth",
+        "basic-auth-environment-variables",
+        "optional",
+        "server-sent-event-examples",
+        "extra-properties",
+        "streaming:.",
+        "oauth-client-credentials-custom",
+        "http-head"
       ],
-      "groupTotalTimeSeconds": 395
+      "groupTotalTimeSeconds": 401
     },
     {
       "fixtures": [
         "version",
-        "mixed-case",
-        "simple-fhir",
-        "circular-references",
-        "query-parameters",
-        "errors",
-        "oauth-client-credentials-environment-variables",
+        "nullable-optional",
+        "nullable",
+        "plain-text",
+        "client-side-params",
         "circular-references-advanced",
-        "inferred-auth-implicit",
-        "oauth-client-credentials-custom",
-        "public-object",
-        "any-auth",
-        "error-property",
-        "validation",
+        "multi-line-docs",
+        "query-parameters",
+        "custom-auth",
+        "required-nullable",
+        "websocket-bearer-auth",
         "multi-url-environment-no-default",
-        "license",
-        "audiences",
-        "go-content-type"
+        "pagination",
+        "server-sent-events",
+        "multi-url-environment",
+        "streaming-parameter",
+        "oauth-client-credentials-environment-variables",
+        "mixed-file-directory"
       ],
-      "groupTotalTimeSeconds": 394
+      "groupTotalTimeSeconds": 401
     },
     {
       "fixtures": [
         "version-no-default",
-        "nullable",
-        "nullable-optional",
-        "property-access",
+        "simple-fhir",
+        "object",
+        "public-object",
+        "mixed-case",
+        "inferred-auth-implicit",
         "multiple-request-bodies",
-        "client-side-params",
-        "inferred-auth-implicit-no-expiry",
-        "objects-with-imports",
-        "multi-line-docs",
-        "oauth-client-credentials-default",
+        "response-property",
+        "oauth-client-credentials",
         "trace",
-        "basic-auth",
-        "pagination",
-        "websocket",
+        "websocket-inferred-auth",
+        "oauth-client-credentials-nested-root",
+        "path-parameters",
+        "simple-api",
+        "objects-with-imports",
+        "undiscriminated-unions",
         "oauth-client-credentials-with-variables",
-        "literals-unions",
-        "empty-clients",
-        "package-yml"
+        "folders",
+        "reserved-keywords"
       ],
-      "groupTotalTimeSeconds": 394
+      "groupTotalTimeSeconds": 404
     },
     {
-      "fixtures": ["api-wide-base-path", "extends", "server-sent-events", "undiscriminated-unions"],
-      "groupTotalTimeSeconds": 394
+      "fixtures": ["bearer-token-environment-variable", "extends", "websocket", "imdb", "request-parameters"],
+      "groupTotalTimeSeconds": 402
     },
     {
-      "fixtures": ["bytes-download", "file-download", "simple-api", "cross-package-type-names", "http-head"],
-      "groupTotalTimeSeconds": 398
+      "fixtures": [
+        "bytes-download",
+        "go-bytes-request",
+        "errors",
+        "single-url-environment-no-default",
+        "literals-unions",
+        "enum"
+      ],
+      "groupTotalTimeSeconds": 400
     },
     {
-      "fixtures": ["bytes-upload", "file-upload", "websocket-inferred-auth", "folders", "exhaustive"],
-      "groupTotalTimeSeconds": 397
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "examples",
+        "error-property",
+        "pagination-custom",
+        "circular-references",
+        "single-url-environment-default"
+      ],
+      "groupTotalTimeSeconds": 400
     },
     {
-      "fixtures": ["content-type", "query-parameters-openapi-as-objects", "enum", "pagination-custom", "literal"],
-      "groupTotalTimeSeconds": 396
+      "fixtures": ["accept-header", "content-type", "empty-clients", "validation"],
+      "groupTotalTimeSeconds": 400
+    },
+    {
+      "fixtures": ["alias", "file-download", "inferred-auth-explicit", "audiences", "go-content-type"],
+      "groupTotalTimeSeconds": 405
+    },
+    {
+      "fixtures": ["api-wide-base-path", "file-upload", "license", "cross-package-type-names", "literal"],
+      "groupTotalTimeSeconds": 405
+    },
+    {
+      "fixtures": ["auth-environment-variables", "bytes-upload", "variables", "idempotency-headers:.", "exhaustive"],
+      "groupTotalTimeSeconds": 404
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/go-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-model-seed-groups.json
@@ -1,125 +1,130 @@
 {
-  "totalTestTimeSeconds": 4067,
+  "totalTestTimeSeconds": 4126,
   "groups": [
     {
-      "fixtures": [
-        "version",
-        "validation",
-        "multiple-request-bodies",
-        "optional",
-        "simple-fhir",
-        "empty-clients",
-        "websocket-inferred-auth",
-        "basic-auth-environment-variables",
-        "inferred-auth-implicit-no-expiry",
-        "single-url-environment-no-default",
-        "path-parameters",
-        "oauth-client-credentials-environment-variables",
-        "single-url-environment-default",
-        "mixed-file-directory",
-        "query-parameters",
-        "enum"
-      ],
-      "groupTotalTimeSeconds": 409
-    },
-    {
-      "fixtures": [
-        "version-no-default",
-        "websocket-bearer-auth",
-        "nullable",
-        "any-auth",
-        "no-environment",
-        "websocket",
-        "inferred-auth-explicit",
-        "http-head",
-        "oauth-client-credentials",
-        "basic-auth",
-        "oauth-client-credentials-custom",
-        "response-property",
-        "variables",
-        "multi-url-environment",
-        "server-sent-event-examples",
-        "literal"
-      ],
-      "groupTotalTimeSeconds": 409
+      "fixtures": ["accept-header", "file-upload", "empty-clients", "query-parameters"],
+      "groupTotalTimeSeconds": 410
     },
     {
       "fixtures": [
         "query-parameters-openapi",
-        "undiscriminated-unions",
-        "literals-unions",
-        "nullable-optional",
-        "plain-text",
-        "unions",
-        "imdb",
-        "inferred-auth-implicit",
-        "oauth-client-credentials-default",
-        "circular-references",
-        "package-yml",
+        "simple-fhir",
+        "nullable",
+        "property-access",
+        "errors",
         "extra-properties",
-        "oauth-client-credentials-with-variables",
-        "client-side-params",
-        "folders",
-        "oauth-client-credentials-nested-root"
+        "inferred-auth-explicit",
+        "unions",
+        "inferred-auth-implicit",
+        "custom-auth",
+        "http-head",
+        "oauth-client-credentials-default",
+        "server-sent-event-examples",
+        "streaming-parameter",
+        "pagination",
+        "literal"
       ],
-      "groupTotalTimeSeconds": 409
+      "groupTotalTimeSeconds": 414
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "unknown",
-        "mixed-case",
+        "undiscriminated-unions",
+        "multiple-request-bodies",
         "object",
-        "property-access",
-        "circular-references-advanced",
-        "streaming-parameter",
-        "streaming:.",
-        "pagination",
-        "license",
-        "pagination-custom",
-        "multi-line-docs",
-        "simple-api",
-        "idempotency-headers:.",
-        "go-content-type",
-        "objects-with-imports"
+        "validation",
+        "client-side-params",
+        "multi-url-environment-no-default",
+        "websocket-inferred-auth",
+        "required-nullable",
+        "error-property",
+        "literals-unions",
+        "oauth-client-credentials-environment-variables",
+        "server-sent-events",
+        "unknown",
+        "public-object",
+        "examples"
       ],
-      "groupTotalTimeSeconds": 409
+      "groupTotalTimeSeconds": 414
     },
     {
-      "fixtures": ["accept-header", "bytes-download", "errors", "server-sent-events"],
-      "groupTotalTimeSeconds": 403
+      "fixtures": [
+        "version",
+        "mixed-case",
+        "websocket",
+        "plain-text",
+        "inferred-auth-implicit-no-expiry",
+        "any-auth",
+        "imdb",
+        "oauth-client-credentials",
+        "basic-auth-environment-variables",
+        "response-property",
+        "multi-url-environment",
+        "package-yml",
+        "simple-api",
+        "variables",
+        "request-parameters",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 414
     },
     {
-      "fixtures": ["alias", "content-type", "examples", "exhaustive", "request-parameters"],
-      "groupTotalTimeSeconds": 409
+      "fixtures": [
+        "version-no-default",
+        "optional",
+        "license",
+        "nullable-optional",
+        "websocket-bearer-auth",
+        "idempotency-headers:.",
+        "no-environment",
+        "basic-auth",
+        "circular-references",
+        "single-url-environment-no-default",
+        "oauth-client-credentials-custom",
+        "pagination-custom",
+        "streaming:.",
+        "circular-references-advanced",
+        "objects-with-imports",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 414
+    },
+    {
+      "fixtures": [
+        "alias",
+        "auth-environment-variables",
+        "oauth-client-credentials-nested-root",
+        "single-url-environment-default"
+      ],
+      "groupTotalTimeSeconds": 410
     },
     {
       "fixtures": [
         "alias-extends",
-        "bytes-upload",
+        "bytes-download",
+        "path-parameters",
         "cross-package-type-names",
-        "go-bytes-request",
-        "required-nullable"
+        "reserved-keywords"
       ],
-      "groupTotalTimeSeconds": 408
+      "groupTotalTimeSeconds": 414
+    },
+    {
+      "fixtures": ["api-wide-base-path", "bytes-upload", "go-bytes-request", "audiences", "exhaustive"],
+      "groupTotalTimeSeconds": 414
     },
     {
       "fixtures": [
-        "api-wide-base-path",
-        "extends",
-        "custom-auth",
-        "multi-url-environment-no-default",
-        "reserved-keywords"
+        "bearer-token-environment-variable",
+        "content-type",
+        "go-content-type",
+        "mixed-file-directory",
+        "enum"
       ],
-      "groupTotalTimeSeconds": 407
+      "groupTotalTimeSeconds": 413
     },
     {
-      "fixtures": ["auth-environment-variables", "file-upload", "error-property", "public-object"],
-      "groupTotalTimeSeconds": 402
-    },
-    {
-      "fixtures": ["bearer-token-environment-variable", "file-download", "audiences", "trace"],
-      "groupTotalTimeSeconds": 402
+      "fixtures": ["file-download", "extends", "multi-line-docs", "oauth-client-credentials-with-variables"],
+      "groupTotalTimeSeconds": 409
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/go-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/go-sdk-seed-groups.json
@@ -1,165 +1,165 @@
 {
-  "totalTestTimeSeconds": 8582,
+  "totalTestTimeSeconds": 9212,
   "groups": [
     {
       "fixtures": [
-        "version",
-        "pagination",
-        "oauth-client-credentials-custom",
-        "audiences",
-        "cross-package-type-names",
-        "examples:client-name",
-        "imdb:package-path",
-        "variables",
-        "license",
-        "errors",
-        "query-parameters",
-        "examples:readme-config",
-        "basic-auth"
-      ],
-      "groupTotalTimeSeconds": 857
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi",
-        "oauth-client-credentials-with-variables",
-        "mixed-file-directory",
-        "oauth-client-credentials-nested-root",
-        "folders",
-        "path-parameters:no-custom-config",
-        "multi-line-docs",
-        "circular-references",
-        "go-content-type",
-        "circular-references-advanced",
-        "unions:package-name",
-        "any-auth",
-        "client-side-params"
-      ],
-      "groupTotalTimeSeconds": 854
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "file-upload:v0",
-        "oauth-client-credentials-environment-variables",
-        "examples:package-path",
-        "streaming:.",
-        "package-yml:no-custom-config",
-        "optional",
-        "http-head",
-        "bytes-download",
-        "examples:v0",
-        "streaming-parameter"
-      ],
-      "groupTotalTimeSeconds": 855
-    },
-    {
-      "fixtures": [
         "alias",
-        "file-upload:package-name",
+        "file-upload:v0",
         "simple-fhir",
-        "idempotency-headers:.",
-        "undiscriminated-unions:no-custom-config",
-        "response-property",
-        "simple-api",
-        "custom-auth",
-        "alias-extends",
-        "examples:always-send-required-properties",
+        "unknown",
+        "imdb:package-path",
+        "object",
+        "circular-references",
+        "go-bytes-request:use-reader-for-bytes-request",
+        "query-parameters",
+        "property-access",
         "request-parameters"
       ],
-      "groupTotalTimeSeconds": 853
-    },
-    {
-      "fixtures": [
-        "version-no-default",
-        "examples:exported-client-name",
-        "enum",
-        "unions:v0",
-        "undiscriminated-unions:v0",
-        "validation",
-        "single-url-environment-default",
-        "go-bytes-request:no-custom-config",
-        "inferred-auth-implicit-no-expiry",
-        "examples:getters-pass-by-value",
-        "trace"
-      ],
-      "groupTotalTimeSeconds": 865
+      "groupTotalTimeSeconds": 911
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "file-download",
+        "examples:v0",
+        "cross-package-type-names",
         "path-parameters:v0",
-        "multi-url-environment-no-default",
-        "mixed-case:default-values",
-        "nullable-optional",
-        "literals-unions:no-custom-config",
-        "inferred-auth-implicit",
-        "property-access",
-        "basic-auth-environment-variables"
-      ],
-      "groupTotalTimeSeconds": 861
-    },
-    {
-      "fixtures": [
-        "file-upload:no-custom-config",
-        "examples:no-custom-config",
-        "objects-with-imports",
-        "imdb:no-custom-config",
-        "unknown",
-        "websocket-inferred-auth",
-        "websocket",
-        "required-nullable",
-        "public-object",
-        "exhaustive",
-        "pagination-custom"
-      ],
-      "groupTotalTimeSeconds": 854
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
-        "content-type",
-        "server-sent-events",
-        "path-parameters:package-name",
+        "circular-references-advanced",
         "no-environment",
-        "oauth-client-credentials-default",
-        "multiple-request-bodies",
-        "websocket-bearer-auth",
-        "examples:client-name-with-custom-constructor-name",
-        "empty-clients"
+        "server-sent-events",
+        "objects-with-imports",
+        "any-auth",
+        "basic-auth",
+        "plain-text"
       ],
-      "groupTotalTimeSeconds": 861
+      "groupTotalTimeSeconds": 928
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "query-parameters-openapi-as-objects",
-        "single-url-environment-no-default",
-        "server-sent-event-examples",
-        "nullable",
-        "object",
-        "go-bytes-request:use-reader-for-bytes-request",
-        "unions:no-custom-config",
-        "literal",
-        "plain-text"
+        "examples:always-send-required-properties",
+        "oauth-client-credentials-with-variables",
+        "unions:package-name",
+        "http-head",
+        "nullable-optional",
+        "go-content-type",
+        "websocket-bearer-auth",
+        "examples:exported-client-name",
+        "exhaustive",
+        "streaming-parameter"
       ],
-      "groupTotalTimeSeconds": 861
+      "groupTotalTimeSeconds": 911
     },
     {
       "fixtures": [
-        "bytes-upload",
-        "extends",
-        "oauth-client-credentials",
+        "file-download",
+        "examples:no-custom-config",
+        "examples:client-name",
+        "pagination",
+        "audiences",
+        "path-parameters:no-custom-config",
+        "variables",
+        "license",
         "multi-url-environment",
-        "imdb:deep-package-path",
-        "mixed-case:no-custom-config",
-        "extra-properties",
-        "error-property",
-        "examples:export-all-requests-at-root",
-        "inferred-auth-explicit"
+        "go-bytes-request:no-custom-config",
+        "examples:readme-config",
+        "custom-auth",
+        "oauth-client-credentials-custom"
       ],
-      "groupTotalTimeSeconds": 861
+      "groupTotalTimeSeconds": 929
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "examples:client-name-with-custom-constructor-name",
+        "examples:package-path",
+        "examples:getters-pass-by-value",
+        "folders",
+        "unions:no-custom-config",
+        "websocket",
+        "mixed-case:default-values",
+        "nullable",
+        "multi-url-environment-no-default",
+        "extra-properties",
+        "inferred-auth-explicit",
+        "errors"
+      ],
+      "groupTotalTimeSeconds": 927
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "query-parameters-openapi-as-objects",
+        "undiscriminated-unions:no-custom-config",
+        "response-property",
+        "multiple-request-bodies",
+        "mixed-case:no-custom-config",
+        "oauth-client-credentials-environment-variables",
+        "oauth-client-credentials",
+        "bytes-download",
+        "basic-auth-environment-variables"
+      ],
+      "groupTotalTimeSeconds": 924
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "version",
+        "undiscriminated-unions:v0",
+        "validation",
+        "idempotency-headers:.",
+        "package-yml:no-custom-config",
+        "required-nullable",
+        "inferred-auth-implicit",
+        "public-object",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 925
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "version-no-default",
+        "mixed-file-directory",
+        "websocket-inferred-auth",
+        "imdb:no-custom-config",
+        "simple-api",
+        "unions:v0",
+        "oauth-client-credentials-nested-root",
+        "alias-extends",
+        "oauth-client-credentials-default"
+      ],
+      "groupTotalTimeSeconds": 924
+    },
+    {
+      "fixtures": [
+        "extends",
+        "bytes-upload",
+        "streaming:.",
+        "path-parameters:package-name",
+        "imdb:deep-package-path",
+        "literals-unions:no-custom-config",
+        "multi-line-docs",
+        "empty-clients",
+        "literal",
+        "client-side-params"
+      ],
+      "groupTotalTimeSeconds": 923
+    },
+    {
+      "fixtures": [
+        "file-upload:no-custom-config",
+        "file-upload:package-name",
+        "examples:export-all-requests-at-root",
+        "single-url-environment-default",
+        "single-url-environment-no-default",
+        "optional",
+        "enum",
+        "server-sent-event-examples",
+        "error-property",
+        "inferred-auth-implicit-no-expiry",
+        "pagination-custom"
+      ],
+      "groupTotalTimeSeconds": 910
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/java-spring-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/java-spring-seed-groups.json
@@ -1,152 +1,152 @@
 {
-  "totalTestTimeSeconds": 2200,
+  "totalTestTimeSeconds": 2078,
   "groups": [
     {
       "fixtures": [
         "trace",
-        "websocket-inferred-auth",
-        "basic-auth",
-        "inferred-auth-explicit",
-        "multi-url-environment-no-default",
-        "multi-url-environment",
-        "single-url-environment-no-default",
-        "license"
+        "multiple-request-bodies",
+        "circular-references",
+        "property-access",
+        "websocket",
+        "basic-auth-environment-variables",
+        "oauth-client-credentials-with-variables",
+        "literals-unions",
+        "imdb:enable-public-constructors"
       ],
-      "groupTotalTimeSeconds": 214
+      "groupTotalTimeSeconds": 210
     },
     {
       "fixtures": [
         "nullable-optional:legacy",
         "bytes-download",
-        "java-inline-types",
-        "inferred-auth-implicit-no-expiry",
-        "query-parameters",
-        "any-auth",
-        "response-property",
-        "oauth-client-credentials-with-variables",
-        "literals-unions",
-        "imdb:disable-required-property-builder-checks"
-      ],
-      "groupTotalTimeSeconds": 223
-    },
-    {
-      "fixtures": [
-        "nullable-optional:with-nullable-annotation",
-        "alias-extends",
         "unions",
-        "object",
-        "websocket-bearer-auth",
-        "empty-clients",
-        "server-sent-event-examples",
-        "objects-with-imports",
-        "mixed-file-directory",
-        "http-head"
+        "inferred-auth-explicit",
+        "request-parameters",
+        "custom-auth",
+        "package-yml",
+        "reserved-keywords",
+        "variables",
+        "file-upload"
       ],
-      "groupTotalTimeSeconds": 221
+      "groupTotalTimeSeconds": 205
     },
     {
       "fixtures": [
         "accept-header",
-        "auth-environment-variables",
-        "exhaustive",
-        "inferred-auth-implicit",
-        "circular-references",
-        "multi-line-docs",
-        "oauth-client-credentials-default",
-        "multiple-request-bodies",
-        "plain-text",
-        "file-upload"
+        "bearer-token-environment-variable",
+        "java-inline-types",
+        "oauth-client-credentials",
+        "oauth-client-credentials-custom",
+        "extra-properties",
+        "java-custom-package-prefix",
+        "server-sent-events",
+        "cross-package-type-names",
+        "folders"
       ],
-      "groupTotalTimeSeconds": 217
+      "groupTotalTimeSeconds": 211
     },
     {
       "fixtures": [
-        "java-nullable-named-request-types",
-        "bearer-token-environment-variable",
-        "circular-references-advanced",
-        "path-parameters",
-        "mixed-case",
-        "oauth-client-credentials-custom",
-        "oauth-client-credentials-environment-variables",
+        "query-parameters-openapi-as-objects",
+        "client-side-params",
+        "file-download",
+        "inferred-auth-implicit-no-expiry",
+        "response-property",
+        "empty-clients",
+        "pagination-custom",
+        "simple-api",
+        "imdb:disable-required-property-builder-checks",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 211
+    },
+    {
+      "fixtures": [
+        "version",
+        "simple-fhir",
+        "exhaustive",
+        "websocket-bearer-auth",
+        "any-auth",
         "optional",
+        "query-parameters",
+        "single-url-environment-default",
+        "license",
+        "java-builder-extension"
+      ],
+      "groupTotalTimeSeconds": 211
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "alias-extends",
+        "bytes-upload",
+        "websocket-inferred-auth",
+        "basic-auth",
+        "unknown",
+        "server-sent-event-examples",
+        "literal",
+        "required-nullable"
+      ],
+      "groupTotalTimeSeconds": 200
+    },
+    {
+      "fixtures": [
+        "alias",
+        "extends",
+        "nullable",
+        "multi-url-environment",
+        "multi-url-environment-no-default",
+        "error-property",
+        "streaming",
+        "mixed-file-directory",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 200
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "java-nullable-named-request-types",
+        "errors",
+        "undiscriminated-unions",
+        "path-parameters",
+        "validation",
+        "streaming-parameter",
+        "plain-text",
+        "audiences",
         "public-object"
       ],
       "groupTotalTimeSeconds": 211
     },
     {
       "fixtures": [
-        "query-parameters-openapi",
-        "content-type:package-prefix",
-        "pagination-custom",
-        "request-parameters",
-        "oauth-client-credentials",
-        "reserved-keywords",
-        "oauth-client-credentials-nested-root",
-        "required-nullable",
-        "idempotency-headers",
-        "audiences"
-      ],
-      "groupTotalTimeSeconds": 223
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "extends",
-        "undiscriminated-unions",
-        "validation",
-        "pagination",
-        "simple-api",
-        "package-yml",
-        "server-sent-events",
-        "imdb:enable-public-constructors",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 223
-    },
-    {
-      "fixtures": [
-        "version",
-        "simple-fhir",
-        "file-download",
-        "property-access",
-        "basic-auth-environment-variables",
-        "streaming",
-        "streaming-parameter",
-        "single-url-environment-default",
-        "java-builder-extension",
+        "auth-environment-variables",
+        "nullable-optional:with-nullable-annotation",
+        "circular-references-advanced",
+        "inferred-auth-implicit",
+        "oauth-client-credentials-environment-variables",
+        "oauth-client-credentials-default",
+        "mixed-case",
+        "java-pagination-deep-cursor-path",
+        "enum",
         "examples"
       ],
-      "groupTotalTimeSeconds": 223
+      "groupTotalTimeSeconds": 210
     },
     {
       "fixtures": [
-        "version-no-default",
-        "client-side-params",
-        "bytes-upload",
-        "unknown",
-        "custom-auth",
-        "variables",
-        "error-property",
-        "java-custom-package-prefix",
-        "enum",
-        "java-single-property-endpoint"
-      ],
-      "groupTotalTimeSeconds": 223
-    },
-    {
-      "fixtures": [
-        "alias",
-        "api-wide-base-path",
-        "nullable",
-        "websocket",
-        "errors",
-        "java-pagination-deep-cursor-path",
-        "extra-properties",
+        "content-type:package-prefix",
+        "query-parameters-openapi",
+        "multi-line-docs",
+        "pagination",
+        "object",
+        "oauth-client-credentials-nested-root",
+        "objects-with-imports",
         "no-environment",
-        "literal",
-        "folders"
+        "java-single-property-endpoint",
+        "http-head"
       ],
-      "groupTotalTimeSeconds": 222
+      "groupTotalTimeSeconds": 209
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/openapi-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/openapi-seed-groups.json
@@ -1,149 +1,149 @@
 {
-  "totalTestTimeSeconds": 1007,
+  "totalTestTimeSeconds": 1020,
   "groups": [
     {
       "fixtures": [
         "query-parameters-openapi",
-        "oauth-client-credentials-environment-variables",
-        "oauth-client-credentials-custom",
-        "pagination",
-        "folders",
-        "imdb:json-format",
-        "any-auth",
-        "package-yml",
-        "multi-line-docs",
-        "server-sent-events",
-        "exhaustive"
-      ],
-      "groupTotalTimeSeconds": 102
-    },
-    {
-      "fixtures": [
-        "version",
-        "enum:no-custom-config",
-        "enum:custom-overrides",
-        "oauth-client-credentials-with-variables",
-        "audiences",
-        "client-side-params",
-        "literals-unions",
-        "path-parameters",
-        "multi-url-environment",
-        "single-url-environment-default",
-        "extra-properties"
-      ],
-      "groupTotalTimeSeconds": 102
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "bytes-upload",
-        "nullable",
-        "inferred-auth-implicit-no-expiry",
-        "custom-auth",
-        "plain-text",
-        "multi-url-environment-no-default",
-        "single-url-environment-no-default",
-        "oauth-client-credentials"
-      ],
-      "groupTotalTimeSeconds": 102
-    },
-    {
-      "fixtures": [
-        "alias",
-        "content-type",
-        "optional",
-        "license",
-        "errors",
-        "property-access",
-        "pagination-custom",
-        "streaming-parameter",
-        "websocket-inferred-auth"
-      ],
-      "groupTotalTimeSeconds": 102
-    },
-    {
-      "fixtures": [
-        "alias-extends",
-        "extends",
-        "circular-references",
-        "inferred-auth-explicit",
-        "http-head",
-        "reserved-keywords",
-        "public-object",
-        "undiscriminated-unions"
-      ],
-      "groupTotalTimeSeconds": 99
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
-        "file-upload",
-        "circular-references-advanced",
-        "multiple-request-bodies",
-        "idempotency-headers",
-        "streaming",
-        "query-parameters",
-        "unknown"
-      ],
-      "groupTotalTimeSeconds": 99
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
-        "file-download",
-        "literal",
-        "simple-fhir",
         "inferred-auth-implicit",
-        "unions",
-        "request-parameters",
-        "variables"
+        "pagination",
+        "audiences",
+        "literal",
+        "basic-auth-environment-variables",
+        "no-environment",
+        "extra-properties",
+        "oauth-client-credentials-environment-variables",
+        "any-auth",
+        "validation"
       ],
-      "groupTotalTimeSeconds": 99
+      "groupTotalTimeSeconds": 104
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "mixed-file-directory",
-        "oauth-client-credentials-default",
+        "inferred-auth-implicit-no-expiry",
+        "exhaustive",
         "nullable-optional",
-        "cross-package-type-names",
-        "imdb:custom-overrides",
-        "no-environment",
-        "validation",
-        "required-nullable",
-        "websocket"
+        "literals-unions",
+        "circular-references-advanced",
+        "oauth-client-credentials",
+        "idempotency-headers",
+        "optional",
+        "basic-auth",
+        "variables"
       ],
-      "groupTotalTimeSeconds": 99
+      "groupTotalTimeSeconds": 104
+    },
+    {
+      "fixtures": [
+        "version",
+        "oauth-client-credentials-default",
+        "oauth-client-credentials-nested-root",
+        "oauth-client-credentials-with-variables",
+        "nullable",
+        "custom-auth",
+        "object",
+        "imdb:no-custom-config",
+        "package-yml",
+        "imdb:json-format",
+        "simple-api"
+      ],
+      "groupTotalTimeSeconds": 103
     },
     {
       "fixtures": [
         "version-no-default",
         "objects-with-imports",
-        "oauth-client-credentials-nested-root",
-        "trace",
-        "examples",
-        "imdb:custom-filename",
-        "object",
-        "basic-auth",
-        "imdb:no-custom-config",
-        "response-property",
-        "websocket-bearer-auth"
+        "mixed-case",
+        "mixed-file-directory",
+        "enum:custom-overrides",
+        "path-parameters",
+        "plain-text",
+        "imdb:override",
+        "pagination-custom",
+        "license",
+        "streaming"
       ],
-      "groupTotalTimeSeconds": 102
+      "groupTotalTimeSeconds": 103
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "extends",
+        "client-side-params",
+        "empty-clients",
+        "property-access",
+        "imdb:custom-overrides",
+        "query-parameters",
+        "required-nullable",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 103
+    },
+    {
+      "fixtures": [
+        "alias",
+        "file-download",
+        "examples",
+        "errors",
+        "public-object",
+        "imdb:custom-filename",
+        "request-parameters",
+        "server-sent-event-examples",
+        "unknown"
+      ],
+      "groupTotalTimeSeconds": 103
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "bytes-upload",
+        "cross-package-type-names",
+        "inferred-auth-explicit",
+        "http-head",
+        "websocket-bearer-auth",
+        "reserved-keywords",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 100
+    },
+    {
+      "fixtures": [
+        "api-wide-base-path",
+        "file-upload",
+        "enum:no-custom-config",
+        "oauth-client-credentials-custom",
+        "multiple-request-bodies",
+        "error-property",
+        "multi-url-environment-no-default",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 100
+    },
+    {
+      "fixtures": [
+        "auth-environment-variables",
+        "bytes-download",
+        "trace",
+        "folders",
+        "response-property",
+        "multi-line-docs",
+        "simple-fhir",
+        "undiscriminated-unions"
+      ],
+      "groupTotalTimeSeconds": 100
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "bytes-download",
-        "mixed-case",
-        "empty-clients",
-        "simple-api",
-        "basic-auth-environment-variables",
-        "imdb:override",
-        "server-sent-event-examples",
-        "error-property"
+        "content-type",
+        "circular-references",
+        "websocket-inferred-auth",
+        "websocket",
+        "multi-url-environment",
+        "single-url-environment-default",
+        "unions"
       ],
-      "groupTotalTimeSeconds": 101
+      "groupTotalTimeSeconds": 100
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/php-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/php-model-seed-groups.json
@@ -1,144 +1,144 @@
 {
-  "totalTestTimeSeconds": 4338,
+  "totalTestTimeSeconds": 4298,
   "groups": [
     {
       "fixtures": [
-        "alias-extends",
+        "query-parameters-openapi",
         "nullable-optional",
-        "error-property",
-        "circular-references-advanced",
-        "license",
-        "errors",
-        "websocket-bearer-auth",
-        "oauth-client-credentials-with-variables",
-        "mixed-file-directory"
+        "public-object",
+        "optional",
+        "oauth-client-credentials-nested-root",
+        "objects-with-imports",
+        "simple-fhir",
+        "single-url-environment-default",
+        "audiences"
       ],
-      "groupTotalTimeSeconds": 438
+      "groupTotalTimeSeconds": 431
     },
     {
       "fixtures": [
-        "query-parameters-openapi",
+        "version",
         "client-side-params",
-        "property-access",
-        "basic-auth",
-        "circular-references",
+        "oauth-client-credentials",
+        "object",
+        "oauth-client-credentials-default",
+        "multi-url-environment",
+        "server-sent-event-examples",
+        "simple-api",
+        "mixed-file-directory"
+      ],
+      "groupTotalTimeSeconds": 428
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "nullable",
+        "inferred-auth-explicit",
+        "inferred-auth-implicit",
+        "oauth-client-credentials-custom",
+        "http-head",
+        "oauth-client-credentials-environment-variables",
+        "oauth-client-credentials-with-variables",
+        "literal"
+      ],
+      "groupTotalTimeSeconds": 427
+    },
+    {
+      "fixtures": [
+        "bytes-download",
+        "unions",
+        "plain-text",
+        "path-parameters",
+        "package-yml",
+        "pagination-custom",
+        "streaming",
+        "multi-line-docs",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 431
+    },
+    {
+      "fixtures": [
+        "alias",
+        "api-wide-base-path",
+        "response-property",
+        "custom-auth",
         "streaming-parameter",
-        "request-parameters",
-        "multi-url-environment-no-default",
-        "enum"
+        "extra-properties",
+        "unknown",
+        "file-download",
+        "cross-package-type-names"
       ],
       "groupTotalTimeSeconds": 435
     },
     {
       "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "unions",
-        "object",
-        "undiscriminated-unions",
-        "extra-properties",
-        "unknown",
-        "simple-fhir",
+        "alias-extends",
+        "bearer-token-environment-variable",
+        "inferred-auth-implicit-no-expiry",
+        "basic-auth",
+        "reserved-keywords",
+        "request-parameters",
         "websocket",
-        "trace"
+        "pagination",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 435
+    },
+    {
+      "fixtures": [
+        "idempotency-headers",
+        "extends",
+        "circular-references",
+        "property-access",
+        "server-sent-events",
+        "required-nullable",
+        "multiple-request-bodies",
+        "no-environment",
+        "exhaustive"
       ],
       "groupTotalTimeSeconds": 434
     },
     {
       "fixtures": [
-        "version-no-default",
+        "auth-environment-variables",
+        "query-parameters-openapi-as-objects",
+        "empty-clients",
         "mixed-case",
-        "nullable",
-        "single-url-environment-default",
-        "streaming",
-        "custom-auth",
-        "oauth-client-credentials-default",
-        "variables",
-        "audiences"
-      ],
-      "groupTotalTimeSeconds": 433
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "extends",
-        "imdb",
-        "inferred-auth-implicit",
-        "oauth-client-credentials-environment-variables",
-        "inferred-auth-implicit-no-expiry",
-        "required-nullable",
-        "multi-url-environment",
-        "examples"
-      ],
-      "groupTotalTimeSeconds": 438
-    },
-    {
-      "fixtures": [
-        "alias",
-        "file-download",
-        "oauth-client-credentials",
-        "multi-line-docs",
-        "oauth-client-credentials-nested-root",
-        "path-parameters",
-        "reserved-keywords",
-        "pagination-custom",
+        "basic-auth-environment-variables",
+        "license",
+        "undiscriminated-unions",
+        "query-parameters",
         "folders"
       ],
-      "groupTotalTimeSeconds": 437
+      "groupTotalTimeSeconds": 434
     },
     {
       "fixtures": [
-        "version",
-        "file-upload",
-        "query-parameters",
-        "oauth-client-credentials-custom",
-        "objects-with-imports",
-        "server-sent-event-examples",
-        "response-property",
-        "literals-unions",
-        "literal"
-      ],
-      "groupTotalTimeSeconds": 438
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
-        "bytes-download",
-        "http-head",
-        "plain-text",
-        "package-yml",
-        "simple-api",
-        "server-sent-events",
-        "pagination",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 437
-    },
-    {
-      "fixtures": [
-        "auth-environment-variables",
         "bytes-upload",
-        "websocket-inferred-auth",
-        "public-object",
-        "single-url-environment-no-default",
-        "basic-auth-environment-variables",
-        "any-auth",
-        "optional",
-        "exhaustive"
+        "accept-header",
+        "circular-references-advanced",
+        "error-property",
+        "websocket-bearer-auth",
+        "literals-unions",
+        "validation",
+        "single-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 436
+      "groupTotalTimeSeconds": 408
     },
     {
       "fixtures": [
-        "bearer-token-environment-variable",
+        "file-upload",
         "content-type",
-        "idempotency-headers",
-        "empty-clients",
-        "multiple-request-bodies",
-        "inferred-auth-explicit",
-        "no-environment",
-        "validation"
+        "websocket-inferred-auth",
+        "imdb",
+        "any-auth",
+        "variables",
+        "errors",
+        "multi-url-environment-no-default",
+        "enum"
       ],
-      "groupTotalTimeSeconds": 412
+      "groupTotalTimeSeconds": 435
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/postman-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/postman-seed-groups.json
@@ -1,145 +1,145 @@
 {
-  "totalTestTimeSeconds": 1035,
+  "totalTestTimeSeconds": 1057,
   "groups": [
     {
       "fixtures": [
-        "query-parameters-openapi",
-        "pagination",
-        "oauth-client-credentials-nested-root",
-        "trace",
-        "literal",
+        "accept-header",
+        "file-upload",
+        "circular-references-advanced",
+        "http-head",
         "public-object",
-        "errors",
-        "server-sent-event-examples",
-        "websocket-inferred-auth",
-        "request-parameters",
-        "reserved-keywords"
+        "any-auth",
+        "error-property",
+        "websocket"
+      ],
+      "groupTotalTimeSeconds": 106
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "oauth-client-credentials-environment-variables",
+        "audiences",
+        "mixed-file-directory",
+        "trace",
+        "plain-text",
+        "inferred-auth-explicit",
+        "basic-auth",
+        "license",
+        "websocket-bearer-auth"
       ],
       "groupTotalTimeSeconds": 106
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "oauth-client-credentials",
-        "oauth-client-credentials-environment-variables",
-        "audiences",
-        "enum",
-        "multi-url-environment",
+        "oauth-client-credentials-nested-root",
+        "cross-package-type-names",
+        "nullable",
+        "examples",
+        "inferred-auth-implicit",
         "response-property",
-        "server-sent-events",
-        "basic-auth",
-        "inferred-auth-implicit-no-expiry"
+        "circular-references",
+        "multi-url-environment",
+        "basic-auth-environment-variables",
+        "server-sent-events"
       ],
-      "groupTotalTimeSeconds": 103
+      "groupTotalTimeSeconds": 108
     },
     {
       "fixtures": [
         "version",
-        "oauth-client-credentials-custom",
         "objects-with-imports",
-        "cross-package-type-names",
-        "examples",
-        "optional",
-        "unions",
-        "simple-api",
-        "circular-references",
-        "license"
+        "enum",
+        "nullable-optional",
+        "folders",
+        "multiple-request-bodies",
+        "streaming",
+        "client-side-params",
+        "package-yml",
+        "multi-line-docs"
       ],
-      "groupTotalTimeSeconds": 103
+      "groupTotalTimeSeconds": 105
     },
     {
       "fixtures": [
         "version-no-default",
-        "oauth-client-credentials-default",
-        "mixed-file-directory",
+        "pagination",
+        "literal",
         "oauth-client-credentials-with-variables",
-        "folders",
-        "property-access",
-        "any-auth",
-        "multi-line-docs",
+        "mixed-case",
+        "no-environment",
         "streaming-parameter",
-        "multi-url-environment-no-default"
-      ],
-      "groupTotalTimeSeconds": 103
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "bytes-upload",
-        "nullable",
-        "object",
-        "extra-properties",
-        "single-url-environment-default",
         "custom-auth",
-        "package-yml"
+        "query-parameters",
+        "request-parameters"
       ],
-      "groupTotalTimeSeconds": 103
+      "groupTotalTimeSeconds": 105
     },
     {
       "fixtures": [
         "alias",
-        "content-type",
-        "nullable-optional",
-        "plain-text",
-        "http-head",
-        "single-url-environment-no-default",
-        "inferred-auth-explicit",
-        "path-parameters"
+        "bytes-upload",
+        "exhaustive",
+        "oauth-client-credentials-custom",
+        "websocket-inferred-auth",
+        "empty-clients",
+        "single-url-environment-default",
+        "required-nullable"
       ],
-      "groupTotalTimeSeconds": 103
+      "groupTotalTimeSeconds": 105
     },
     {
       "fixtures": [
         "alias-extends",
-        "extends",
-        "client-side-params",
-        "simple-fhir",
-        "literals-unions",
-        "streaming",
-        "inferred-auth-implicit",
-        "unknown"
+        "content-type",
+        "oauth-client-credentials",
+        "oauth-client-credentials-default",
+        "errors",
+        "inferred-auth-implicit-no-expiry",
+        "single-url-environment-no-default",
+        "reserved-keywords"
       ],
-      "groupTotalTimeSeconds": 103
+      "groupTotalTimeSeconds": 105
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "file-download",
-        "imdb:no-custom-config",
-        "empty-clients",
-        "basic-auth-environment-variables",
-        "no-environment",
-        "undiscriminated-unions",
-        "websocket"
+        "extends",
+        "simple-fhir",
+        "object",
+        "idempotency-headers",
+        "literals-unions",
+        "unknown",
+        "server-sent-event-examples"
       ],
-      "groupTotalTimeSeconds": 103
+      "groupTotalTimeSeconds": 105
     },
     {
       "fixtures": [
         "auth-environment-variables",
-        "file-upload",
-        "mixed-case",
-        "idempotency-headers",
-        "circular-references-advanced",
+        "file-download",
+        "unions",
         "pagination-custom",
+        "imdb:no-custom-config",
+        "optional",
         "validation",
-        "websocket-bearer-auth"
+        "simple-api"
       ],
-      "groupTotalTimeSeconds": 103
+      "groupTotalTimeSeconds": 105
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
         "bytes-download",
-        "multiple-request-bodies",
+        "property-access",
+        "path-parameters",
         "imdb:collection-name",
-        "error-property",
-        "query-parameters",
+        "undiscriminated-unions",
         "variables",
-        "exhaustive",
-        "required-nullable"
+        "extra-properties",
+        "multi-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 105
+      "groupTotalTimeSeconds": 107
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/pydantic-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/pydantic-seed-groups.json
@@ -1,152 +1,152 @@
 {
-  "totalTestTimeSeconds": 4849,
+  "totalTestTimeSeconds": 4662,
   "groups": [
     {
       "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "oauth-client-credentials-environment-variables",
+        "query-parameters-openapi",
+        "client-side-params",
         "nullable-optional",
-        "oauth-client-credentials-custom",
-        "http-head",
+        "object",
         "undiscriminated-unions",
+        "circular-references:no-custom-config",
         "multi-url-environment",
-        "server-sent-event-examples",
-        "path-parameters",
-        "public-object"
+        "optional",
+        "oauth-client-credentials-custom",
+        "folders"
       ],
-      "groupTotalTimeSeconds": 499
+      "groupTotalTimeSeconds": 478
     },
     {
       "fixtures": [
-        "query-parameters-openapi",
-        "inferred-auth-explicit",
-        "inferred-auth-implicit-no-expiry",
+        "query-parameters-openapi-as-objects",
+        "http-head",
         "nullable",
+        "multi-line-docs",
         "simple-fhir:no-custom-config",
-        "circular-references:no-custom-config",
-        "streaming",
-        "websocket-bearer-auth",
-        "trace",
-        "audiences"
+        "websocket-inferred-auth",
+        "no-environment",
+        "pagination:no-custom-config",
+        "oauth-client-credentials-with-variables",
+        "pagination-custom"
       ],
-      "groupTotalTimeSeconds": 498
+      "groupTotalTimeSeconds": 478
+    },
+    {
+      "fixtures": [
+        "extends",
+        "file-download:no-custom-config",
+        "oauth-client-credentials",
+        "mixed-case",
+        "plain-text",
+        "license",
+        "streaming-parameter",
+        "literal",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 443
     },
     {
       "fixtures": [
         "accept-header",
-        "bearer-token-environment-variable",
-        "mixed-case",
-        "empty-clients",
+        "version-no-default",
+        "inferred-auth-implicit",
         "property-access",
-        "oauth-client-credentials-nested-root",
-        "single-url-environment-default",
-        "idempotency-headers",
-        "mixed-file-directory"
+        "request-parameters",
+        "oauth-client-credentials-environment-variables",
+        "websocket",
+        "mixed-file-directory",
+        "trace"
       ],
-      "groupTotalTimeSeconds": 460
+      "groupTotalTimeSeconds": 443
     },
     {
       "fixtures": [
         "alias",
-        "bytes-download",
-        "multi-line-docs",
-        "inferred-auth-implicit",
-        "server-sent-events",
-        "optional",
-        "single-url-environment-no-default",
+        "api-wide-base-path",
         "oauth-client-credentials-default",
-        "query-parameters"
+        "response-property",
+        "server-sent-events",
+        "required-nullable",
+        "circular-references:no-inheritance-for-extended-models",
+        "imdb",
+        "audiences",
+        "public-object"
       ],
-      "groupTotalTimeSeconds": 460
+      "groupTotalTimeSeconds": 478
     },
     {
       "fixtures": [
         "alias-extends:no-custom-config",
-        "bytes-upload",
-        "unions:no-custom-config",
-        "multiple-request-bodies",
-        "simple-api",
-        "required-nullable",
-        "websocket",
-        "oauth-client-credentials-with-variables",
-        "examples",
-        "enum"
+        "auth-environment-variables",
+        "basic-auth",
+        "simple-fhir:no-inheritance-for-extended-models",
+        "unknown",
+        "reserved-keywords",
+        "literals-unions",
+        "oauth-client-credentials-nested-root",
+        "validation",
+        "exhaustive:pydantic-v1"
       ],
-      "groupTotalTimeSeconds": 498
+      "groupTotalTimeSeconds": 473
     },
     {
       "fixtures": [
         "alias-extends:no-inheritance-for-extended-models",
-        "extends",
+        "bearer-token-environment-variable",
+        "basic-auth-environment-variables",
         "any-auth",
-        "object",
-        "simple-fhir:no-inheritance-for-extended-models",
-        "response-property",
-        "request-parameters",
-        "imdb",
-        "cross-package-type-names",
-        "folders"
+        "websocket-bearer-auth",
+        "streaming",
+        "multi-url-environment-no-default",
+        "objects-with-imports",
+        "variables",
+        "exhaustive:pydantic-v2"
       ],
-      "groupTotalTimeSeconds": 498
+      "groupTotalTimeSeconds": 472
+    },
+    {
+      "fixtures": [
+        "unions:no-custom-config",
+        "bytes-download",
+        "custom-auth",
+        "circular-references-advanced:no-inheritance-for-extended-models",
+        "circular-references-advanced:no-custom-config",
+        "file-upload",
+        "package-yml",
+        "pagination:no-inheritance-for-extended-models",
+        "cross-package-type-names",
+        "examples"
+      ],
+      "groupTotalTimeSeconds": 478
     },
     {
       "fixtures": [
         "unions:no-inheritance-for-extended-models",
-        "content-type",
-        "circular-references-advanced:no-custom-config",
-        "basic-auth",
-        "license",
-        "circular-references:no-inheritance-for-extended-models",
-        "multi-url-environment-no-default",
-        "objects-with-imports",
-        "pagination-custom",
+        "bytes-upload",
+        "error-property",
+        "extra-properties",
+        "empty-clients",
+        "idempotency-headers",
+        "server-sent-event-examples",
+        "simple-api",
+        "path-parameters",
         "file-download:no-inheritance-for-extended-models"
       ],
-      "groupTotalTimeSeconds": 496
+      "groupTotalTimeSeconds": 477
     },
     {
       "fixtures": [
         "version",
-        "file-download:no-custom-config",
-        "custom-auth",
-        "basic-auth-environment-variables",
-        "pagination:no-inheritance-for-extended-models",
-        "file-upload",
-        "package-yml",
-        "no-environment",
-        "literal",
-        "exhaustive:pydantic-v2"
-      ],
-      "groupTotalTimeSeconds": 491
-    },
-    {
-      "fixtures": [
-        "version-no-default",
-        "client-side-params",
+        "content-type",
         "errors",
-        "extra-properties",
-        "oauth-client-credentials",
-        "streaming-parameter",
-        "unknown",
-        "websocket-inferred-auth",
-        "validation",
-        "exhaustive:pydantic-v1"
+        "inferred-auth-implicit-no-expiry",
+        "multiple-request-bodies",
+        "inferred-auth-explicit",
+        "single-url-environment-default",
+        "enum",
+        "query-parameters"
       ],
-      "groupTotalTimeSeconds": 490
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
-        "auth-environment-variables",
-        "error-property",
-        "circular-references-advanced:no-inheritance-for-extended-models",
-        "plain-text",
-        "literals-unions",
-        "reserved-keywords",
-        "pagination:no-custom-config",
-        "variables"
-      ],
-      "groupTotalTimeSeconds": 459
+      "groupTotalTimeSeconds": 442
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ruby-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-model-seed-groups.json
@@ -1,145 +1,145 @@
 {
-  "totalTestTimeSeconds": 2181,
+  "totalTestTimeSeconds": 2219,
   "groups": [
     {
       "fixtures": [
         "nullable-optional",
-        "objects-with-imports",
-        "oauth-client-credentials-with-variables",
-        "literal",
-        "examples",
-        "property-access",
-        "validation",
-        "mixed-case",
-        "public-object"
-      ],
-      "groupTotalTimeSeconds": 220
-    },
-    {
-      "fixtures": [
-        "unions",
-        "oauth-client-credentials",
-        "errors",
-        "custom-auth",
         "websocket-inferred-auth",
-        "path-parameters",
-        "empty-clients",
-        "basic-auth",
-        "idempotency-headers"
+        "undiscriminated-unions",
+        "examples",
+        "plain-text",
+        "extra-properties",
+        "nullable",
+        "audiences",
+        "exhaustive"
       ],
-      "groupTotalTimeSeconds": 219
+      "groupTotalTimeSeconds": 223
     },
     {
       "fixtures": [
         "client-side-params",
-        "alias",
-        "file-download",
-        "undiscriminated-unions",
-        "cross-package-type-names",
-        "folders",
-        "required-nullable",
-        "inferred-auth-explicit",
+        "bytes-download",
+        "objects-with-imports",
+        "errors",
+        "request-parameters",
+        "validation",
+        "multi-url-environment",
+        "enum",
         "imdb"
       ],
-      "groupTotalTimeSeconds": 219
+      "groupTotalTimeSeconds": 223
     },
     {
       "fixtures": [
-        "alias-extends",
-        "oauth-client-credentials-nested-root",
-        "bytes-upload",
         "circular-references-advanced",
-        "multi-line-docs",
-        "websocket",
-        "server-sent-events",
-        "inferred-auth-implicit",
-        "circular-references"
-      ],
-      "groupTotalTimeSeconds": 218
-    },
-    {
-      "fixtures": [
-        "file-upload",
-        "version",
-        "content-type",
-        "error-property",
-        "ruby-reserved-word-properties",
-        "pagination-custom",
-        "any-auth",
-        "plain-text",
-        "http-head"
-      ],
-      "groupTotalTimeSeconds": 218
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi",
-        "version-no-default",
-        "pagination",
-        "extra-properties",
-        "audiences",
-        "package-yml",
-        "reserved-keywords",
-        "simple-api",
-        "license"
-      ],
-      "groupTotalTimeSeconds": 218
-    },
-    {
-      "fixtures": [
-        "query-parameters-openapi-as-objects",
-        "accept-header",
-        "api-wide-base-path",
-        "enum",
-        "basic-auth-environment-variables",
-        "query-parameters",
-        "server-sent-event-examples",
-        "unknown",
-        "no-environment"
-      ],
-      "groupTotalTimeSeconds": 217
-    },
-    {
-      "fixtures": [
-        "extends",
-        "nullable",
         "auth-environment-variables",
-        "mixed-file-directory",
-        "multi-url-environment",
-        "streaming",
+        "response-property",
         "streaming-parameter",
-        "variables",
-        "exhaustive"
+        "unknown",
+        "basic-auth",
+        "oauth-client-credentials",
+        "folders",
+        "mixed-case"
       ],
-      "groupTotalTimeSeconds": 214
+      "groupTotalTimeSeconds": 223
+    },
+    {
+      "fixtures": [
+        "unions",
+        "bearer-token-environment-variable",
+        "oauth-client-credentials-environment-variables",
+        "object",
+        "streaming",
+        "basic-auth-environment-variables",
+        "package-yml",
+        "literal",
+        "single-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 223
     },
     {
       "fixtures": [
         "simple-fhir",
-        "oauth-client-credentials-default",
-        "bearer-token-environment-variable",
-        "object",
-        "request-parameters",
-        "multi-url-environment-no-default",
-        "single-url-environment-default",
-        "inferred-auth-implicit-no-expiry",
+        "api-wide-base-path",
+        "file-download",
+        "pagination",
+        "ruby-reserved-word-properties",
+        "query-parameters",
+        "required-nullable",
+        "mixed-file-directory",
         "literals-unions"
       ],
-      "groupTotalTimeSeconds": 219
+      "groupTotalTimeSeconds": 222
+    },
+    {
+      "fixtures": [
+        "file-upload",
+        "alias-extends",
+        "empty-clients",
+        "websocket",
+        "optional",
+        "reserved-keywords",
+        "custom-auth",
+        "oauth-client-credentials-default",
+        "license"
+      ],
+      "groupTotalTimeSeconds": 221
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "extends",
+        "oauth-client-credentials-nested-root",
+        "websocket-bearer-auth",
+        "pagination-custom",
+        "server-sent-event-examples",
+        "inferred-auth-explicit",
+        "variables",
+        "no-environment"
+      ],
+      "groupTotalTimeSeconds": 221
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "version",
+        "oauth-client-credentials-custom",
+        "property-access",
+        "single-url-environment-default",
+        "server-sent-events",
+        "inferred-auth-implicit",
+        "cross-package-type-names",
+        "circular-references"
+      ],
+      "groupTotalTimeSeconds": 221
     },
     {
       "fixtures": [
         "trace",
-        "oauth-client-credentials-environment-variables",
-        "bytes-download",
-        "response-property",
-        "websocket-bearer-auth",
-        "oauth-client-credentials-custom",
-        "single-url-environment-no-default",
-        "optional",
-        "multiple-request-bodies"
+        "alias",
+        "content-type",
+        "path-parameters",
+        "any-auth",
+        "public-object",
+        "multi-line-docs",
+        "multi-url-environment-no-default",
+        "http-head"
       ],
-      "groupTotalTimeSeconds": 219
+      "groupTotalTimeSeconds": 221
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "accept-header",
+        "bytes-upload",
+        "multiple-request-bodies",
+        "error-property",
+        "simple-api",
+        "inferred-auth-implicit-no-expiry",
+        "oauth-client-credentials-with-variables",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 221
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ruby-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ruby-sdk-seed-groups.json
@@ -1,140 +1,140 @@
 {
-  "totalTestTimeSeconds": 1132,
+  "totalTestTimeSeconds": 1115,
   "groups": [
     {
       "fixtures": [
-        "accept-header",
-        "file-upload",
-        "basic-auth",
-        "error-property",
-        "multi-url-environment",
-        "reserved-keywords",
-        "idempotency-headers"
+        "alias",
+        "extends",
+        "unions",
+        "circular-references-advanced",
+        "inferred-auth-implicit-no-expiry",
+        "server-sent-event-examples"
       ],
-      "groupTotalTimeSeconds": 115
+      "groupTotalTimeSeconds": 111
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "file-download",
+        "unknown",
+        "custom-auth",
+        "multi-url-environment-no-default",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 111
+    },
+    {
+      "fixtures": ["api-wide-base-path", "file-upload", "validation", "empty-clients", "object", "simple-api"],
+      "groupTotalTimeSeconds": 111
     },
     {
       "fixtures": [
         "query-parameters-openapi",
         "pagination",
         "oauth-client-credentials",
-        "simple-fhir",
-        "errors",
-        "inferred-auth-explicit",
-        "multiple-request-bodies",
-        "object",
-        "query-parameters",
+        "any-auth",
+        "enum",
+        "exhaustive:flattened-module-structure",
+        "mixed-file-directory",
+        "oauth-client-credentials-default",
+        "optional",
+        "streaming",
         "basic-auth-environment-variables",
-        "exhaustive:extra-deps",
-        "multi-url-environment-no-default",
-        "ruby-reserved-word-properties",
-        "server-sent-events"
+        "imdb",
+        "property-access",
+        "request-parameters"
       ],
-      "groupTotalTimeSeconds": 115
+      "groupTotalTimeSeconds": 113
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "unions",
-        "oauth-client-credentials-custom",
-        "audiences",
+        "examples",
+        "trace",
+        "undiscriminated-unions",
+        "errors",
+        "folders",
+        "multi-line-docs",
+        "oauth-client-credentials-environment-variables",
+        "query-parameters",
+        "streaming-parameter",
         "circular-references",
-        "exhaustive:no-custom-config",
-        "inferred-auth-implicit-no-expiry",
-        "no-environment",
-        "objects-with-imports",
-        "response-property",
-        "extra-properties",
-        "oauth-client-credentials-default",
-        "server-sent-event-examples",
-        "variables"
+        "inferred-auth-explicit",
+        "public-object",
+        "required-nullable"
       ],
-      "groupTotalTimeSeconds": 115
+      "groupTotalTimeSeconds": 113
     },
     {
       "fixtures": [
         "version",
+        "nullable-optional",
         "client-side-params",
-        "examples",
-        "oauth-client-credentials-environment-variables",
-        "circular-references-advanced",
-        "exhaustive:flattened-module-structure",
+        "oauth-client-credentials-custom",
+        "basic-auth",
+        "exhaustive:no-custom-config",
         "literal",
-        "nullable",
-        "property-access",
-        "undiscriminated-unions",
-        "folders",
-        "optional",
-        "simple-api"
+        "multi-url-environment",
+        "oauth-client-credentials-with-variables",
+        "ruby-reserved-word-properties",
+        "websocket-inferred-auth",
+        "inferred-auth-implicit",
+        "response-property",
+        "reserved-keywords"
       ],
-      "groupTotalTimeSeconds": 112
+      "groupTotalTimeSeconds": 113
     },
     {
       "fixtures": [
         "version-no-default",
-        "trace",
-        "nullable-optional",
+        "simple-fhir",
+        "nullable",
         "oauth-client-credentials-nested-root",
-        "empty-clients",
-        "imdb",
+        "cross-package-type-names",
+        "exhaustive:extra-deps",
         "mixed-case",
-        "oauth-client-credentials-with-variables",
-        "public-object",
-        "unknown",
-        "http-head",
-        "package-yml",
-        "single-url-environment-default"
+        "multiple-request-bodies",
+        "objects-with-imports",
+        "single-url-environment-default",
+        "audiences",
+        "idempotency-headers",
+        "plain-text",
+        "no-environment"
       ],
       "groupTotalTimeSeconds": 112
     },
     {
       "fixtures": [
-        "alias",
+        "accept-header",
         "bytes-download",
-        "cross-package-type-names",
-        "inferred-auth-implicit",
-        "pagination-custom",
+        "variables",
+        "error-property",
+        "package-yml",
         "single-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 112
-    },
-    {
-      "fixtures": ["alias-extends", "bytes-upload", "custom-auth", "license", "path-parameters", "streaming"],
-      "groupTotalTimeSeconds": 112
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
-        "content-type",
-        "validation",
-        "literals-unions",
-        "plain-text",
-        "streaming-parameter"
-      ],
-      "groupTotalTimeSeconds": 112
+      "groupTotalTimeSeconds": 111
     },
     {
       "fixtures": [
         "auth-environment-variables",
-        "extends",
-        "websocket-inferred-auth",
-        "mixed-file-directory",
-        "request-parameters",
-        "websocket"
+        "bytes-upload",
+        "websocket",
+        "extra-properties",
+        "pagination-custom",
+        "license"
       ],
-      "groupTotalTimeSeconds": 112
+      "groupTotalTimeSeconds": 110
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "file-download",
-        "any-auth",
-        "enum",
-        "multi-line-docs",
-        "required-nullable",
-        "websocket-bearer-auth"
+        "content-type",
+        "websocket-bearer-auth",
+        "http-head",
+        "path-parameters",
+        "literals-unions"
       ],
-      "groupTotalTimeSeconds": 115
+      "groupTotalTimeSeconds": 110
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/rust-model-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/rust-model-seed-groups.json
@@ -1,144 +1,144 @@
 {
-  "totalTestTimeSeconds": 737,
+  "totalTestTimeSeconds": 728,
   "groups": [
-    {
-      "fixtures": [
-        "query-parameters-openapi",
-        "unions",
-        "oauth-client-credentials",
-        "query-parameters",
-        "request-parameters",
-        "inferred-auth-explicit",
-        "path-parameters",
-        "error-property",
-        "required-nullable",
-        "idempotency-headers"
-      ],
-      "groupTotalTimeSeconds": 75
-    },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
         "circular-references-advanced",
-        "mixed-case",
-        "oauth-client-credentials-environment-variables",
-        "pagination",
-        "basic-auth-environment-variables",
-        "no-environment",
+        "nullable",
+        "oauth-client-credentials-nested-root",
+        "undiscriminated-unions",
+        "object",
         "trace",
-        "multi-url-environment",
-        "variables"
+        "folders",
+        "oauth-client-credentials-with-variables",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 73
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "nullable-optional",
+        "oauth-client-credentials-default",
+        "websocket-inferred-auth",
+        "basic-auth-environment-variables",
+        "path-parameters",
+        "websocket",
+        "inferred-auth-implicit-no-expiry",
+        "required-nullable",
+        "pagination-custom"
       ],
       "groupTotalTimeSeconds": 74
     },
     {
       "fixtures": [
         "version",
-        "client-side-params",
-        "nullable",
-        "property-access",
-        "plain-text",
-        "custom-auth",
-        "oauth-client-credentials-with-variables",
-        "unknown",
-        "multi-url-environment-no-default",
-        "cross-package-type-names",
-        "exhaustive"
-      ],
-      "groupTotalTimeSeconds": 75
-    },
-    {
-      "fixtures": [
-        "accept-header",
-        "file-upload",
-        "public-object",
-        "empty-clients",
-        "object",
-        "websocket",
-        "multiple-request-bodies",
-        "folders"
-      ],
-      "groupTotalTimeSeconds": 73
-    },
-    {
-      "fixtures": [
-        "alias-extends",
-        "file-download",
-        "websocket-bearer-auth",
-        "extra-properties",
+        "unions",
+        "oauth-client-credentials-environment-variables",
+        "circular-references",
+        "basic-auth",
         "optional",
-        "websocket-inferred-auth",
-        "oauth-client-credentials-default",
-        "http-head"
+        "validation",
+        "imdb",
+        "package-yml",
+        "license"
       ],
       "groupTotalTimeSeconds": 73
     },
     {
       "fixtures": [
         "version-no-default",
-        "nullable-optional",
-        "oauth-client-credentials-custom",
-        "simple-fhir",
-        "reserved-keywords",
-        "inferred-auth-implicit",
+        "client-side-params",
+        "oauth-client-credentials",
         "response-property",
-        "examples",
-        "server-sent-event-examples",
-        "imdb"
+        "any-auth",
+        "mixed-case",
+        "single-url-environment-no-default",
+        "error-property",
+        "multi-url-environment-no-default",
+        "variables"
       ],
-      "groupTotalTimeSeconds": 75
+      "groupTotalTimeSeconds": 73
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "extends",
+        "query-parameters",
+        "multi-url-environment",
+        "streaming",
+        "examples",
+        "no-environment",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 73
     },
     {
       "fixtures": [
         "alias",
-        "bytes-download",
-        "circular-references",
-        "undiscriminated-unions",
-        "package-yml",
-        "audiences",
-        "license",
-        "single-url-environment-default"
+        "file-upload",
+        "simple-fhir",
+        "multiple-request-bodies",
+        "streaming-parameter",
+        "extra-properties",
+        "oauth-client-credentials-custom",
+        "http-head",
+        "exhaustive"
       ],
-      "groupTotalTimeSeconds": 73
+      "groupTotalTimeSeconds": 74
+    },
+    {
+      "fixtures": [
+        "alias-extends",
+        "file-download",
+        "objects-with-imports",
+        "empty-clients",
+        "plain-text",
+        "audiences",
+        "literal",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 72
     },
     {
       "fixtures": [
         "api-wide-base-path",
-        "bytes-upload",
+        "bytes-download",
+        "pagination",
         "errors",
-        "validation",
-        "pagination-custom",
-        "enum",
-        "literal",
-        "single-url-environment-no-default"
+        "request-parameters",
+        "cross-package-type-names",
+        "literals-unions",
+        "simple-api"
       ],
-      "groupTotalTimeSeconds": 73
+      "groupTotalTimeSeconds": 72
     },
     {
       "fixtures": [
         "auth-environment-variables",
-        "content-type",
-        "oauth-client-credentials-nested-root",
-        "any-auth",
-        "inferred-auth-implicit-no-expiry",
-        "server-sent-events",
-        "literals-unions",
-        "streaming"
+        "bytes-upload",
+        "property-access",
+        "inferred-auth-explicit",
+        "reserved-keywords",
+        "custom-auth",
+        "mixed-file-directory",
+        "single-url-environment-default"
       ],
-      "groupTotalTimeSeconds": 73
+      "groupTotalTimeSeconds": 72
     },
     {
       "fixtures": [
         "bearer-token-environment-variable",
-        "extends",
-        "objects-with-imports",
-        "basic-auth",
-        "mixed-file-directory",
-        "simple-api",
+        "content-type",
+        "public-object",
+        "inferred-auth-implicit",
+        "server-sent-event-examples",
+        "enum",
         "multi-line-docs",
-        "streaming-parameter"
+        "unknown"
       ],
-      "groupTotalTimeSeconds": 73
+      "groupTotalTimeSeconds": 72
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/rust-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/rust-sdk-seed-groups.json
@@ -1,148 +1,148 @@
 {
-  "totalTestTimeSeconds": 3208,
+  "totalTestTimeSeconds": 3254,
   "groups": [
     {
       "fixtures": [
-        "client-side-params",
-        "bearer-token-environment-variable",
-        "response-property",
-        "property-access",
-        "multi-url-environment-no-default",
-        "exhaustive",
+        "trace",
+        "mixed-case",
+        "request-parameters",
         "streaming",
-        "plain-text",
-        "circular-references-advanced"
+        "inferred-auth-implicit-no-expiry",
+        "multi-url-environment",
+        "single-url-environment-default:basic",
+        "object",
+        "public-object"
       ],
-      "groupTotalTimeSeconds": 317
+      "groupTotalTimeSeconds": 322
+    },
+    {
+      "fixtures": [
+        "client-side-params",
+        "extends",
+        "bytes-download",
+        "oauth-client-credentials-with-variables",
+        "query-parameters",
+        "variables",
+        "imdb:imdb-custom-config",
+        "websocket-inferred-auth",
+        "websocket",
+        "literals-unions"
+      ],
+      "groupTotalTimeSeconds": 321
     },
     {
       "fixtures": [
         "errors",
-        "accept-header",
-        "nullable",
-        "oauth-client-credentials-with-variables",
-        "bytes-download",
-        "required-nullable",
-        "streaming-parameter",
-        "folders",
-        "circular-references"
-      ],
-      "groupTotalTimeSeconds": 316
-    },
-    {
-      "fixtures": [
-        "nullable-optional",
-        "version-no-default",
-        "unions",
-        "basic-auth-environment-variables",
+        "pagination",
+        "oauth-client-credentials-custom",
+        "multiple-request-bodies",
         "any-auth",
+        "literal",
         "pagination-custom",
-        "simple-fhir",
-        "audiences",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 330
-    },
-    {
-      "fixtures": [
-        "examples:no-custom-config",
-        "undiscriminated-unions",
-        "mixed-case",
-        "request-parameters",
-        "query-parameters",
-        "optional",
-        "multi-url-environment",
-        "idempotency-headers",
+        "server-sent-event-examples",
         "http-head"
       ],
       "groupTotalTimeSeconds": 319
     },
     {
       "fixtures": [
-        "oauth-client-credentials",
-        "version",
-        "path-parameters",
+        "undiscriminated-unions",
+        "bytes-upload",
+        "nullable",
         "basic-auth",
-        "mixed-file-directory",
-        "license",
+        "optional",
+        "idempotency-headers",
         "reserved-keywords",
-        "server-sent-event-examples",
-        "object",
+        "simple-api",
+        "empty-clients",
         "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 321
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "auth-environment-variables",
+        "oauth-client-credentials",
+        "inferred-auth-implicit",
+        "unknown",
+        "multi-line-docs",
+        "simple-fhir",
+        "audiences",
+        "no-environment"
+      ],
+      "groupTotalTimeSeconds": 334
+    },
+    {
+      "fixtures": [
+        "nullable-optional",
+        "bearer-token-environment-variable",
+        "response-property",
+        "custom-auth",
+        "package-yml",
+        "mixed-file-directory",
+        "single-url-environment-default:full-custom",
+        "examples:no-custom-config",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 334
+    },
+    {
+      "fixtures": [
+        "accept-header",
+        "api-wide-base-path",
+        "unions",
+        "oauth-client-credentials-nested-root",
+        "imdb",
+        "single-url-environment-no-default",
+        "validation",
+        "examples:readme-config",
+        "license"
+      ],
+      "groupTotalTimeSeconds": 331
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi",
+        "version-no-default",
+        "path-parameters",
+        "basic-auth-environment-variables",
+        "property-access",
+        "inferred-auth-explicit",
+        "single-url-environment-default:custom-environment",
+        "cross-package-type-names",
+        "folders"
+      ],
+      "groupTotalTimeSeconds": 333
+    },
+    {
+      "fixtures": [
+        "query-parameters-openapi-as-objects",
+        "alias",
+        "file-download",
+        "oauth-client-credentials-default",
+        "required-nullable",
+        "error-property",
+        "exhaustive",
+        "multi-url-environment-no-default",
+        "objects-with-imports"
       ],
       "groupTotalTimeSeconds": 318
     },
     {
       "fixtures": [
-        "pagination",
-        "query-parameters-openapi-as-objects",
-        "inferred-auth-implicit",
-        "package-yml",
-        "multiple-request-bodies",
-        "trace",
-        "variables",
-        "single-url-environment-default:full-custom",
-        "public-object"
-      ],
-      "groupTotalTimeSeconds": 314
-    },
-    {
-      "fixtures": [
-        "content-type",
-        "query-parameters-openapi",
-        "file-upload",
-        "oauth-client-credentials-nested-root",
-        "inferred-auth-implicit-no-expiry",
-        "validation",
-        "extra-properties",
-        "single-url-environment-no-default",
-        "objects-with-imports",
-        "empty-clients"
-      ],
-      "groupTotalTimeSeconds": 317
-    },
-    {
-      "fixtures": [
-        "alias",
-        "auth-environment-variables",
-        "bytes-upload",
-        "oauth-client-credentials-default",
-        "inferred-auth-explicit",
-        "unknown",
-        "literal",
-        "examples:readme-config",
-        "websocket",
-        "literals-unions"
-      ],
-      "groupTotalTimeSeconds": 317
-    },
-    {
-      "fixtures": [
+        "version",
         "alias-extends",
-        "oauth-client-credentials-custom",
-        "extends",
-        "custom-auth",
-        "no-environment",
-        "enum",
-        "imdb:imdb-custom-config",
-        "simple-api",
-        "server-sent-events"
-      ],
-      "groupTotalTimeSeconds": 330
-    },
-    {
-      "fixtures": [
-        "api-wide-base-path",
+        "file-upload",
         "oauth-client-credentials-environment-variables",
-        "file-download",
-        "imdb",
-        "multi-line-docs",
-        "error-property",
-        "websocket-inferred-auth",
-        "single-url-environment-default:basic",
-        "single-url-environment-default:custom-environment"
+        "enum",
+        "streaming-parameter",
+        "extra-properties",
+        "plain-text",
+        "circular-references-advanced",
+        "circular-references"
       ],
-      "groupTotalTimeSeconds": 330
+      "groupTotalTimeSeconds": 321
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/swift-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/swift-sdk-seed-groups.json
@@ -1,149 +1,149 @@
 {
-  "totalTestTimeSeconds": 5217,
+  "totalTestTimeSeconds": 5412,
   "groups": [
     {
       "fixtures": [
         "client-side-params:no-custom-config",
-        "oauth-client-credentials",
-        "websocket-inferred-auth",
-        "oauth-client-credentials-default",
-        "multiple-request-bodies",
-        "http-head",
-        "validation",
-        "folders",
-        "enum",
-        "cross-package-type-names"
-      ],
-      "groupTotalTimeSeconds": 536
-    },
-    {
-      "fixtures": [
-        "content-type",
-        "bytes-download",
-        "auth-environment-variables",
-        "basic-auth",
+        "bytes-upload",
+        "mixed-case",
+        "pagination-custom",
         "error-property",
-        "query-parameters-openapi",
-        "websocket",
-        "public-object",
-        "reserved-keywords"
+        "multi-url-environment-no-default",
+        "server-sent-events",
+        "unions",
+        "nullable-optional"
       ],
-      "groupTotalTimeSeconds": 513
-    },
-    {
-      "fixtures": [
-        "file-upload",
-        "api-wide-base-path",
-        "response-property",
-        "extra-properties",
-        "simple-api",
-        "unknown",
-        "single-url-environment-default:no-custom-config",
-        "literals-unions",
-        "mixed-file-directory"
-      ],
-      "groupTotalTimeSeconds": 513
+      "groupTotalTimeSeconds": 532
     },
     {
       "fixtures": [
         "client-side-params:with-custom-config",
-        "file-download",
-        "oauth-client-credentials-custom",
-        "imdb",
-        "streaming",
-        "empty-clients",
-        "server-sent-events",
-        "unions",
-        "trace"
+        "auth-environment-variables",
+        "inferred-auth-implicit-no-expiry",
+        "any-auth",
+        "multiple-request-bodies",
+        "query-parameters-openapi-as-objects",
+        "single-url-environment-no-default",
+        "variables",
+        "cross-package-type-names"
       ],
-      "groupTotalTimeSeconds": 513
+      "groupTotalTimeSeconds": 532
     },
     {
       "fixtures": [
-        "version",
-        "bytes-upload",
+        "file-upload",
+        "file-download",
         "oauth-client-credentials-environment-variables",
-        "mixed-case",
+        "basic-auth-environment-variables",
         "idempotency-headers",
-        "query-parameters-openapi-as-objects",
-        "object",
-        "variables",
+        "license",
+        "streaming",
+        "literals-unions",
+        "reserved-keywords"
+      ],
+      "groupTotalTimeSeconds": 532
+    },
+    {
+      "fixtures": [
+        "content-type",
+        "websocket-inferred-auth",
+        "nullable",
+        "multi-line-docs",
+        "empty-clients",
+        "path-parameters",
+        "streaming-parameter",
+        "plain-text",
         "simple-fhir"
       ],
-      "groupTotalTimeSeconds": 513
+      "groupTotalTimeSeconds": 532
     },
     {
       "fixtures": [
         "alias-extends",
-        "accept-header",
-        "oauth-client-credentials-nested-root",
-        "any-auth",
-        "basic-auth-environment-variables",
-        "multi-url-environment",
-        "streaming-parameter",
+        "alias",
+        "inferred-auth-implicit",
+        "extra-properties",
+        "objects-with-imports",
+        "no-environment",
+        "validation",
         "circular-references-advanced",
         "exhaustive",
-        "property-access"
+        "examples:readme-config"
       ],
-      "groupTotalTimeSeconds": 535
+      "groupTotalTimeSeconds": 555
     },
     {
       "fixtures": [
         "pagination:no-custom-config",
-        "bearer-token-environment-variable",
-        "inferred-auth-explicit",
-        "inferred-auth-implicit-no-expiry",
-        "path-parameters",
-        "pagination-custom",
-        "websocket-bearer-auth",
-        "circular-references",
-        "literal",
-        "examples:readme-config"
-      ],
-      "groupTotalTimeSeconds": 533
-    },
-    {
-      "fixtures": [
-        "extends",
-        "alias",
-        "custom-auth",
-        "package-yml",
-        "license",
-        "server-sent-event-examples",
+        "accept-header",
+        "api-wide-base-path",
+        "basic-auth",
+        "multi-url-environment",
+        "simple-api",
         "single-url-environment-default:with-custom-config",
-        "plain-text",
-        "nullable-optional"
+        "single-url-environment-default:no-custom-config",
+        "audiences",
+        "property-access"
       ],
-      "groupTotalTimeSeconds": 513
-    },
-    {
-      "fixtures": [
-        "pagination:custom-pager-with-exception-handler",
-        "errors",
-        "nullable",
-        "objects-with-imports",
-        "multi-url-environment-no-default",
-        "oauth-client-credentials-with-variables",
-        "optional",
-        "no-environment",
-        "query-parameters"
-      ],
-      "groupTotalTimeSeconds": 514
+      "groupTotalTimeSeconds": 556
     },
     {
       "fixtures": [
         "pagination:custom-pager",
-        "version-no-default",
-        "inferred-auth-implicit",
-        "multi-line-docs",
+        "bearer-token-environment-variable",
+        "oauth-client-credentials",
         "undiscriminated-unions",
+        "server-sent-event-examples",
+        "package-yml",
+        "websocket",
+        "circular-references",
+        "enum",
+        "mixed-file-directory"
+      ],
+      "groupTotalTimeSeconds": 556
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "response-property",
+        "oauth-client-credentials-custom",
+        "custom-auth",
         "required-nullable",
-        "request-parameters",
-        "single-url-environment-no-default",
-        "audiences",
+        "oauth-client-credentials-default",
+        "websocket-bearer-auth",
+        "folders",
+        "literal",
         "examples:no-custom-config"
       ],
-      "groupTotalTimeSeconds": 534
+      "groupTotalTimeSeconds": 553
+    },
+    {
+      "fixtures": [
+        "errors",
+        "pagination:custom-pager-with-exception-handler",
+        "oauth-client-credentials-nested-root",
+        "imdb",
+        "oauth-client-credentials-with-variables",
+        "object",
+        "query-parameters-openapi",
+        "optional",
+        "query-parameters"
+      ],
+      "groupTotalTimeSeconds": 532
+    },
+    {
+      "fixtures": [
+        "extends",
+        "version",
+        "bytes-download",
+        "inferred-auth-explicit",
+        "unknown",
+        "http-head",
+        "request-parameters",
+        "public-object",
+        "trace"
+      ],
+      "groupTotalTimeSeconds": 532
     }
   ]
 }

--- a/.github/workflow-resource-files/seed-groups/ts-express-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/ts-express-seed-groups.json
@@ -1,158 +1,158 @@
 {
-  "totalTestTimeSeconds": 5830,
+  "totalTestTimeSeconds": 5965,
   "groups": [
     {
       "fixtures": [
         "trace:no-custom-config",
-        "pagination",
-        "extra-properties",
-        "query-parameters",
-        "oauth-client-credentials-with-variables",
-        "error-property",
-        "websocket-inferred-auth",
+        "api-wide-base-path",
+        "oauth-client-credentials-custom",
+        "request-parameters",
+        "enum",
+        "websocket",
+        "path-parameters",
         "bytes-download",
-        "imdb:no-custom-config"
+        "simple-fhir"
       ],
-      "groupTotalTimeSeconds": 586
+      "groupTotalTimeSeconds": 598
     },
     {
       "fixtures": [
         "trace:no-zurg-trace",
-        "exhaustive:no-optional-properties",
-        "api-wide-base-path",
-        "mixed-file-directory",
-        "audiences",
-        "enum",
-        "inferred-auth-implicit",
-        "exhaustive:retain-original-casing",
-        "ts-express-casing:no-serde-layer",
-        "file-upload",
-        "streaming"
-      ],
-      "groupTotalTimeSeconds": 583
-    },
-    {
-      "fixtures": [
-        "nullable-optional",
-        "bearer-token-environment-variable",
-        "imdb:skip-request-validation",
-        "oauth-client-credentials",
-        "websocket",
-        "errors",
-        "pagination-custom",
-        "ts-express-casing:no-custom-config",
-        "exhaustive:allow-extra-fields",
-        "imdb:validation-status-code"
-      ],
-      "groupTotalTimeSeconds": 586
-    },
-    {
-      "fixtures": [
-        "unions",
-        "property-access",
-        "mixed-case:no-custom-config",
-        "oauth-client-credentials-custom",
-        "any-auth",
-        "package-yml",
+        "accept-header",
+        "literals-unions",
+        "query-parameters",
         "websocket-bearer-auth",
         "unknown",
-        "file-download",
-        "public-object",
-        "server-sent-events"
+        "pagination-custom",
+        "websocket-inferred-auth",
+        "http-head",
+        "public-object"
       ],
-      "groupTotalTimeSeconds": 577
-    },
-    {
-      "fixtures": [
-        "nullable",
-        "version-no-default",
-        "accept-header",
-        "license",
-        "request-parameters",
-        "required-nullable",
-        "circular-references-advanced",
-        "examples",
-        "variables",
-        "simple-api"
-      ],
-      "groupTotalTimeSeconds": 585
+      "groupTotalTimeSeconds": 592
     },
     {
       "fixtures": [
         "content-type",
+        "pagination",
         "client-side-params",
-        "no-environment",
         "oauth-client-credentials-environment-variables",
-        "multi-url-environment",
-        "ts-inline-types",
-        "cross-package-type-names",
-        "undiscriminated-unions",
-        "imdb:skip-response-validation",
-        "single-url-environment-default"
-      ],
-      "groupTotalTimeSeconds": 587
-    },
-    {
-      "fixtures": [
-        "idempotency-headers",
-        "version",
-        "multi-line-docs",
-        "literals-unions",
-        "basic-auth",
-        "custom-auth",
-        "validation",
-        "exhaustive:no-custom-config",
-        "bytes-upload",
-        "plain-text",
-        "server-sent-event-examples"
-      ],
-      "groupTotalTimeSeconds": 577
-    },
-    {
-      "fixtures": [
-        "extends",
-        "auth-environment-variables",
-        "object",
-        "oauth-client-credentials-nested-root",
-        "basic-auth-environment-variables",
-        "inferred-auth-implicit-no-expiry",
-        "multi-url-environment-no-default",
-        "empty-clients",
-        "exhaustive:test-package-path",
+        "literal",
+        "license",
+        "simple-api",
+        "file-upload",
+        "imdb:skip-request-validation",
         "single-url-environment-no-default"
       ],
-      "groupTotalTimeSeconds": 587
+      "groupTotalTimeSeconds": 599
+    },
+    {
+      "fixtures": [
+        "nullable-optional",
+        "mixed-case:retain-original-casing",
+        "exhaustive:allow-extra-fields",
+        "inferred-auth-implicit",
+        "mixed-file-directory",
+        "oauth-client-credentials-nested-root",
+        "multi-url-environment-no-default",
+        "examples",
+        "idempotency-headers",
+        "exhaustive:test-package-path"
+      ],
+      "groupTotalTimeSeconds": 596
     },
     {
       "fixtures": [
         "alias-extends",
         "query-parameters-openapi",
-        "optional",
+        "imdb:validation-status-code",
         "objects-with-imports",
-        "imdb:output-compiled",
-        "literal",
-        "path-parameters",
-        "folders",
-        "simple-fhir",
-        "http-head"
+        "multi-url-environment",
+        "basic-auth",
+        "audiences",
+        "exhaustive:union-utils",
+        "imdb:skip-response-validation",
+        "exhaustive:retain-original-casing"
       ],
-      "groupTotalTimeSeconds": 585
+      "groupTotalTimeSeconds": 595
+    },
+    {
+      "fixtures": [
+        "extends",
+        "nullable",
+        "oauth-client-credentials",
+        "custom-auth",
+        "basic-auth-environment-variables",
+        "error-property",
+        "package-yml",
+        "folders",
+        "bytes-upload",
+        "multiple-request-bodies",
+        "streaming",
+        "streaming-parameter"
+      ],
+      "groupTotalTimeSeconds": 597
     },
     {
       "fixtures": [
         "query-parameters-openapi-as-objects",
-        "alias",
-        "mixed-case:retain-original-casing",
+        "mixed-case:no-custom-config",
+        "property-access",
+        "undiscriminated-unions",
         "oauth-client-credentials-default",
-        "inferred-auth-explicit",
-        "reserved-keywords",
-        "response-property",
-        "circular-references",
-        "exhaustive:union-utils",
-        "multiple-request-bodies",
-        "streaming-parameter"
+        "required-nullable",
+        "circular-references-advanced",
+        "ts-express-casing:no-custom-config",
+        "exhaustive:no-optional-properties",
+        "imdb:no-custom-config"
       ],
-      "groupTotalTimeSeconds": 577
+      "groupTotalTimeSeconds": 598
+    },
+    {
+      "fixtures": [
+        "unions",
+        "alias",
+        "object",
+        "imdb:output-compiled",
+        "multi-line-docs",
+        "oauth-client-credentials-with-variables",
+        "validation",
+        "empty-clients",
+        "circular-references",
+        "plain-text",
+        "server-sent-event-examples",
+        "server-sent-events"
+      ],
+      "groupTotalTimeSeconds": 596
+    },
+    {
+      "fixtures": [
+        "version",
+        "auth-environment-variables",
+        "optional",
+        "no-environment",
+        "ts-inline-types",
+        "reserved-keywords",
+        "cross-package-type-names",
+        "single-url-environment-default",
+        "response-property",
+        "ts-express-casing:no-serde-layer"
+      ],
+      "groupTotalTimeSeconds": 593
+    },
+    {
+      "fixtures": [
+        "version-no-default",
+        "bearer-token-environment-variable",
+        "inferred-auth-implicit-no-expiry",
+        "any-auth",
+        "extra-properties",
+        "errors",
+        "inferred-auth-explicit",
+        "file-download",
+        "exhaustive:no-custom-config",
+        "variables"
+      ],
+      "groupTotalTimeSeconds": 601
     }
   ]
 }


### PR DESCRIPTION
Auto-generated PR, triggered by nightly-seed-grouping workflow with: push from branch: mallinson/run-on-failure-cases-test.
GitHub workflow run: https://github.com/fern-api/fern/actions/runs/18202471177