### PR TITLE
fix(cli): Fix local generation due to unknown type in down-migration

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix local generation for CLI IR versions >= 58 and generator pre IR 58.
+      type: fix
+  irVersion: 60
+  createdAt: "2025-10-02"
+  version: 0.84.2
+
+- changelogEntry:
+    - summary: |
         Fail loud when no configuration files are found for either SDKs or docs.
       type: chore
   irVersion: 60

--- a/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
+++ b/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
@@ -3,6 +3,7 @@ import { GeneratorName } from "@fern-api/configuration-loader";
 import { IrSerialization } from "../../ir-serialization";
 import { IrVersions } from "../../ir-versions";
 import { GeneratorWasNeverUpdatedToConsumeNewIR, IrMigration } from "../../types/IrMigration";
+import { assertNever } from "@fern-api/core-utils";
 
 export const V58_TO_V57_MIGRATION: IrMigration<
     IrVersions.V58.ir.IntermediateRepresentation,
@@ -49,6 +50,7 @@ export const V58_TO_V57_MIGRATION: IrMigration<
     migrateBackwards: (v58): IrVersions.V57.ir.IntermediateRepresentation => {
         return {
             ...v58,
+            publishConfig: v58.publishConfig != null ? convertPublishConfigIr(v58.publishConfig) : undefined,
             services: v58.services != null ? convertServicesIr(v58.services) : undefined,
             dynamic: v58.dynamic != null ? convertDynamicIr(v58.dynamic) : undefined
         } as IrVersions.V57.ir.IntermediateRepresentation;
@@ -142,4 +144,53 @@ function convertDynamicExample(
             method
         }
     };
+}
+
+function convertPublishConfigIr(
+    publishConfig: IrVersions.V58.publish.PublishingConfig
+): IrVersions.V57.publish.PublishingConfig | undefined {
+    switch (publishConfig.type) {
+        case "github": {
+            const convertedTarget = convertPublishTarget(publishConfig.target);
+            if (convertedTarget == null) {
+                return undefined;
+            }
+            return IrVersions.V57.publish.PublishingConfig.github({
+                ...publishConfig,
+                target: convertedTarget
+            });
+        }
+        case "direct": {
+            const convertedTarget = convertPublishTarget(publishConfig.target);
+            if (convertedTarget == null) {
+                return undefined;
+            }
+            return IrVersions.V57.publish.PublishingConfig.direct({
+                target: convertedTarget
+            });
+        }
+        case "filesystem":
+            // filesystem publish config is not supported in v57, return undefined
+            return undefined;
+        default:
+            assertNever(publishConfig);
+    }
+}
+
+function convertPublishTarget(
+    target: IrVersions.V58.publish.PublishTarget
+): IrVersions.V57.publish.PublishTarget | undefined {
+    switch (target.type) {
+        case "postman":
+            return IrVersions.V57.publish.PublishTarget.postman(target);
+        case "npm":
+            return IrVersions.V57.publish.PublishTarget.npm(target);
+        case "maven":
+            return IrVersions.V57.publish.PublishTarget.maven(target);
+        case "pypi":
+            // pypi publish target is not supported in v57, return undefined
+            return undefined;
+        default:
+            assertNever(target);
+    }
 }

--- a/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
+++ b/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
@@ -1,9 +1,8 @@
 import { GeneratorName } from "@fern-api/configuration-loader";
-
+import { assertNever } from "@fern-api/core-utils";
 import { IrSerialization } from "../../ir-serialization";
 import { IrVersions } from "../../ir-versions";
 import { GeneratorWasNeverUpdatedToConsumeNewIR, IrMigration } from "../../types/IrMigration";
-import { assertNever } from "@fern-api/core-utils";
 
 export const V58_TO_V57_MIGRATION: IrMigration<
     IrVersions.V58.ir.IntermediateRepresentation,

--- a/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
+++ b/packages/cli/generation/ir-migrations/src/migrations/v58-to-v57/migrateFromV58ToV57.ts
@@ -51,9 +51,9 @@ export const V58_TO_V57_MIGRATION: IrMigration<
         return {
             ...v58,
             publishConfig: v58.publishConfig != null ? convertPublishConfigIr(v58.publishConfig) : undefined,
-            services: v58.services != null ? convertServicesIr(v58.services) : undefined,
+            services: convertServicesIr(v58.services),
             dynamic: v58.dynamic != null ? convertDynamicIr(v58.dynamic) : undefined
-        } as IrVersions.V57.ir.IntermediateRepresentation;
+        };
     }
 };
 


### PR DESCRIPTION
## Description
Fix a down migration that was punching through an unknown union type. This was only happening with `--local` because it gets set here: https://github.com/fern-api/fern/pull/7305/files

## Changes Made
- Amend the migration to strip out local
- Remove cast which was...masking the exact error

## Testing
Generated their SDK locally, also turned the type checker back on.