### PR TITLE
fix(go): absolutely last wiremock follow-up

### DIFF
--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.13.8
+  changelogEntry:
+    - summary: |
+        use correct port for wire tests in containerized environments (seed and CI)
+      type: fix
+  createdAt: "2025-10-02"
+  irVersion: 60
+
 - version: 1.13.7
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/imdb/imdb_test/imdb_test.go
@@ -44,6 +44,7 @@ func TestMain(m *testing.M) {
 	baseURL, err := container.Endpoint(ctx, "")
 	if err == nil {
 		// Standard method worked (running outside DinD)
+		// This uses the mapped port (e.g., localhost:59553)
 		WireMockBaseURL = "http://" + baseURL
 		WireMockClient = container.Client
 	} else {
@@ -70,24 +71,11 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 
-		// Get the exposed port from the container config
-		var containerPort string
-		for port := range inspect.Config.ExposedPorts {
-			// Get the first TCP port (WireMock uses TCP)
-			if port.Proto() == "tcp" {
-				containerPort = port.Port()
-				break
-			}
-		}
+		// In DinD, use the internal port directly (8080 for WireMock HTTP)
+		// Don't use the mapped port since it doesn't exist in this environment
+		WireMockBaseURL = fmt.Sprintf("http://%s:8080", containerIP)
 
-		if containerPort == "" {
-			fmt.Printf("Failed to get WireMock container port\n")
-			os.Exit(1)
-		}
-
-		// Construct the URL using internal IP and port
-		WireMockBaseURL = fmt.Sprintf("http://%s:%s", containerIP, containerPort)
-		// reconstruct the client with the newly derived internal URL
+		// The container.Client was created with a bad URL, so we need a new one
 		WireMockClient = gowiremock.NewClient(WireMockBaseURL)
 	}
 


### PR DESCRIPTION
Always use port 8080 in the fallback scenario since you don't need to know the port its being mapped to if you are referencing it from the docker bridge network ip address