### PR TITLE
fix(cli): Fix colliding files in local generator groups

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix CLI files colliding when running multiple generators in the same group in local generation.
+      type: fix
+  irVersion: 60
+  createdAt: "2025-10-02"
+  version: 0.84.3
+
+- changelogEntry:
+    - summary: |
         Fix local generation for CLI IR versions >= 58 and generator pre IR 58.
       type: fix
   irVersion: 60

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -40,8 +40,6 @@ export async function runLocalGenerationForWorkspace({
     runner: ContainerRunner | undefined;
     inspect: boolean;
 }): Promise<void> {
-    const workspaceTempDir = await getWorkspaceTempDir();
-
     const results = await Promise.all(
         generatorGroup.generators.map(async (generatorInvocation) => {
             return context.runInteractiveTask({ name: generatorInvocation.name }, async (interactiveTaskContext) => {
@@ -138,6 +136,9 @@ export async function runLocalGenerationForWorkspace({
                               )
                           )
                         : undefined;
+
+                // NOTE(tjb9dc): Important that we get a new temp dir per-generator, as we don't want their local files to collide.
+                const workspaceTempDir = await getWorkspaceTempDir();
 
                 await writeFilesToDiskAndRunGenerator({
                     organization: projectConfig.organization,


### PR DESCRIPTION
Fixes an issue where local generators in the same group share a temp dir and may hammer over each others files, like custom project configs.