### PR TITLE
fix(java): make SSE parser to respect blank line event boundaries

### DIFF
--- a/generators/java/generator-utils/src/main/resources/Stream.java
+++ b/generators/java/generator-utils/src/main/resources/Stream.java
@@ -169,8 +169,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -218,39 +218,67 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (streamTerminator != null && line.trim().equals(streamTerminator)) {
+                        endOfStream = true;
+                        return false;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(
+                                    eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
                         }
+                        continue;
+                    }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
+                        }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
 
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
-                            endOfStream = true;
-                            return false;
-                        }
-
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false; 
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
-                        }
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(
+                            eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        endOfStream = true;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
                     }
                 }
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,3 +1,14 @@
+# yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.8.5
+  changelogEntry:
+    - summary: |
+        Fix SSE parser concatenating multiple events into malformed JSON. Events are now properly
+        separated at blank line boundaries per SSE specification, with correct handling of multiline
+        data fields and stream terminators.
+      type: fix
+  createdAt: "2025-10-02"
+  irVersion: 60
+
 - version: 3.8.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-7034: \[Java, Anduril\] SSE issues](https://linear.app/buildwithfern/issue/FER-7034/java-anduril-sse-issues)

SSE parser was concatenating multiple events instead of properly separating them at blank line boundaries, causing malformed JSON like `{JSON1}{JSON2}{JSON3}`. This is because the parser ignored blank lines (SSE event boundaries per
spec) and returned immediately after parsing the first data line, causing multiple events to bleed together. 

## Changes Made
<!-- List the main changes and updates implemented in this PcR -->
- Accumulate multiple data: lines with \n delimiter per SSE spec
- Handle all SSE field types (event:, id:, retry:, comments) but don't actually do anything with them yet can follow up with this later 
- Handle incomplete events at stream end
- Only remove single space after `:` per SSE spec

This improves the solution that they were able to fix with claude https://github.com/anduril/lattice-sdk-java/pull/160

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed
