### PR TITLE
fix(typescript): Handle colons in basic auth passwords

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.3.6
+  changelogEntry:
+    - summary: Fix basic auth password parsing to support colons in passwords.
+      type: fix
+  createdAt: "2025-10-03"
+  irVersion: 60
 
 - version: 3.3.5
   changelogEntry:

--- a/generators/typescript/utils/core-utilities/src/core/auth/BasicAuth.ts
+++ b/generators/typescript/utils/core-utilities/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/generators/typescript/utils/core-utilities/tests/unit/auth/BasicAuth.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password"
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word"
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: ""
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password"
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: ""
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/accept-header/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/accept-header/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/accept-header/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/basic-auth/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/basic-auth/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/basic-auth/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/client-side-params/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/client-side-params/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/client-side-params/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/bundle/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/bundle/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/bundle/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/bundle/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/custom-package-json/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/custom-package-json/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/dev-dependencies/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/dev-dependencies/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/jsr/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/jsr/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/jsr/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/jsr/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/legacy-exports/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/legacy-exports/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/legacy-exports/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/legacy-exports/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/BasicAuth.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/BasicAuth.js
@@ -14,7 +14,8 @@ exports.BasicAuth = {
     fromAuthorizationHeader: (header) => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = (0, base64_js_1.base64Decode)(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");
         }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/BasicAuth.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/BasicAuth.mjs
@@ -11,7 +11,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header) => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");
         }

--- a/seed/ts-sdk/exhaustive/local-files/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/omit-fern-headers/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/use-jest/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/use-yarn/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/use-yarn/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/use-yarn/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/use-yarn/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/idempotency-headers/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/idempotency-headers/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/imdb/noScripts/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/imdb/noScripts/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/imdb/noScripts/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/imdb/noScripts/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password"
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word"
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: ""
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password"
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: ""
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/multi-url-environment/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/multi-url-environment/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/multiple-request-bodies/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/no-environment/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/no-environment/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/no-environment/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/pagination-custom/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/pagination-custom/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/pagination/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/pagination/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/pagination/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/pagination/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/simple-api/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/simple-api/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/simple-api/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/simple-api/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/single-url-environment-default/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/trace/exhaustive/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/trace/no-custom-config/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/trace/serde-trace/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/trace/serde-trace/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/trace/serde-trace/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/trace/serde-trace/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/ts-express-casing/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/ts-express-casing/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/BasicAuth.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/BasicAuth.ts
@@ -18,7 +18,8 @@ export const BasicAuth = {
     fromAuthorizationHeader: (header: string): BasicAuth => {
         const credentials = header.replace(BASIC_AUTH_HEADER_PREFIX, "");
         const decoded = base64Decode(credentials);
-        const [username, password] = decoded.split(":", 2);
+        const [username, ...passwordParts] = decoded.split(":");
+        const password = passwordParts.length > 0 ? passwordParts.join(":") : undefined;
 
         if (username == null || password == null) {
             throw new Error("Invalid basic auth");

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/auth/BasicAuth.test.ts
@@ -18,5 +18,41 @@ describe("BasicAuth", () => {
                 password: "password",
             });
         });
+
+        it("handles password with colons", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcjpwYXNzOndvcmQ=")).toEqual({
+                username: "user",
+                password: "pass:word",
+            });
+        });
+
+        it("handles empty username and password (just colon)", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic Og==")).toEqual({
+                username: "",
+                password: "",
+            });
+        });
+
+        it("handles empty username", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic OnBhc3N3b3Jk")).toEqual({
+                username: "",
+                password: "password",
+            });
+        });
+
+        it("handles empty password", () => {
+            expect(BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU6")).toEqual({
+                username: "username",
+                password: "",
+            });
+        });
+
+        it("throws error for completely empty credentials", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic ")).toThrow("Invalid basic auth");
+        });
+
+        it("throws error for credentials without colon", () => {
+            expect(() => BasicAuth.fromAuthorizationHeader("Basic dXNlcm5hbWU=")).toThrow("Invalid basic auth");
+        });
     });
 });


### PR DESCRIPTION
We weren't handling basic auth passwords with colons before. This change handles that, while being sure to still support the existing behavior that allows empty usernames and/or passwords, as long as they are properly "delimited" with a colon.