### PR TITLE
feat(ci): Run seed with balanced groups

### DIFF
--- a/.github/actions/check-and-run-leftover-seed-tests/action.yaml
+++ b/.github/actions/check-and-run-leftover-seed-tests/action.yaml
@@ -1,0 +1,69 @@
+name: Check and Run Leftover Seed Tests
+description: Find any seed tests for a given generator that aren't found in the seed groups file. Return the newly added tests to run and error on any tests that should be removed.
+
+inputs:
+  sdk-name:
+    description: The name of the SDK to get the test matrix for
+    required: true
+
+outputs:
+  leftover-tests-to-run:
+    description: "Tests recently added that should be run in the leftover runner"
+    value: ${{ steps.find-differences.outputs.leftover-tests-to-run }}
+  tests-to-remove:
+    description: "Tests recently removed that should be deleted from the seed groups file"
+    value: ${{ steps.find-differences.outputs.tests-to-remove }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install
+      uses: ./.github/actions/install
+
+    - uses: bufbuild/buf-setup-action@v1.34.0
+      with:
+        github_token: ${{ github.token }}
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: "stable"
+
+    - name: Install protoc-gen-openapi
+      shell: bash
+      run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+
+    - name: Build seed
+      shell: bash
+      run: |
+        pnpm seed:build
+
+    - name: Parse test set for ${{ inputs.sdk-name }}
+      id: parse-test-matrices
+      uses: ./.github/actions/parse-test-matrix-output
+      with:
+        generator-name: ${{ inputs.sdk-name }}
+        include-output-folders: true
+
+    - name: Find Differences in Test Sets
+      id: find-differences
+      shell: bash
+      run: |
+        # Get the test set for the given generator from the command get-available-fixtures (will be current)
+        TESTS_FROM_CMD='${{ steps.parse-test-matrices.outputs.parsed }}'
+
+        # Get the test set for the given generator from the seed group JSON files (will only be synced to the latest successful nightly update)
+        TESTS_FROM_FILE=$(jq '[.groups[].fixtures[]] | unique | sort' .github/workflow-resource-files/seed-groups/${{ inputs.sdk-name }}-seed-groups.json)
+
+        # Determine which tests are only in one or the other. Only in cmd = newly added test. Only in file = newly removed test.
+        # Note: file is parsed as JSON object, cmd line is parsed as JSON array
+        ONLY_IN_CMD=$(jq -n --argjson cmd "$TESTS_FROM_CMD" --argjson file "$TESTS_FROM_FILE" '$cmd - $file | .[]')
+        ONLY_IN_FILE=$(jq -n --argjson cmd "$TESTS_FROM_CMD" --argjson file "$TESTS_FROM_FILE" '$file - $cmd | .[]')
+
+        # Echo for command line visibility
+        echo "Tests only in get-available-fixtures:"
+        echo "$ONLY_IN_CMD" | jq .
+        echo "Tests only in seed groups file:"
+        echo "$ONLY_IN_FILE" | jq .
+
+        echo "leftover-tests-to-run=$(echo "$ONLY_IN_CMD" | jq -c -s .)" >> $GITHUB_OUTPUT
+        echo "tests-to-remove=$(echo "$ONLY_IN_FILE" | jq -c -s .)" >> $GITHUB_OUTPUT

--- a/.github/actions/get-test-matrix/action.yaml
+++ b/.github/actions/get-test-matrix/action.yaml
@@ -8,8 +8,19 @@ inputs:
   package-amount:
     description: "Maximum number of packages to bundle the test sets into"
     required: true
+  include-output-folders:
+    description: "Whether to include output folders as unique tests of a fixture or just include the fixtures"
+    required: false
+    default: "false"
+  package-alphabetically:
+    description: "Whether to package the test sets alphabetically (legacy workflow, will eventually be deprecated)"
+    required: false
+    default: "true"
 
 outputs:
+  unpacked-test-matrix:
+    description: "Test matrix without any packaging"
+    value: ${{ steps.get-test-matrices.outputs.parsed }}
   test-matrix:
     description: "Packaged test matrix"
     value: ${{ steps.package-test-matrices.outputs.packaged }}
@@ -46,7 +57,8 @@ runs:
       id: determine-test-setups
       shell: bash
       run: |
-        if [[ "${{ inputs.sdk-name }}" == "fastapi" || \
+        if [[ "${{inputs.package-alphabetically}}" == "false" || \
+        "${{ inputs.sdk-name }}" == "fastapi" || \
         "${{ inputs.sdk-name }}" == "go-fiber" || \
         "${{ inputs.sdk-name }}" == "go-model" || \
         "${{ inputs.sdk-name }}" == "java-spring" || \
@@ -62,14 +74,15 @@ runs:
         fi
 
     - name: Get test matrix for ${{ inputs.sdk-name }}
-      if: steps.determine-test-setups.outputs.split-tests == 'true'
+      if: (steps.determine-test-setups.outputs.split-tests == 'true' && inputs.package-alphabetically == 'true') || inputs.package-alphabetically == 'false'
       id: get-test-matrices
       uses: ./.github/actions/parse-test-matrix-output
       with:
         generator-name: ${{ inputs.sdk-name }}
+        include-output-folders: ${{ inputs.include-output-folders }}
 
     - name: Package test matrices for ${{ inputs.sdk-name }}
-      if: steps.determine-test-setups.outputs.split-tests == 'true'
+      if: steps.determine-test-setups.outputs.split-tests == 'true' && inputs.package-alphabetically == 'true'
       id: package-test-matrices
       uses: ./.github/actions/package-test-matrix
       with:

--- a/.github/actions/handle-leftover-seed-tests/action.yaml
+++ b/.github/actions/handle-leftover-seed-tests/action.yaml
@@ -1,0 +1,87 @@
+name: Handle Leftover Seed Tests
+description: Find any seed tests for a given generator that aren't found in the seed groups file or vice versa. Run any new tests, error on any missing tests that should be removed.
+
+inputs:
+  sdk-name:
+    description: The name of the SDK to get the test matrix for
+    required: true
+  generator-path:
+    description: The path to the generator to run
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse Test Matrix
+      id: parse-test-matrix
+      uses: ./.github/actions/get-test-matrix
+      with:
+        sdk-name: ${{ inputs.sdk-name }}
+        package-alphabetically: false
+        include-output-folders: true
+
+    - name: Find Differences in Test Sets
+      id: find-differences
+      shell: bash
+      run: |
+        # Get the test set for the given generator from the command get-available-fixtures (will be current)
+        TESTS_FROM_CMD='${{ steps.parse-test-matrix.outputs.unpacked-test-matrix }}'
+
+        # Get the test set for the given generator from the seed group JSON files (will only be synced to the latest successful nightly update)
+        TESTS_FROM_FILE=$(jq '[.groups[].fixtures[]] | unique | sort' .github/workflow-resource-files/seed-groups/${{ inputs.sdk-name }}-seed-groups.json)
+
+        # Determine which tests are only in one or the other. Only in cmd = newly added test. Only in file = newly removed test.
+        # Note: file is parsed as JSON object, cmd line is parsed as JSON array
+        ONLY_IN_CMD=$(jq -n --argjson cmd "$TESTS_FROM_CMD" --argjson file "$TESTS_FROM_FILE" '$cmd - $file | .[]')
+        ONLY_IN_FILE=$(jq -n --argjson cmd "$TESTS_FROM_CMD" --argjson file "$TESTS_FROM_FILE" '$file - $cmd | .[]')
+
+        # Echo for command line visibility
+        echo "Tests only in get-available-fixtures:"
+        echo "$ONLY_IN_CMD" | jq .
+        echo "Tests only in seed groups file:"
+        echo "$ONLY_IN_FILE" | jq .
+
+        echo "leftover-tests-to-run=$(echo "$ONLY_IN_CMD" | jq -c -s .)" >> $GITHUB_OUTPUT
+        echo "tests-to-remove=$(echo "$ONLY_IN_FILE" | jq -c -s .)" >> $GITHUB_OUTPUT
+
+    # Tests that were removed in recent changes are already attempting to run on other parallelized runners.
+    # Those are going to error, give a more descriptive message here.
+    - name: Error on Removed Tests
+      if: ${{ steps.find-differences.outputs.tests-to-remove != '' && steps.find-differences.outputs.tests-to-remove != '[]' }}
+      shell: bash
+      run: |
+        echo "These tests were recently removed or changed from a single fixture to one with an output folder(s). Please remove them from the ${{ inputs.sdk-name }}-seed-groups.json file as part of this change."
+        echo "Tests to remove: ${{ steps.find-differences.outputs.tests-to-remove }}"
+        exit 1
+
+    # Format for seed tests if there are tests to run
+    - name: JSON to String
+      if: ${{ steps.find-differences.outputs.leftover-tests-to-run != '' && steps.find-differences.outputs.leftover-tests-to-run != '[]' }}
+      id: json-to-string
+      shell: bash
+      run: |
+        json_data='${{ steps.find-differences.outputs.leftover-tests-to-run }}'
+        # Convert JSON array to space-separated string
+        string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
+        echo "Generated string: '$string_result'"
+        echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
+    # Tests that were added in recent changes and will be run in this runner for all leftover tests.
+    - name: Run Leftover Tests
+      if: ${{ steps.find-differences.outputs.leftover-tests-to-run != '' && steps.find-differences.outputs.leftover-tests-to-run != '[]' }}
+      uses: ./.github/actions/cached-seed
+      with:
+        generator-name: ${{ inputs.sdk-name }}
+        generator-path: ${{ inputs.generator-path }}
+        fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+    - name: No Changes Detected for Tests
+      if: >- 
+        ${{ 
+          (steps.find-differences.outputs.tests-to-remove == '' || steps.find-differences.outputs.tests-to-remove == '[]') && 
+          (steps.find-differences.outputs.leftover-tests-to-run == '' || steps.find-differences.outputs.leftover-tests-to-run == '[]') 
+        }}
+      shell: bash
+      run: |
+        echo "No new or removed tests detected."
+

--- a/.github/actions/handle-leftover-seed-tests/action.yaml
+++ b/.github/actions/handle-leftover-seed-tests/action.yaml
@@ -76,7 +76,7 @@ runs:
         fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
     - name: No Changes Detected for Tests
-      if: >- 
+      if: >-
         ${{ 
           (steps.find-differences.outputs.tests-to-remove == '' || steps.find-differences.outputs.tests-to-remove == '[]') && 
           (steps.find-differences.outputs.leftover-tests-to-run == '' || steps.find-differences.outputs.leftover-tests-to-run == '[]') 
@@ -84,4 +84,3 @@ runs:
       shell: bash
       run: |
         echo "No new or removed tests detected."
-

--- a/.github/actions/parse-test-matrix-output/action.yaml
+++ b/.github/actions/parse-test-matrix-output/action.yaml
@@ -5,11 +5,10 @@ inputs:
   generator-name:
     description: "Generator to get fixtures for"
     required: true
-  #  TODO - add back eventually when CLI is updated for this
-  # include-output-folders:
-  #   description: "Whether to include output folders as unique tests"
-  #   required: false
-  #   default: "true"
+  include-output-folders:
+    description: "Whether to include output folders as unique tests"
+    required: false
+    default: "false"
 
 outputs:
   parsed:
@@ -23,8 +22,13 @@ runs:
       id: parse-test-set-matrix
       shell: bash
       run: |
+        INCLUDE_OUTPUT_FOLDERS_OPTION=""
+        if [[ "${{inputs.include-output-folders}}" == "true" ]]; then
+          INCLUDE_OUTPUT_FOLDERS_OPTION="--include-output-folders"
+        fi
+
         # Get JSON output from get-available-fixtures command
-        COMMAND_OUTPUT=$(pnpm seed get-available-fixtures --generator ${{inputs.generator-name}})
+        COMMAND_OUTPUT=$(pnpm seed get-available-fixtures --generator ${{inputs.generator-name}} $INCLUDE_OUTPUT_FOLDERS_OPTION)
 
         echo "${COMMAND_OUTPUT}"
 
@@ -34,6 +38,7 @@ runs:
         # Extract fixtures to JSON array
         FIXTURES_FLAT_JSON=$(echo "${JSON_OUTPUT}" | jq -c '.fixtures')
 
-        echo "Debug: Extracted fixtures: $FIXTURES_FLAT_JSON | jq ."
+        echo "Extracted fixtures: "
+        echo "$FIXTURES_FLAT_JSON" | jq .
 
         echo "fixture_list=$FIXTURES_FLAT_JSON" >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   run-seed-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false # Let all tests run and cascade errors, will only PR generator updates that passed
       matrix:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -260,7 +260,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
     steps:
@@ -305,7 +305,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
     steps:
@@ -350,7 +350,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
     steps:
@@ -396,7 +396,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
     steps:
@@ -436,7 +436,7 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
     if: >-
@@ -482,7 +482,7 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
     if: >-
@@ -532,7 +532,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
     steps:
@@ -572,7 +572,7 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
     if: >-
@@ -617,7 +617,7 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
     if: >-
@@ -663,7 +663,7 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
     if: >-
@@ -708,7 +708,7 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
     if: >-
@@ -758,7 +758,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
     steps:
@@ -800,7 +800,7 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
     if: >-
@@ -850,7 +850,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
     steps:
@@ -896,7 +896,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
     steps:
@@ -942,7 +942,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
     steps:
@@ -987,7 +987,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
     steps:
@@ -1032,7 +1032,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
     steps:
@@ -1077,7 +1077,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
     steps:
@@ -1122,7 +1122,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
     steps:
@@ -1167,7 +1167,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
     steps:
@@ -1212,7 +1212,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
     steps:
@@ -1257,7 +1257,7 @@ jobs:
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 11 # Limit the number of runners for this job
+      max-parallel: 15 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
     steps:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -25,7 +25,21 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
+        generator-name:
+          [
+            ruby,
+            ruby-v2,
+            openapi,
+            python,
+            postman,
+            java,
+            typescript,
+            go,
+            csharp,
+            php,
+            swift,
+            rust,
+          ]
         include:
           - files: |
               generators/ruby/
@@ -126,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false # Don't let failing generators block the passing generators
       matrix:
         sdk-name:
           [
@@ -133,7 +148,7 @@ jobs:
             ruby-sdk,
             ruby-sdk-v2,
             pydantic,
-            python-sdk,
+            # python-sdk, TODO FER-6998: figure out why python-sdk is hanging in CI
             fastapi,
             openapi,
             postman,
@@ -154,57 +169,98 @@ jobs:
             rust-sdk
           ]
     outputs:
-      ruby-model: ${{ steps.set-test-matrix.outputs.ruby-model-test-matrix }}
-      ruby-sdk: ${{ steps.set-test-matrix.outputs.ruby-sdk-test-matrix }}
-      ruby-sdk-v2: ${{ steps.set-test-matrix.outputs.ruby-sdk-v2-test-matrix }}
-      pydantic: ${{ steps.set-test-matrix.outputs.pydantic-test-matrix }}
-      python-sdk: ${{ steps.set-test-matrix.outputs.python-sdk-test-matrix }}
-      fastapi: ${{ steps.set-test-matrix.outputs.fastapi-test-matrix }}
-      openapi: ${{ steps.set-test-matrix.outputs.openapi-test-matrix }}
-      postman: ${{ steps.set-test-matrix.outputs.postman-test-matrix }}
-      java-sdk: ${{ steps.set-test-matrix.outputs.java-sdk-test-matrix }}
-      java-model: ${{ steps.set-test-matrix.outputs.java-model-test-matrix }}
-      java-spring: ${{ steps.set-test-matrix.outputs.java-spring-test-matrix }}
-      ts-sdk: ${{ steps.set-test-matrix.outputs.ts-sdk-test-matrix }}
-      ts-express: ${{ steps.set-test-matrix.outputs.ts-express-test-matrix }}
-      go-fiber: ${{ steps.set-test-matrix.outputs.go-fiber-test-matrix }}
-      go-model: ${{ steps.set-test-matrix.outputs.go-model-test-matrix }}
-      go-sdk: ${{ steps.set-test-matrix.outputs.go-sdk-test-matrix }}
-      csharp-model: ${{ steps.set-test-matrix.outputs.csharp-model-test-matrix }}
-      csharp-sdk: ${{ steps.set-test-matrix.outputs.csharp-sdk-test-matrix }}
-      php-model: ${{ steps.set-test-matrix.outputs.php-model-test-matrix }}
-      php-sdk: ${{ steps.set-test-matrix.outputs.php-sdk-test-matrix }}
-      swift-sdk: ${{ steps.set-test-matrix.outputs.swift-sdk-test-matrix }}
-      rust-model: ${{ steps.set-test-matrix.outputs.rust-model-test-matrix }}
-      rust-sdk: ${{ steps.set-test-matrix.outputs.rust-sdk-test-matrix }}
+      ruby-model: ${{ steps.create-seed-groups-matrix.outputs.ruby-model-test-matrix }}
+      ruby-sdk: ${{ steps.create-seed-groups-matrix.outputs.ruby-sdk-test-matrix }}
+      ruby-sdk-v2: ${{ steps.create-seed-groups-matrix.outputs.ruby-sdk-v2-test-matrix }}
+      pydantic: ${{ steps.create-seed-groups-matrix.outputs.pydantic-test-matrix }}
+      python-sdk: ${{ steps.create-seed-groups-matrix.outputs.python-sdk-test-matrix }}
+      fastapi: ${{ steps.create-seed-groups-matrix.outputs.fastapi-test-matrix }}
+      openapi: ${{ steps.create-seed-groups-matrix.outputs.openapi-test-matrix }}
+      postman: ${{ steps.create-seed-groups-matrix.outputs.postman-test-matrix }}
+      java-sdk: ${{ steps.create-seed-groups-matrix.outputs.java-sdk-test-matrix }}
+      java-model: ${{ steps.create-seed-groups-matrix.outputs.java-model-test-matrix }}
+      java-spring: ${{ steps.create-seed-groups-matrix.outputs.java-spring-test-matrix }}
+      ts-sdk: ${{ steps.create-seed-groups-matrix.outputs.ts-sdk-test-matrix }}
+      ts-express: ${{ steps.create-seed-groups-matrix.outputs.ts-express-test-matrix }}
+      go-fiber: ${{ steps.create-seed-groups-matrix.outputs.go-fiber-test-matrix }}
+      go-model: ${{ steps.create-seed-groups-matrix.outputs.go-model-test-matrix }}
+      go-sdk: ${{ steps.create-seed-groups-matrix.outputs.go-sdk-test-matrix }}
+      csharp-model: ${{ steps.create-seed-groups-matrix.outputs.csharp-model-test-matrix }}
+      csharp-sdk: ${{ steps.create-seed-groups-matrix.outputs.csharp-sdk-test-matrix }}
+      php-model: ${{ steps.create-seed-groups-matrix.outputs.php-model-test-matrix }}
+      php-sdk: ${{ steps.create-seed-groups-matrix.outputs.php-sdk-test-matrix }}
+      swift-sdk: ${{ steps.create-seed-groups-matrix.outputs.swift-sdk-test-matrix }}
+      rust-model: ${{ steps.create-seed-groups-matrix.outputs.rust-model-test-matrix }}
+      rust-sdk: ${{ steps.create-seed-groups-matrix.outputs.rust-sdk-test-matrix }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Get test matrix
-        id: get-test-matrix
-        uses: ./.github/actions/get-test-matrix
         with:
-          sdk-name: ${{ matrix.sdk-name }}
-          package-amount: 10
+          sparse-checkout: |
+            .github/workflow-resource-files/seed-groups/
 
-      - name: Set test matrix for ${{ matrix.sdk-name }}
-        id: set-test-matrix
+      - name: Verify Seed Groups File Exists
         run: |
-          if [[ "${{ steps.get-test-matrix.outputs.split-tests }}" == "true" ]]; then
-              BASH_VAR='${{ steps.get-test-matrix.outputs.test-matrix }}'
-              echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
-
-              # Echo the data to command line for visibility
-              echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
-              echo "$BASH_VAR" | jq .
+          if [ ! -f .github/workflow-resource-files/seed-groups/${{ matrix.sdk-name }}-seed-groups.json ]; then
+            echo "${{ matrix.sdk-name }}-seed-groups.json file not found. This file should be created automatically by the nightly-seed-grouping workflow."
+            exit 1
           else
-            echo "Set empty json matrix, which will run all tests on a single runner"
+            echo "${{ matrix.sdk-name }}-seed-groups.json file found."
+          fi
+
+      - name: Determine Parallelization
+        id: determine-parallelization
+        run: |
+          # Note: these times are the total time of generation and compilation for all seed tests. This is not a 
+          # measurement of throughput because it does not account of concurrency or parallelization. This is not 
+          # a perfect representation, but it gets the job done. 3800 seconds was chosen as it is approximately 
+          # 8 minutes when running with 16 concurrent tests as is our default setting in CI.
+          CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS=3800
+          TOTAL_TEST_TIME_SECONDS=$(jq '.totalTestTimeSeconds' .github/workflow-resource-files/seed-groups/${{ matrix.sdk-name }}-seed-groups.json)
+          echo "Checking if ${{ matrix.sdk-name }} total test time of $TOTAL_TEST_TIME_SECONDS seconds is greater than $CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS seconds to split tests into parallel runners"
+
+          # Validate both times are non-negative integers (zero is allowed)
+          if [[ ! $CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS =~ ^[0-9]+$ ]]; then
+            echo "Cut off time from seed.yml workflow is not a non-negative integer ($CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS)"
+            exit 1
+          fi
+
+          if [[ ! $TOTAL_TEST_TIME_SECONDS =~ ^[0-9]+$ ]]; then
+            echo "Total test time from ${{ matrix.sdk-name }}-seed-groups.json is not a non-negative integer ($TOTAL_TEST_TIME_SECONDS)"
+            exit 1
+          fi
+
+          # Determine if we should split tests into parallel runners based on the cutoff time
+          if [[ $TOTAL_TEST_TIME_SECONDS -gt $CUTOFF_TIME_FOR_PARALLELIZATION_SECONDS ]]; then
+            echo "Running ${{ matrix.sdk-name }} tests in parallel runners"
+            echo "split-tests=true" >> $GITHUB_OUTPUT
+          else
+            echo "Running ${{ matrix.sdk-name }} tests in a single runner"
+            echo "split-tests=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Seed Groups Matrix
+        id: create-seed-groups-matrix
+        run: |
+          # Parallelize tests and add leftover test runner, or run all tests in a single runner
+          # Note: "leftovers" and "all" are used as keywords in the matrix jobs following this setup
+          BASH_VAR=""
+          if [[ "${{ steps.determine-parallelization.outputs.split-tests }}" == "true" ]]; then
+            echo "Using balanced groups from ${{ matrix.sdk-name }}-seed-groups.json and adding a group for any leftover tests"
+            BASH_VAR=$(jq '[.groups[] | {fixtures: .fixtures}]' .github/workflow-resource-files/seed-groups/${{ matrix.sdk-name }}-seed-groups.json)
+            WITH_LEFTOVERS=$(echo "$BASH_VAR" | jq -c '. += [{"fixtures": ["leftovers"]}]')
+            echo "${{ matrix.sdk-name }}-test-matrix=$WITH_LEFTOVERS" >> $GITHUB_OUTPUT
+
+            # Echo the data to command line for visibility
+            echo "Groups for ${{ matrix.sdk-name }}-test-matrix:"
+            echo "$WITH_LEFTOVERS" | jq .
+          else
+            echo "Using single group to run all ${{ matrix.sdk-name }} tests"
             BASH_VAR='[{"fixtures":["all"]}]'
             echo "${{ matrix.sdk-name }}-test-matrix=$BASH_VAR" >> $GITHUB_OUTPUT
 
             # Echo the data to command line for visibility
-            echo "Packaged data for ${{ matrix.sdk-name }}-test-matrix:"
+            echo "Single group for ${{ matrix.sdk-name }}-test-matrix:"
             echo "$BASH_VAR" | jq .
           fi
 
@@ -214,12 +270,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.ruby == 'true'
+        (needs.changes.outputs.ruby == 'true' && needs.get-all-test-matrices.outputs.ruby-model != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-model) }}
     steps:
@@ -239,11 +295,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: ruby-model
           generator-path: generators/ruby
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: ruby-model
+          generator-path: generators/ruby
 
   ruby-sdk:
     runs-on: ubuntu-latest
@@ -251,12 +315,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.ruby == 'true'
+        (needs.changes.outputs.ruby == 'true' && needs.get-all-test-matrices.outputs.ruby-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk) }}
     steps:
@@ -276,11 +340,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: ruby-sdk
           generator-path: generators/ruby
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: ruby-sdk
+          generator-path: generators/ruby
 
   ruby-sdk-v2:
     runs-on: ubuntu-latest
@@ -288,12 +360,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.ruby-v2 == 'true'
+        (needs.changes.outputs.ruby-v2 == 'true' && needs.get-all-test-matrices.outputs.ruby-sdk-v2 != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
     steps:
@@ -313,6 +385,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: ruby-sdk-v2
@@ -320,18 +393,25 @@ jobs:
           validation-exclude-paths: "seed/*/.mock/*,seed/**/Gemfile.lock"
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: ruby-sdk-v2
+          generator-path: generators/ruby-v2
+
   pydantic:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.python == 'true'
+        (needs.changes.outputs.python == 'true' && needs.get-all-test-matrices.outputs.pydantic != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
     steps:
@@ -351,11 +431,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: pydantic
           generator-path: generators/python
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: pydantic
+          generator-path: generators/python
 
   python-sdk:
     runs-on: ubuntu-latest
@@ -363,12 +451,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
     if: >-
       ${{
-        (needs.changes.outputs.python == 'true'
+        (needs.changes.outputs.python == 'true' && needs.get-all-test-matrices.outputs.python-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     steps:
@@ -388,6 +476,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: python-sdk
@@ -395,18 +484,25 @@ jobs:
           validation-exclude-paths: "seed/*/.mock/*,seed/**/poetry.lock"
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
 
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: python-sdk
+          generator-path: generators/python
+
   fastapi:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.fastapi) }}
     if: >-
       ${{
-        (needs.changes.outputs.python == 'true'
+        (needs.changes.outputs.python == 'true' && needs.get-all-test-matrices.outputs.fastapi != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     steps:
@@ -426,11 +522,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: fastapi
           generator-path: generators/python
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: fastapi
+          generator-path: generators/python
 
   openapi:
     runs-on: ubuntu-latest
@@ -438,12 +542,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.openapi == 'true'
+        (needs.changes.outputs.openapi == 'true' && needs.get-all-test-matrices.outputs.openapi != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
     steps:
@@ -463,11 +567,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: openapi
           generator-path: generators/openapi
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: openapi
+          generator-path: generators/openapi
 
   postman:
     runs-on: ubuntu-latest
@@ -475,12 +587,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.postman) }}
     if: >-
       ${{
-        (needs.changes.outputs.postman == 'true'
+        (needs.changes.outputs.postman == 'true' && needs.get-all-test-matrices.outputs.postman != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     steps:
@@ -500,11 +612,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: postman
           generator-path: generators/postman
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: postman
+          generator-path: generators/postman
 
   java-sdk:
     runs-on: ubuntu-latest
@@ -512,12 +632,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
     if: >-
       ${{
-        (needs.changes.outputs.java == 'true'
+        (needs.changes.outputs.java == 'true' && needs.get-all-test-matrices.outputs.java-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     steps:
@@ -533,15 +653,24 @@ jobs:
           string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
           echo "Generated string: '$string_result'"
           echo "as-string=$string_result" >> $GITHUB_OUTPUT
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: java-sdk
           generator-path: generators/java generators/java-v2
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: java-sdk
+          generator-path: generators/java generators/java-v2
 
   java-model:
     runs-on: ubuntu-latest
@@ -549,12 +678,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
     if: >-
       ${{
-        (needs.changes.outputs.java == 'true'
+        (needs.changes.outputs.java == 'true' && needs.get-all-test-matrices.outputs.java-model != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     steps:
@@ -574,11 +703,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: java-model
           generator-path: generators/java
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: java-model
+          generator-path: generators/java
 
   java-spring:
     runs-on: ubuntu-latest
@@ -586,12 +723,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-spring) }}
     if: >-
       ${{
-        (needs.changes.outputs.java == 'true'
+        (needs.changes.outputs.java == 'true' && needs.get-all-test-matrices.outputs.java-spring != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     steps:
@@ -611,11 +748,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: java-spring
           generator-path: generators/java
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: java-spring
+          generator-path: generators/java
 
   typescript-sdk:
     runs-on: ubuntu-latest
@@ -623,12 +768,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.typescript == 'true'
+        (needs.changes.outputs.typescript == 'true' && needs.get-all-test-matrices.outputs.ts-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
     steps:
@@ -649,6 +794,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: ts-sdk
@@ -656,18 +802,25 @@ jobs:
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
           validation-exclude-paths: "seed/*/.mock/*,seed/ts-sdk/**/pnpm-lock.yaml"
 
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: ts-sdk
+          generator-path: generators/typescript
+
   typescript-express:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, get-all-test-matrices]
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ts-express) }}
     if: >-
       ${{
-        (needs.changes.outputs.typescript == 'true'
+        (needs.changes.outputs.typescript == 'true' && needs.get-all-test-matrices.outputs.ts-express != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     steps:
@@ -687,11 +840,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: ts-express
           generator-path: generators/typescript
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: ts-express
+          generator-path: generators/typescript
 
   go-fiber:
     runs-on: ubuntu-latest
@@ -699,12 +860,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.go == 'true'
+        (needs.changes.outputs.go == 'true' && needs.get-all-test-matrices.outputs.go-fiber != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-fiber) }}
     steps:
@@ -725,11 +886,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: go-fiber
           generator-path: generators/go generators/go-v2
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: go-fiber
+          generator-path: generators/go generators/go-v2
 
   go-model:
     runs-on: ubuntu-latest
@@ -737,12 +906,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.go == 'true'
+        (needs.changes.outputs.go == 'true' && needs.get-all-test-matrices.outputs.go-model != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
     steps:
@@ -763,11 +932,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: go-model
           generator-path: generators/go generators/go-v2
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: go-model
+          generator-path: generators/go generators/go-v2
 
   go-sdk:
     runs-on: ubuntu-latest
@@ -775,12 +952,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.go == 'true'
+        (needs.changes.outputs.go == 'true' && needs.get-all-test-matrices.outputs.go-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
     steps:
@@ -800,11 +977,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: go-sdk
           generator-path: generators/go generators/go-v2
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: go-sdk
+          generator-path: generators/go generators/go-v2
 
   csharp-model:
     runs-on: ubuntu-latest
@@ -812,12 +997,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.csharp == 'true'
+        (needs.changes.outputs.csharp == 'true' && needs.get-all-test-matrices.outputs.csharp-model != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
     steps:
@@ -837,11 +1022,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: csharp-model
           generator-path: generators/csharp
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: csharp-model
+          generator-path: generators/csharp
 
   csharp-sdk:
     runs-on: ubuntu-latest
@@ -849,12 +1042,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.csharp == 'true'
+        (needs.changes.outputs.csharp == 'true' && needs.get-all-test-matrices.outputs.csharp-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
     steps:
@@ -874,11 +1067,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: csharp-sdk
           generator-path: generators/csharp
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: csharp-sdk
+          generator-path: generators/csharp
 
   php-model:
     runs-on: ubuntu-latest
@@ -886,12 +1087,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.php == 'true'
+        (needs.changes.outputs.php == 'true' && needs.get-all-test-matrices.outputs.php-model != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
     steps:
@@ -911,11 +1112,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: php-model
           generator-path: generators/php
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: php-model
+          generator-path: generators/php
 
   php-sdk:
     runs-on: ubuntu-latest
@@ -923,12 +1132,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.php == 'true'
+        (needs.changes.outputs.php == 'true' && needs.get-all-test-matrices.outputs.php-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
     steps:
@@ -948,11 +1157,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: php-sdk
           generator-path: generators/php
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with: 
+          sdk-name: php-sdk
+          generator-path: generators/php
 
   swift-sdk:
     runs-on: ubuntu-latest
@@ -960,12 +1177,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.swift == 'true'
+        (needs.changes.outputs.swift == 'true' && needs.get-all-test-matrices.outputs.swift-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
     steps:
@@ -985,11 +1202,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: swift-sdk
           generator-path: generators/swift
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: swift-sdk
+          generator-path: generators/swift
 
   rust-model:
     runs-on: ubuntu-latest
@@ -997,12 +1222,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.rust == 'true'
+        (needs.changes.outputs.rust == 'true' && needs.get-all-test-matrices.outputs.rust-model != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
     steps:
@@ -1022,11 +1247,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: rust-model
           generator-path: generators/rust
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: rust-model
+          generator-path: generators/rust
 
   rust-sdk:
     runs-on: ubuntu-latest
@@ -1034,12 +1267,12 @@ jobs:
     needs: [changes, get-all-test-matrices]
     if: >-
       ${{
-        (needs.changes.outputs.rust == 'true'
+        (needs.changes.outputs.rust == 'true' && needs.get-all-test-matrices.outputs.rust-sdk != ''
         && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false # Let all tests run, even if some fail
-      max-parallel: 10 # Limit the number of runners for this job to 10
+      max-parallel: 11 # Limit the number of runners for this job
       matrix:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
     steps:
@@ -1059,8 +1292,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run seed
+        if: ${{ steps.json-to-string.outputs.as-string != 'leftovers' }}
         uses: ./.github/actions/cached-seed
         with:
           generator-name: rust-sdk
           generator-path: generators/rust
           fixtures-to-run: ${{ steps.json-to-string.outputs.as-string }}
+
+      - name: Handle Seed Leftover Tests
+        if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
+        uses: ./.github/actions/handle-leftover-seed-tests
+        with:
+          sdk-name: rust-sdk
+          generator-path: generators/rust

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -25,21 +25,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        generator-name:
-          [
-            ruby,
-            ruby-v2,
-            openapi,
-            python,
-            postman,
-            java,
-            typescript,
-            go,
-            csharp,
-            php,
-            swift,
-            rust,
-          ]
+        generator-name: [ruby, ruby-v2, openapi, python, postman, java, typescript, go, csharp, php, swift, rust]
         include:
           - files: |
               generators/ruby/
@@ -142,8 +128,7 @@ jobs:
     strategy:
       fail-fast: false # Don't let failing generators block the passing generators
       matrix:
-        sdk-name:
-          [
+        sdk-name: [
             ruby-model,
             ruby-sdk,
             ruby-sdk-v2,
@@ -1167,7 +1152,7 @@ jobs:
       - name: Handle Seed Leftover Tests
         if: ${{ steps.json-to-string.outputs.as-string == 'leftovers' }}
         uses: ./.github/actions/handle-leftover-seed-tests
-        with: 
+        with:
           sdk-name: php-sdk
           generator-path: generators/php
 

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -236,6 +236,7 @@ jobs:
         with:
           sdk-name: ${{ matrix.sdk-name }}
           package-amount: 10
+          include-output-folders: true
 
       - name: Set test matrix for ${{ matrix.sdk-name }}
         id: set-test-matrix

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -325,7 +325,7 @@ function addGetAvailableFixturesCommand(cli: Argv) {
                     demandOption: true,
                     description: "Generator to get fixtures for"
                 })
-                .option("include-subfolders", {
+                .option("include-output-folders", {
                     type: "boolean",
                     demandOption: false,
                     default: false,
@@ -343,7 +343,7 @@ function addGetAvailableFixturesCommand(cli: Argv) {
                 );
             }
 
-            const availableFixtures = await getAvailableFixtures(generator, argv["include-subfolders"]);
+            const availableFixtures = await getAvailableFixtures(generator, argv["include-output-folders"]);
 
             // Note: HAVE to log the output for CI to pick it up
             console.log(JSON.stringify({ fixtures: availableFixtures }, null, 2));

--- a/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/Stream.java
+++ b/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/alias/src/main/java/com/seed/alias/core/Stream.java
+++ b/seed/java-sdk/alias/src/main/java/com/seed/alias/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/Stream.java
+++ b/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/Stream.java
+++ b/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/Stream.java
+++ b/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/auth-environment-variables/src/main/java/com/seed/authEnvironmentVariables/core/Stream.java
+++ b/seed/java-sdk/auth-environment-variables/src/main/java/com/seed/authEnvironmentVariables/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/Stream.java
+++ b/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/Stream.java
+++ b/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/Stream.java
+++ b/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/Stream.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/Stream.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/Stream.java
+++ b/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/Stream.java
+++ b/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/custom-auth/custom-auth/src/main/java/com/seed/customAuth/core/Stream.java
+++ b/seed/java-sdk/custom-auth/custom-auth/src/main/java/com/seed/customAuth/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/Stream.java
+++ b/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/Stream.java
+++ b/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/Stream.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/Stream.java
+++ b/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/errors/src/main/java/com/seed/errors/core/Stream.java
+++ b/seed/java-sdk/errors/src/main/java/com/seed/errors/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/Stream.java
+++ b/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/Stream.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/Stream.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/Stream.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/local-files/core/Stream.java
+++ b/seed/java-sdk/exhaustive/local-files/core/Stream.java
@@ -175,8 +175,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -224,39 +224,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(
+                                    eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0 && streamTerminator != null && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false; 
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(
+                            eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/Stream.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/Stream.java
+++ b/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/Stream.java
+++ b/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/Stream.java
+++ b/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/Stream.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/Stream.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/Stream.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/folders/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/folders/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/Stream.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/idempotency-headers/src/main/java/com/seed/idempotencyHeaders/core/Stream.java
+++ b/seed/java-sdk/idempotency-headers/src/main/java/com/seed/idempotencyHeaders/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/Stream.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/Stream.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/Stream.java
+++ b/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/Stream.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/Stream.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/Stream.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/Stream.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/Stream.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/Stream.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/Stream.java
+++ b/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/license/src/main/java/com/seed/license/core/Stream.java
+++ b/seed/java-sdk/license/src/main/java/com/seed/license/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/literal/src/main/java/com/seed/literal/core/Stream.java
+++ b/seed/java-sdk/literal/src/main/java/com/seed/literal/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/Stream.java
+++ b/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/Stream.java
+++ b/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/Stream.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/Stream.java
+++ b/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/Stream.java
+++ b/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/Stream.java
+++ b/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/Stream.java
+++ b/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/Stream.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/Stream.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/Stream.java
+++ b/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/Stream.java
+++ b/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/Stream.java
+++ b/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/Stream.java
+++ b/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/Stream.java
+++ b/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/Stream.java
+++ b/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/Stream.java
+++ b/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/Stream.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/object/src/main/java/com/seed/object/core/Stream.java
+++ b/seed/java-sdk/object/src/main/java/com/seed/object/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/Stream.java
+++ b/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/optional/src/main/java/com/seed/objectsWithImports/core/Stream.java
+++ b/seed/java-sdk/optional/src/main/java/com/seed/objectsWithImports/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/Stream.java
+++ b/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/Stream.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/Stream.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/Stream.java
+++ b/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/Stream.java
+++ b/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/Stream.java
+++ b/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/Stream.java
+++ b/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/Stream.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/Stream.java
+++ b/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/Stream.java
+++ b/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/server-sent-event-examples/src/main/java/com/seed/serverSentEvents/core/Stream.java
+++ b/seed/java-sdk/server-sent-event-examples/src/main/java/com/seed/serverSentEvents/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/Stream.java
+++ b/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/Stream.java
@@ -249,7 +249,6 @@ public final class Stream<T> implements Iterable<T>, Closeable {
                             dataContent = dataContent.substring(1);
                         }
 
-                        // Check for stream terminator only at event boundaries to prevent data loss
                         if (eventDataBuffer.length() == 0
                                 && streamTerminator != null
                                 && dataContent.trim().equals(streamTerminator)) {

--- a/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/Stream.java
+++ b/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/Stream.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/Stream.java
+++ b/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/Stream.java
+++ b/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/streaming/src/main/java/com/seed/streaming/core/Stream.java
+++ b/seed/java-sdk/streaming/src/main/java/com/seed/streaming/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/core/Stream.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/Stream.java
+++ b/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/Stream.java
+++ b/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/Stream.java
+++ b/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/validation/src/main/java/com/seed/validation/core/Stream.java
+++ b/seed/java-sdk/validation/src/main/java/com/seed/validation/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/variables/src/main/java/com/seed/variables/core/Stream.java
+++ b/seed/java-sdk/variables/src/main/java/com/seed/variables/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/Stream.java
+++ b/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/Stream.java
+++ b/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/Stream.java
+++ b/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/Stream.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/Stream.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/Stream.java
@@ -174,8 +174,8 @@ public final class Stream<T> implements Iterable<T>, Closeable {
         private T nextItem;
         private boolean hasNextItem = false;
         private boolean endOfStream = false;
-        private StringBuilder buffer = new StringBuilder();
-        private boolean prefixSeen = false;
+        private StringBuilder eventDataBuffer = new StringBuilder();
+        private String currentEventType = null;
 
         private SSEIterator() {
             if (sseReader != null && !isStreamClosed()) {
@@ -223,39 +223,69 @@ public final class Stream<T> implements Iterable<T>, Closeable {
 
             try {
                 while (sseScanner.hasNextLine()) {
-                    String chunk = sseScanner.nextLine();
-                    buffer.append(chunk).append(NEWLINE);
+                    String line = sseScanner.nextLine();
 
-                    int terminatorIndex;
-                    while ((terminatorIndex = buffer.indexOf(messageTerminator)) >= 0) {
-                        String line = buffer.substring(0, terminatorIndex + messageTerminator.length());
-                        buffer.delete(0, terminatorIndex + messageTerminator.length());
+                    if (line.trim().isEmpty()) {
+                        if (eventDataBuffer.length() > 0) {
+                            try {
+                                nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                                hasNextItem = true;
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                return true;
+                            } catch (Exception parseEx) {
+                                System.err.println("Failed to parse SSE event: " + parseEx.getMessage());
+                                eventDataBuffer.setLength(0);
+                                currentEventType = null;
+                                continue;
+                            }
+                        }
+                        continue;
+                    }
 
-                        line = line.trim();
-                        if (line.isEmpty()) {
-                            continue;
+                    if (line.startsWith(DATA_PREFIX)) {
+                        String dataContent = line.substring(DATA_PREFIX.length());
+                        if (dataContent.startsWith(" ")) {
+                            dataContent = dataContent.substring(1);
                         }
 
-                        if (!prefixSeen && line.startsWith(DATA_PREFIX)) {
-                            prefixSeen = true;
-                            line = line.substring(DATA_PREFIX.length()).trim();
-                        } else if (!prefixSeen) {
-                            continue;
-                        }
-
-                        if (streamTerminator != null && line.contains(streamTerminator)) {
+                        if (eventDataBuffer.length() == 0
+                                && streamTerminator != null
+                                && dataContent.trim().equals(streamTerminator)) {
                             endOfStream = true;
                             return false;
                         }
 
-                        try {
-                            nextItem = ObjectMappers.JSON_MAPPER.readValue(line, valueType);
-                            hasNextItem = true;
-                            prefixSeen = false;
-                            return true;
-                        } catch (Exception parseEx) {
-                            continue;
+                        if (eventDataBuffer.length() > 0) {
+                            eventDataBuffer.append('\n');
                         }
+                        eventDataBuffer.append(dataContent);
+                    } else if (line.startsWith("event:")) {
+                        String eventValue = line.length() > 6 ? line.substring(6) : "";
+                        if (eventValue.startsWith(" ")) {
+                            eventValue = eventValue.substring(1);
+                        }
+                        currentEventType = eventValue;
+                    } else if (line.startsWith("id:")) {
+                        // Event ID field (ignored)
+                    } else if (line.startsWith("retry:")) {
+                        // Retry field (ignored)
+                    } else if (line.startsWith(":")) {
+                        // Comment line (ignored)
+                    }
+                }
+
+                if (eventDataBuffer.length() > 0) {
+                    try {
+                        nextItem = ObjectMappers.JSON_MAPPER.readValue(eventDataBuffer.toString(), valueType);
+                        hasNextItem = true;
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
+                        return true;
+                    } catch (Exception parseEx) {
+                        System.err.println("Failed to parse final SSE event: " + parseEx.getMessage());
+                        eventDataBuffer.setLength(0);
+                        currentEventType = null;
                     }
                 }
 


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-6953/ci-use-package-balancer-output-in-seed-test
Closes FER-6953
Use output of nightly seed test balancer in every PR run instead of parallelizing alphabetically

## Changes Made
- Update get-test-matrix action file to be used by balanced seed groups and also by alphabetical seed groups (legacy support for update-seed until that is updated)
- New file `.github/actions/check-and-run-leftover-seed-tests/action.yaml` to handle checks and running of leftover seed tests that are not covered in the nightly groupings
- New file `.github/actions/handle-leftover-seed-tests/action.yaml` to determine what seed tests are leftovers
- Updated `.github/actions/handle-leftover-seed-tests/action.yaml` to start including output folders
- Updated for clearer name in `packages/seed/src/cli.ts`
- Add more tolerance to nightly run timeout for `.github/workflows/nightly-seed-grouping.yml`
- Updated `.github/actions/parse-test-matrix-output/action.yaml` to start including output folders
- Updating `.github/workflows/seed.yml` to use balanced groups now

## Testing
- Verified in CI in test branch here: https://github.com/fern-api/fern/actions/runs/18225134630
