### PR TITLE
fix(go): fix regression where go mod should not be generated for embedded packages

### DIFF
--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -53,6 +53,11 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
 
     public async writeGoMod(): Promise<void> {
         const moduleConfig = this.getModuleConfig({ config: this.context.config });
+        // do not write a go.mod file in situations where this is an embedded local package
+        // (use of importPath: https://buildwithfern.com/learn/sdks/generators/go/configuration#importpath)
+        if (moduleConfig == null) {
+            return;
+        }
         // We write the go.mod file to disk upfront so that 'go fmt' can be run on the project.
         const moduleConfigWriter = new ModuleConfigWriter({ context: this.context, moduleConfig });
         await this.writeRawFile(moduleConfigWriter.generate());
@@ -195,12 +200,28 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
         });
     }
 
-    private getModuleConfig({ config }: { config: FernGeneratorExec.config.GeneratorConfig }): ModuleConfig {
+    private getModuleConfig({
+        config
+    }: {
+        config: FernGeneratorExec.config.GeneratorConfig;
+    }): ModuleConfig | undefined {
         const outputMode = config.output.mode as OutputMode;
         switch (outputMode.type) {
             case "github":
-            case "downloadFiles":
             case "publish": {
+                // always generate a go.mod file if the output mode is github or publish
+                const modulePath = resolveRootModulePath({ config, customConfig: this.context.customConfig });
+                return {
+                    path: modulePath,
+                    version: this.context.customConfig.module?.version ?? ModuleConfig.DEFAULT.version,
+                    imports: this.context.customConfig.module?.imports ?? ModuleConfig.DEFAULT.imports
+                };
+            }
+            case "downloadFiles": {
+                // importPath provided, but no module config => this is to be used as an embedded local package (not a module)
+                if (this.context.customConfig.module == null && this.context.customConfig.importPath != null) {
+                    return undefined;
+                }
                 const modulePath = resolveRootModulePath({ config, customConfig: this.context.customConfig });
                 return {
                     path: modulePath,

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -7,6 +7,14 @@
   createdAt: "2025-10-03"
   irVersion: 60
 
+- version: 1.13.9
+  changelogEntry:
+    - summary: |
+        fix regression - v2 should not produce go.mod files for embedded local packages (use of importPath option)
+      type: fix
+  createdAt: "2025-10-02"
+  irVersion: 60
+
 - version: 1.13.8
   changelogEntry:
     - summary: |

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,18 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 1.13.10
+  changelogEntry:
+    - summary: |
+        fix regression - v2 should not produce go.mod files for embedded local packages (use of importPath option)
+      type: fix
+  createdAt: "2025-10-06"
+  irVersion: 60
+
 - version: 1.13.9
   changelogEntry:
     - summary: |
         Fix code snippets in the README to alias root imports with the configured package name.
       type: fix
   createdAt: "2025-10-03"
-  irVersion: 60
-
-- version: 1.13.9
-  changelogEntry:
-    - summary: |
-        fix regression - v2 should not produce go.mod files for embedded local packages (use of importPath option)
-      type: fix
-  createdAt: "2025-10-02"
   irVersion: 60
 
 - version: 1.13.8


### PR DESCRIPTION
I realized that I created a regression in behavior around the `importPath` custom config option based on this [customer slack thread](https://buildwithfern.slack.com/archives/C074BUNTB2Q/p1759269249859649?thread_ts=1756483900.871999&cid=C074BUNTB2Q) by always generating a go.mod in the v2 generator (v1 generator logic is intact which helped me realize the desired behavior here). This is another example of a bug introduced by v1 and v2 generator logic running side-by-side which confuses the desired behavior.