### PR TITLE
chore(rust): Disable doctests and export root client in SDK generator

### DIFF
--- a/generators/rust/base/src/asIs/Cargo.toml
+++ b/generators/rust/base/src/asIs/Cargo.toml
@@ -3,6 +3,9 @@ name = "{{PACKAGE_NAME}}"
 version = "{{PACKAGE_VERSION}}"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -497,6 +497,8 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             }
         });
 
+        // add main root client
+        exports.push(context.getClientName());
         return exports;
     }
 }

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.5.4
+  createdAt: "2025-10-03"
+  changelogEntry:
+    - type: chore
+      summary: Disable doctests and export root client in generator
+
 - version: 0.5.3
   createdAt: "2025-10-03"
   changelogEntry:

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -5,6 +5,7 @@
   changelogEntry:
     - type: chore
       summary: Disable doctests and export root client in generator
+  irVersion: 59
 
 - version: 0.5.3
   createdAt: "2025-10-03"

--- a/seed/rust-sdk/accept-header/Cargo.toml
+++ b/seed/rust-sdk/accept-header/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_accept"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/accept-header/src/api/mod.rs
+++ b/seed/rust-sdk/accept-header/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{AcceptClient, ServiceClient};

--- a/seed/rust-sdk/alias-extends/Cargo.toml
+++ b/seed/rust-sdk/alias-extends/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_alias_extends"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/alias-extends/src/api/mod.rs
+++ b/seed/rust-sdk/alias-extends/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::AliasExtendsClient;
 pub use types::*;

--- a/seed/rust-sdk/alias/Cargo.toml
+++ b/seed/rust-sdk/alias/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_alias"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/alias/src/api/mod.rs
+++ b/seed/rust-sdk/alias/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::AliasClient;
 pub use types::*;

--- a/seed/rust-sdk/any-auth/Cargo.toml
+++ b/seed/rust-sdk/any-auth/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_any_auth"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/any-auth/src/api/mod.rs
+++ b/seed/rust-sdk/any-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, UserClient};
+pub use resources::{AnyAuthClient, AuthClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/api-wide-base-path/Cargo.toml
+++ b/seed/rust-sdk/api-wide-base-path/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api_wide_base_path"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/api-wide-base-path/src/api/mod.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{ApiWideBasePathClient, ServiceClient};

--- a/seed/rust-sdk/audiences/Cargo.toml
+++ b/seed/rust-sdk/audiences/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_audiences"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/audiences/src/api/mod.rs
+++ b/seed/rust-sdk/audiences/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod resources;
 pub mod types;
 
 pub use resources::{
-    CommonsClient, FolderAClient, FolderBClient, FolderCClient, FolderDClient, FooClient,
+    AudiencesClient, CommonsClient, FolderAClient, FolderBClient, FolderCClient, FolderDClient,
+    FooClient,
 };
 pub use types::*;

--- a/seed/rust-sdk/auth-environment-variables/Cargo.toml
+++ b/seed/rust-sdk/auth-environment-variables/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_auth_environment_variables"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/auth-environment-variables/src/api/mod.rs
+++ b/seed/rust-sdk/auth-environment-variables/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{AuthEnvironmentVariablesClient, ServiceClient};

--- a/seed/rust-sdk/basic-auth-environment-variables/Cargo.toml
+++ b/seed/rust-sdk/basic-auth-environment-variables/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_basic_auth_environment_variables"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/basic-auth-environment-variables/src/api/mod.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{BasicAuthClient, ErrorsClient};
+pub use resources::{BasicAuthClient, BasicAuthEnvironmentVariablesClient, ErrorsClient};
 pub use types::*;

--- a/seed/rust-sdk/basic-auth/Cargo.toml
+++ b/seed/rust-sdk/basic-auth/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_basic_auth"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/basic-auth/src/api/mod.rs
+++ b/seed/rust-sdk/basic-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{BasicAuthClient, ErrorsClient};
+pub use resources::{BasicAuthClient, BasicAuthClient, ErrorsClient};
 pub use types::*;

--- a/seed/rust-sdk/bearer-token-environment-variable/Cargo.toml
+++ b/seed/rust-sdk/bearer-token-environment-variable/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_bearer_token_environment_variable"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/bearer-token-environment-variable/src/api/mod.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{BearerTokenEnvironmentVariableClient, ServiceClient};

--- a/seed/rust-sdk/bytes-upload/Cargo.toml
+++ b/seed/rust-sdk/bytes-upload/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_bytes_upload"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/bytes-upload/src/api/mod.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{BytesUploadClient, ServiceClient};

--- a/seed/rust-sdk/client-side-params/Cargo.toml
+++ b/seed/rust-sdk/client-side-params/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_client_side_params"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/client-side-params/src/api/mod.rs
+++ b/seed/rust-sdk/client-side-params/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{ServiceClient, TypesClient};
+pub use resources::{ClientSideParamsClient, ServiceClient, TypesClient};
 pub use types::*;

--- a/seed/rust-sdk/content-type/Cargo.toml
+++ b/seed/rust-sdk/content-type/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_content_types"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/content-type/src/api/mod.rs
+++ b/seed/rust-sdk/content-type/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{ContentTypesClient, ServiceClient};

--- a/seed/rust-sdk/cross-package-type-names/Cargo.toml
+++ b/seed/rust-sdk/cross-package-type-names/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_cross_package_type_names"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/cross-package-type-names/src/api/mod.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod resources;
 pub mod types;
 
 pub use resources::{
-    CommonsClient, FolderAClient, FolderBClient, FolderCClient, FolderDClient, FooClient,
+    CommonsClient, CrossPackageTypeNamesClient, FolderAClient, FolderBClient, FolderCClient,
+    FolderDClient, FooClient,
 };
 pub use types::*;

--- a/seed/rust-sdk/custom-auth/Cargo.toml
+++ b/seed/rust-sdk/custom-auth/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_custom_auth"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/custom-auth/src/api/mod.rs
+++ b/seed/rust-sdk/custom-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{CustomAuthClient, ErrorsClient};
+pub use resources::{CustomAuthClient, CustomAuthClient, ErrorsClient};
 pub use types::*;

--- a/seed/rust-sdk/enum/Cargo.toml
+++ b/seed/rust-sdk/enum/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_enum"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/enum/src/api/mod.rs
+++ b/seed/rust-sdk/enum/src/api/mod.rs
@@ -1,6 +1,6 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{HeadersClient, InlinedRequestClient, PathParamClient, QueryParamClient, UnknownClient};
+pub use resources::{HeadersClient, InlinedRequestClient, PathParamClient, QueryParamClient, UnknownClient, EnumClient};
 pub use types::{*};
 

--- a/seed/rust-sdk/error-property/Cargo.toml
+++ b/seed/rust-sdk/error-property/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_error_property"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/error-property/src/api/mod.rs
+++ b/seed/rust-sdk/error-property/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{ErrorsClient, PropertyBasedErrorClient};
+pub use resources::{ErrorPropertyClient, ErrorsClient, PropertyBasedErrorClient};
 pub use types::*;

--- a/seed/rust-sdk/errors/Cargo.toml
+++ b/seed/rust-sdk/errors/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_errors"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/errors/src/api/mod.rs
+++ b/seed/rust-sdk/errors/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{CommonsClient, SimpleClient};
+pub use resources::{CommonsClient, ErrorsClient, SimpleClient};
 pub use types::*;

--- a/seed/rust-sdk/examples/no-custom-config/Cargo.toml
+++ b/seed/rust-sdk/examples/no-custom-config/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_examples"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/examples/no-custom-config/src/api/mod.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{CommonsClient, FileClient, HealthClient, ServiceClient, TypesClient};
+pub use resources::{
+    CommonsClient, ExamplesClient, FileClient, HealthClient, ServiceClient, TypesClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/examples/readme-config/Cargo.toml
+++ b/seed/rust-sdk/examples/readme-config/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_examples"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/examples/readme-config/src/api/mod.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{CommonsClient, FileClient, HealthClient, ServiceClient, TypesClient};
+pub use resources::{
+    CommonsClient, ExamplesClient, FileClient, HealthClient, ServiceClient, TypesClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/exhaustive/Cargo.toml
+++ b/seed/rust-sdk/exhaustive/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_exhaustive"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/exhaustive/src/api/mod.rs
+++ b/seed/rust-sdk/exhaustive/src/api/mod.rs
@@ -2,7 +2,7 @@ pub mod resources;
 pub mod types;
 
 pub use resources::{
-    EndpointsClient, GeneralErrorsClient, InlinedRequestsClient, NoAuthClient, NoReqBodyClient,
-    ReqWithHeadersClient, TypesClient,
+    EndpointsClient, ExhaustiveClient, GeneralErrorsClient, InlinedRequestsClient, NoAuthClient,
+    NoReqBodyClient, ReqWithHeadersClient, TypesClient,
 };
 pub use types::*;

--- a/seed/rust-sdk/extends/Cargo.toml
+++ b/seed/rust-sdk/extends/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_extends"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/extends/src/api/mod.rs
+++ b/seed/rust-sdk/extends/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::ExtendsClient;
 pub use types::*;

--- a/seed/rust-sdk/extra-properties/Cargo.toml
+++ b/seed/rust-sdk/extra-properties/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_extra_properties"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/extra-properties/src/api/mod.rs
+++ b/seed/rust-sdk/extra-properties/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{ExtraPropertiesClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/file-download/Cargo.toml
+++ b/seed/rust-sdk/file-download/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_file_download"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/file-download/src/api/mod.rs
+++ b/seed/rust-sdk/file-download/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{FileDownloadClient, ServiceClient};

--- a/seed/rust-sdk/file-upload/Cargo.toml
+++ b/seed/rust-sdk/file-upload/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_file_upload"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/file-upload/src/api/mod.rs
+++ b/seed/rust-sdk/file-upload/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::ServiceClient;
+pub use resources::{FileUploadClient, ServiceClient};
 pub use types::*;

--- a/seed/rust-sdk/folders/Cargo.toml
+++ b/seed/rust-sdk/folders/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/folders/src/api/mod.rs
+++ b/seed/rust-sdk/folders/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AClient, FolderClient};
+pub use resources::{AClient, ApiClient, FolderClient};
 pub use types::*;

--- a/seed/rust-sdk/http-head/Cargo.toml
+++ b/seed/rust-sdk/http-head/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_http_head"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/http-head/src/api/mod.rs
+++ b/seed/rust-sdk/http-head/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{HttpHeadClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/idempotency-headers/Cargo.toml
+++ b/seed/rust-sdk/idempotency-headers/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_idempotency_headers"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/idempotency-headers/src/api/mod.rs
+++ b/seed/rust-sdk/idempotency-headers/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::PaymentClient;
+pub use resources::{IdempotencyHeadersClient, PaymentClient};
 pub use types::*;

--- a/seed/rust-sdk/imdb/imdb-custom-config/Cargo.toml
+++ b/seed/rust-sdk/imdb/imdb-custom-config/Cargo.toml
@@ -3,6 +3,9 @@ name = "custom_imdb_sdk"
 version = "2.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/api/mod.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::ImdbClient;
+pub use resources::{CustomImdbClient, ImdbClient};
 pub use types::*;

--- a/seed/rust-sdk/imdb/imdb/Cargo.toml
+++ b/seed/rust-sdk/imdb/imdb/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/imdb/imdb/src/api/mod.rs
+++ b/seed/rust-sdk/imdb/imdb/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::ImdbClient;
+pub use resources::{ApiClient, ImdbClient};
 pub use types::*;

--- a/seed/rust-sdk/inferred-auth-explicit/Cargo.toml
+++ b/seed/rust-sdk/inferred-auth-explicit/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_inferred_auth_explicit"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/inferred-auth-explicit/src/api/mod.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, InferredAuthExplicitClient, NestedClient, NestedNoAuthClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/Cargo.toml
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_inferred_auth_implicit_no_expiry"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, InferredAuthImplicitNoExpiryClient, NestedClient, NestedNoAuthClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/inferred-auth-implicit/Cargo.toml
+++ b/seed/rust-sdk/inferred-auth-implicit/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_inferred_auth_implicit"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/inferred-auth-implicit/src/api/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, InferredAuthImplicitClient, NestedClient, NestedNoAuthClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/license/Cargo.toml
+++ b/seed/rust-sdk/license/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_license"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/license/src/api/mod.rs
+++ b/seed/rust-sdk/license/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::LicenseClient;
 pub use types::*;

--- a/seed/rust-sdk/literal/Cargo.toml
+++ b/seed/rust-sdk/literal/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_literal"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/literal/src/api/mod.rs
+++ b/seed/rust-sdk/literal/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{HeadersClient, InlinedClient, PathClient, QueryClient, ReferenceClient};
+pub use resources::{
+    HeadersClient, InlinedClient, LiteralClient, PathClient, QueryClient, ReferenceClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/mixed-case/Cargo.toml
+++ b/seed/rust-sdk/mixed-case/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_mixed_case"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/mixed-case/src/api/mod.rs
+++ b/seed/rust-sdk/mixed-case/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::ServiceClient;
+pub use resources::{MixedCaseClient, ServiceClient};
 pub use types::*;

--- a/seed/rust-sdk/mixed-file-directory/Cargo.toml
+++ b/seed/rust-sdk/mixed-file-directory/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_mixed_file_directory"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/mixed-file-directory/src/api/mod.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{OrganizationClient, UserClient};
+pub use resources::{MixedFileDirectoryClient, OrganizationClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/multi-line-docs/Cargo.toml
+++ b/seed/rust-sdk/multi-line-docs/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_multi_line_docs"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/multi-line-docs/src/api/mod.rs
+++ b/seed/rust-sdk/multi-line-docs/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{MultiLineDocsClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/multi-url-environment-no-default/Cargo.toml
+++ b/seed/rust-sdk/multi-url-environment-no-default/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_multi_url_environment_no_default"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/multi-url-environment-no-default/src/api/mod.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::{Ec2Client, S3Client};
+pub use resources::{Ec2Client, MultiUrlEnvironmentNoDefaultClient, S3Client};

--- a/seed/rust-sdk/multi-url-environment/Cargo.toml
+++ b/seed/rust-sdk/multi-url-environment/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_multi_url_environment"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/multi-url-environment/src/api/mod.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::{Ec2Client, S3Client};
+pub use resources::{Ec2Client, MultiUrlEnvironmentClient, S3Client};

--- a/seed/rust-sdk/multiple-request-bodies/Cargo.toml
+++ b/seed/rust-sdk/multiple-request-bodies/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/multiple-request-bodies/src/api/mod.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/no-environment/Cargo.toml
+++ b/seed/rust-sdk/no-environment/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_no_environment"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/no-environment/src/api/mod.rs
+++ b/seed/rust-sdk/no-environment/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::DummyClient;
+pub use resources::{DummyClient, NoEnvironmentClient};

--- a/seed/rust-sdk/nullable-optional/Cargo.toml
+++ b/seed/rust-sdk/nullable-optional/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_nullable_optional"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/nullable-optional/src/api/mod.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::NullableOptionalClient;
+pub use resources::{NullableOptionalClient, NullableOptionalClient};
 pub use types::*;

--- a/seed/rust-sdk/nullable/Cargo.toml
+++ b/seed/rust-sdk/nullable/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_nullable"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/nullable/src/api/mod.rs
+++ b/seed/rust-sdk/nullable/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::NullableClient;
+pub use resources::{NullableClient, NullableClient};
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-custom/Cargo.toml
+++ b/seed/rust-sdk/oauth-client-credentials-custom/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_oauth_client_credentials"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, NestedClient, NestedNoAuthClient, OauthClientCredentialsClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-default/Cargo.toml
+++ b/seed/rust-sdk/oauth-client-credentials-default/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_oauth_client_credentials_default"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/oauth-client-credentials-default/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, NestedClient, NestedNoAuthClient, OauthClientCredentialsDefaultClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/Cargo.toml
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_oauth_client_credentials_environment_variables"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/api/mod.rs
@@ -1,5 +1,8 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, NestedClient, NestedNoAuthClient, OauthClientCredentialsEnvironmentVariablesClient,
+    SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/Cargo.toml
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_oauth_client_credentials"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, NestedClient, NestedNoAuthClient, OauthClientCredentialsClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/Cargo.toml
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_oauth_client_credentials_with_variables"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/api/mod.rs
@@ -1,5 +1,8 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, ServiceClient, SimpleClient};
+pub use resources::{
+    AuthClient, NestedClient, NestedNoAuthClient, OauthClientCredentialsWithVariablesClient,
+    ServiceClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/oauth-client-credentials/Cargo.toml
+++ b/seed/rust-sdk/oauth-client-credentials/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_oauth_client_credentials"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/oauth-client-credentials/src/api/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/api/mod.rs
@@ -1,5 +1,7 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, NestedClient, NestedNoAuthClient, SimpleClient};
+pub use resources::{
+    AuthClient, NestedClient, NestedNoAuthClient, OauthClientCredentialsClient, SimpleClient,
+};
 pub use types::*;

--- a/seed/rust-sdk/optional/Cargo.toml
+++ b/seed/rust-sdk/optional/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_objects_with_imports"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/optional/src/api/mod.rs
+++ b/seed/rust-sdk/optional/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::OptionalClient;
+pub use resources::{ObjectsWithImportsClient, OptionalClient};

--- a/seed/rust-sdk/package-yml/Cargo.toml
+++ b/seed/rust-sdk/package-yml/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_package_yml"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/package-yml/src/api/mod.rs
+++ b/seed/rust-sdk/package-yml/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::ServiceClient;
+pub use resources::{PackageYmlClient, ServiceClient};
 pub use types::*;

--- a/seed/rust-sdk/pagination-custom/Cargo.toml
+++ b/seed/rust-sdk/pagination-custom/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_pagination"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/pagination-custom/src/api/mod.rs
+++ b/seed/rust-sdk/pagination-custom/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UsersClient;
+pub use resources::{PaginationClient, UsersClient};
 pub use types::*;

--- a/seed/rust-sdk/pagination/Cargo.toml
+++ b/seed/rust-sdk/pagination/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_pagination"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/pagination/src/api/mod.rs
+++ b/seed/rust-sdk/pagination/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{ComplexClient, InlineUsersClient, UsersClient};
+pub use resources::{ComplexClient, InlineUsersClient, PaginationClient, UsersClient};
 pub use types::*;

--- a/seed/rust-sdk/path-parameters/Cargo.toml
+++ b/seed/rust-sdk/path-parameters/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_path_parameters"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/path-parameters/src/api/mod.rs
+++ b/seed/rust-sdk/path-parameters/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{OrganizationsClient, UserClient};
+pub use resources::{OrganizationsClient, PathParametersClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/plain-text/Cargo.toml
+++ b/seed/rust-sdk/plain-text/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_plain_text"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/plain-text/src/api/mod.rs
+++ b/seed/rust-sdk/plain-text/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{PlainTextClient, ServiceClient};

--- a/seed/rust-sdk/property-access/Cargo.toml
+++ b/seed/rust-sdk/property-access/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_property_access"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/property-access/src/api/mod.rs
+++ b/seed/rust-sdk/property-access/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::PropertyAccessClient;
 pub use types::*;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/Cargo.toml
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/query-parameters-openapi/Cargo.toml
+++ b/seed/rust-sdk/query-parameters-openapi/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/query-parameters-openapi/src/api/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/query-parameters/Cargo.toml
+++ b/seed/rust-sdk/query-parameters/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_query_parameters"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/query-parameters/src/api/mod.rs
+++ b/seed/rust-sdk/query-parameters/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{QueryParametersClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/request-parameters/Cargo.toml
+++ b/seed/rust-sdk/request-parameters/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_request_parameters"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/request-parameters/src/api/mod.rs
+++ b/seed/rust-sdk/request-parameters/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{RequestParametersClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/required-nullable/Cargo.toml
+++ b/seed/rust-sdk/required-nullable/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/required-nullable/src/api/mod.rs
+++ b/seed/rust-sdk/required-nullable/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/reserved-keywords/Cargo.toml
+++ b/seed/rust-sdk/reserved-keywords/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_nursery_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/reserved-keywords/src/api/mod.rs
+++ b/seed/rust-sdk/reserved-keywords/src/api/mod.rs
@@ -1,6 +1,6 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{PackageClient};
+pub use resources::{PackageClient, NurseryApiClient};
 pub use types::{*};
 

--- a/seed/rust-sdk/response-property/Cargo.toml
+++ b/seed/rust-sdk/response-property/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_response_property"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/response-property/src/api/mod.rs
+++ b/seed/rust-sdk/response-property/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::ServiceClient;
+pub use resources::{ResponsePropertyClient, ServiceClient};
 pub use types::*;

--- a/seed/rust-sdk/server-sent-event-examples/Cargo.toml
+++ b/seed/rust-sdk/server-sent-event-examples/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_server_sent_events"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/server-sent-event-examples/src/api/mod.rs
+++ b/seed/rust-sdk/server-sent-event-examples/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::CompletionsClient;
+pub use resources::{CompletionsClient, ServerSentEventsClient};
 pub use types::*;

--- a/seed/rust-sdk/server-sent-events/Cargo.toml
+++ b/seed/rust-sdk/server-sent-events/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_server_sent_events"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/server-sent-events/src/api/mod.rs
+++ b/seed/rust-sdk/server-sent-events/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::CompletionsClient;
+pub use resources::{CompletionsClient, ServerSentEventsClient};
 pub use types::*;

--- a/seed/rust-sdk/simple-api/Cargo.toml
+++ b/seed/rust-sdk/simple-api/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_simple_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/simple-api/src/api/mod.rs
+++ b/seed/rust-sdk/simple-api/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{SimpleApiClient, UserClient};
 pub use types::*;

--- a/seed/rust-sdk/simple-fhir/Cargo.toml
+++ b/seed/rust-sdk/simple-fhir/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_api"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/simple-fhir/src/api/mod.rs
+++ b/seed/rust-sdk/simple-fhir/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::ApiClient;
 pub use types::*;

--- a/seed/rust-sdk/single-url-environment-default/basic/Cargo.toml
+++ b/seed/rust-sdk/single-url-environment-default/basic/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_single_url_environment_default"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/single-url-environment-default/basic/src/api/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::DummyClient;
+pub use resources::{DummyClient, SingleUrlEnvironmentDefaultClient};

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/Cargo.toml
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/Cargo.toml
@@ -3,6 +3,9 @@ name = "environment_test_sdk"
 version = "0.2.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/api/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::DummyClient;
+pub use resources::{DummyClient, SingleUrlEnvironmentDefaultClient};

--- a/seed/rust-sdk/single-url-environment-default/full-custom/Cargo.toml
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/Cargo.toml
@@ -3,6 +3,9 @@ name = "full_custom_sdk"
 version = "1.0.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/api/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::DummyClient;
+pub use resources::{DummyClient, SingleUrlEnvironmentDefaultClient};

--- a/seed/rust-sdk/single-url-environment-no-default/Cargo.toml
+++ b/seed/rust-sdk/single-url-environment-no-default/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_single_url_environment_no_default"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/single-url-environment-no-default/src/api/mod.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::DummyClient;
+pub use resources::{DummyClient, SingleUrlEnvironmentNoDefaultClient};

--- a/seed/rust-sdk/streaming-parameter/Cargo.toml
+++ b/seed/rust-sdk/streaming-parameter/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_streaming"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/streaming-parameter/src/api/mod.rs
+++ b/seed/rust-sdk/streaming-parameter/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::DummyClient;
+pub use resources::{DummyClient, StreamingClient};
 pub use types::*;

--- a/seed/rust-sdk/streaming/Cargo.toml
+++ b/seed/rust-sdk/streaming/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_streaming"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/streaming/src/api/mod.rs
+++ b/seed/rust-sdk/streaming/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::DummyClient;
+pub use resources::{DummyClient, StreamingClient};
 pub use types::*;

--- a/seed/rust-sdk/trace/Cargo.toml
+++ b/seed/rust-sdk/trace/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_trace"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/trace/src/api/mod.rs
+++ b/seed/rust-sdk/trace/src/api/mod.rs
@@ -3,6 +3,6 @@ pub mod types;
 
 pub use resources::{
     AdminClient, CommonsClient, HomepageClient, LangServerClient, MigrationClient, PlaylistClient,
-    ProblemClient, SubmissionClient, SyspropClient, V2Client,
+    ProblemClient, SubmissionClient, SyspropClient, TraceClient, V2Client,
 };
 pub use types::*;

--- a/seed/rust-sdk/undiscriminated-unions/Cargo.toml
+++ b/seed/rust-sdk/undiscriminated-unions/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_undiscriminated_unions"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/undiscriminated-unions/src/api/mod.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UnionClient;
+pub use resources::{UndiscriminatedUnionsClient, UnionClient};
 pub use types::*;

--- a/seed/rust-sdk/unions/Cargo.toml
+++ b/seed/rust-sdk/unions/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_unions"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/unions/src/api/mod.rs
+++ b/seed/rust-sdk/unions/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{BigunionClient, TypesClient, UnionClient};
+pub use resources::{BigunionClient, TypesClient, UnionClient, UnionsClient};
 pub use types::*;

--- a/seed/rust-sdk/unknown/Cargo.toml
+++ b/seed/rust-sdk/unknown/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_unknown_as_any"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/unknown/src/api/mod.rs
+++ b/seed/rust-sdk/unknown/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UnknownClient;
+pub use resources::{UnknownAsAnyClient, UnknownClient};
 pub use types::*;

--- a/seed/rust-sdk/validation/Cargo.toml
+++ b/seed/rust-sdk/validation/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_validation"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/validation/src/api/mod.rs
+++ b/seed/rust-sdk/validation/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod resources;
 pub mod types;
 
+pub use resources::{ValidationClient};
 pub use types::{*};
 

--- a/seed/rust-sdk/variables/Cargo.toml
+++ b/seed/rust-sdk/variables/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_variables"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/variables/src/api/mod.rs
+++ b/seed/rust-sdk/variables/src/api/mod.rs
@@ -1,3 +1,3 @@
 pub mod resources;
 
-pub use resources::ServiceClient;
+pub use resources::{ServiceClient, VariablesClient};

--- a/seed/rust-sdk/version-no-default/Cargo.toml
+++ b/seed/rust-sdk/version-no-default/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_version"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/version-no-default/src/api/mod.rs
+++ b/seed/rust-sdk/version-no-default/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{UserClient, VersionClient};
 pub use types::*;

--- a/seed/rust-sdk/version/Cargo.toml
+++ b/seed/rust-sdk/version/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_version"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/version/src/api/mod.rs
+++ b/seed/rust-sdk/version/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::UserClient;
+pub use resources::{UserClient, VersionClient};
 pub use types::*;

--- a/seed/rust-sdk/websocket-inferred-auth/Cargo.toml
+++ b/seed/rust-sdk/websocket-inferred-auth/Cargo.toml
@@ -3,6 +3,9 @@ name = "seed_websocket_auth"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/seed/rust-sdk/websocket-inferred-auth/src/api/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/api/mod.rs
@@ -1,5 +1,5 @@
 pub mod resources;
 pub mod types;
 
-pub use resources::{AuthClient, RealtimeClient};
+pub use resources::{AuthClient, RealtimeClient, WebsocketAuthClient};
 pub use types::*;


### PR DESCRIPTION
## Description

Linear ticket: https://linear.app/buildwithfern/issue/FER-7041/docs-comment-failure-cargo-test

Disables doctests in the Rust base `Cargo.toml` to prevent running documentation tests. Also updates SdkGeneratorCli to ensure the main `root` client is exported, improving SDK usability.