### PR TITLE
chore(ci): Add manually created python-sdk seed group file

### DIFF
--- a/.github/workflow-resource-files/seed-groups/python-sdk-seed-groups.json
+++ b/.github/workflow-resource-files/seed-groups/python-sdk-seed-groups.json
@@ -1,0 +1,206 @@
+{
+  "totalTestTimeSeconds": 10000,
+  "groups": [
+    {
+      "fixtures": [
+        "examples:readme",
+        "validation:with-defaults",
+        "single-url-environment-no-default",
+        "exhaustive:inline_request_params",
+        "empty-clients",
+        "multi-url-environment",
+        "enum:real-enum-forward-compat"
+      ],
+      "groupTotalTimeSeconds": 194
+    },
+    {
+      "fixtures": [
+        "exhaustive:extra_dependencies",
+        "single-url-environment-default",
+        "exhaustive:additional_init_exports",
+        "bytes-upload",
+        "mixed-file-directory:no-custom-config",
+        "basic-auth"
+      ],
+      "groupTotalTimeSeconds": 193
+    },
+    {
+      "fixtures": [
+        "validation:no-custom-config",
+        "undiscriminated-unions",
+        "inferred-auth-explicit",
+        "bearer-token-environment-variable",
+        "file-download:no-custom-config",
+        "error-property",
+        "package-yml",
+        "imdb"
+      ],
+      "groupTotalTimeSeconds": 199
+    },
+    {
+      "fixtures": [
+        "variables",
+        "file-upload:use_typeddict_requests",
+        "auth-environment-variables",
+        "extends",
+        "enum:real-enum",
+        "object",
+        "idempotency-headers"
+      ],
+      "groupTotalTimeSeconds": 196
+    },
+    {
+      "fixtures": [
+        "circular-references:no-custom-config",
+        "reserved-keywords",
+        "oauth-client-credentials-with-variables",
+        "exhaustive:improved_imports",
+        "alias",
+        "exhaustive:aliases_with_validation",
+        "enum:no-custom-config",
+        "nullable:no-custom-config",
+        "file-download:default-chunk-size"
+      ],
+      "groupTotalTimeSeconds": 194
+    },
+    {
+      "fixtures": [
+        "circular-references:no-inheritance-for-extended-models",
+        "server-sent-event-examples",
+        "pagination:no-custom-config",
+        "exhaustive:skip-pydantic-validation",
+        "alias-extends:no-inheritance-for-extended-models",
+        "exhaustive:eager-imports",
+        "enum:strenum",
+        "nullable:use-typeddict-requests",
+        "file-upload:no-custom-config"
+      ],
+      "groupTotalTimeSeconds": 194
+    },
+    {
+      "fixtures": [
+        "websocket-inferred-auth",
+        "exhaustive:no-custom-config",
+        "oauth-client-credentials-default",
+        "exhaustive:pyproject_extras",
+        "accept-header",
+        "exhaustive:follow_redirects_by_default",
+        "client-side-params",
+        "mixed-file-directory:exclude_types_from_init_exports",
+        "content-type"
+      ],
+      "groupTotalTimeSeconds": 193
+    },
+    {
+      "fixtures": [
+        "circular-references-advanced:no-inheritance-for-extended-models",
+        "examples:no-custom-config",
+        "plain-text",
+        "oauth-client-credentials-custom",
+        "exhaustive:pydantic-v1-with-utils",
+        "query-parameters:no-custom-config",
+        "exhaustive:pydantic-v1",
+        "api-wide-base-path",
+        "file-upload:exclude_types_from_init_exports",
+        "unions:union-utils",
+        "multi-url-environment-no-default"
+      ],
+      "groupTotalTimeSeconds": 200
+    },
+    {
+      "fixtures": [
+        "server-sent-events",
+        "version-no-default",
+        "nullable-optional",
+        "optional",
+        "exhaustive:pydantic-ignore-fields",
+        "request-parameters",
+        "exhaustive:pydantic-v1-wrapped",
+        "audiences",
+        "folders",
+        "unions:union-naming-v1",
+        "multiple-request-bodies"
+      ],
+      "groupTotalTimeSeconds": 200
+    },
+    {
+      "fixtures": [
+        "simple-api",
+        "exhaustive:deps_with_min_python_version",
+        "exhaustive:extra_dev_dependencies",
+        "exhaustive:aliases_without_validation",
+        "public-object",
+        "simple-fhir:no-inheritance-for-extended-models",
+        "exhaustive:pydantic-extra-fields",
+        "basic-auth-environment-variables",
+        "http-head",
+        "websocket:websocket-base",
+        "pagination-custom"
+      ],
+      "groupTotalTimeSeconds": 194
+    },
+    {
+      "fixtures": [
+        "property-access",
+        "query-parameters-openapi:no-custom-config",
+        "trace",
+        "inferred-auth-implicit",
+        "exhaustive:inline-path-params",
+        "inferred-auth-implicit-no-expiry",
+        "bytes-download",
+        "license",
+        "literal:no-custom-config",
+        "websocket:websocket-with_generated_clients"
+      ],
+      "groupTotalTimeSeconds": 192
+    },
+    {
+      "fixtures": [
+        "unknown",
+        "query-parameters-openapi-as-objects:no-custom-config",
+        "examples:client-filename",
+        "examples:legacy-wire-tests",
+        "pagination:no-inheritance-for-extended-models",
+        "oauth-client-credentials-environment-variables",
+        "cross-package-type-names",
+        "no-environment",
+        "literal:use_typeddict_requests",
+        "websocket-bearer-auth"
+      ],
+      "groupTotalTimeSeconds": 192
+    },
+    {
+      "fixtures": [
+        "path-parameters",
+        "streaming:no-custom-config",
+        "exhaustive:pydantic-v2-wrapped",
+        "exhaustive:infinite-timeout",
+        "oauth-client-credentials-nested-root",
+        "custom-auth",
+        "alias-extends:no-custom-config",
+        "errors",
+        "response-property",
+        "literals-unions"
+      ],
+      "groupTotalTimeSeconds": 199
+    },
+    {
+      "fixtures": [
+        "streaming:skip-pydantic-validation",
+        "streaming-parameter",
+        "required-nullable",
+        "version",
+        "mixed-case",
+        "oauth-client-credentials",
+        "exhaustive:five-second-timeout",
+        "objects-with-imports",
+        "exhaustive:union-utils",
+        "any-auth",
+        "extra-properties",
+        "unions:no-custom-config",
+        "multi-line-docs"
+      ],
+      "groupTotalTimeSeconds": 199
+    }
+  ]
+}

--- a/.github/workflows/nightly-seed-grouping.yml
+++ b/.github/workflows/nightly-seed-grouping.yml
@@ -128,6 +128,8 @@ jobs:
         include:
           - number-of-groups-override: 14 # java-sdk override since this one is taking a while
             sdk-name: java-sdk
+          - number-of-groups-override: 14 # python-sdk override since this one is taking a while
+            sdk-name: python-sdk
     steps:
       - name: Make artifacts directory
         shell: bash

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -3,7 +3,8 @@ name: Seed Snapshot Tests
 on:
   push:
     branches:
-      - main
+      # CHRISM - temp
+      - mallinson/test-python-with-file
   # Note: pull request trigger will be removed once repository_dispatch trigger is verified
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -133,7 +134,7 @@ jobs:
             ruby-sdk,
             ruby-sdk-v2,
             pydantic,
-            # python-sdk, TODO FER-6998: figure out why python-sdk is hanging in CI
+            python-sdk,
             fastapi,
             openapi,
             postman,

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -128,7 +128,8 @@ jobs:
     strategy:
       fail-fast: false # Don't let failing generators block the passing generators
       matrix:
-        sdk-name: [
+        sdk-name:
+          [
             ruby-model,
             ruby-sdk,
             ruby-sdk-v2,

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -3,8 +3,7 @@ name: Seed Snapshot Tests
 on:
   push:
     branches:
-      # CHRISM - temp
-      - mallinson/test-python-with-file
+      - main
   # Note: pull request trigger will be removed once repository_dispatch trigger is verified
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
## Description
Linear ticket: https://linear.app/buildwithfern/issue/FER-7053/ci-manually-add-python-sdk-seed-test-group-file
Closes FER-7053
Stop gap solution to get python-sdk working again in seed tests

## Changes Made
- Manually created python-sdk seed test file
- Re-enabled in seed test
- Setup some changes that will be required for nightly grouping when that is fully debugged

## Testing
- Verified in CI here: https://github.com/fern-api/fern/actions/runs/18237784690
